### PR TITLE
New Factory methods for Qowaiv.ComponentModel.Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Also we propose a Result model that includes the validation messages, and Result
 
 ``` CSharp
 Result<DataType> result = Result.For(data);
+Result<DataType> resultWithMessages = Result.For(data, messages);
 ```
 
 ### ValidationMessages with severity

--- a/README.md
+++ b/README.md
@@ -216,20 +216,35 @@ These values can be configured (in the application settings) or can be created w
 a creator function that can be registered. If not specified otherwise the current 
 country will be created (if possible) based on the current culture.
 
-Qowaiv Component Model
-======================
-Annotations
---------------
+## Qowaiv Component Model
+### Annotations
 We're extending the DataAnnotations from Microsoft with some more attributes:
 
 * [Mandatory] Here the difference with Microsoft's [Required] attribute is that it works for value types as well, it will be invalid if the default value is used.
 * [AllowedValues] and 
 * [ForbiddenValues] make it easy to validate string values, or objects/value types that have a string representation.
 
-Result model
-------------
+### Result model
 Also we propose a Result model that includes the validation messages, and Result which can contain both an object and validation messages. This can be a helpful return type for methods that need to return objects but first have to validate them.
 
-ValidationMessages with severity
---------------------------------
+``` CSharp
+Result<DataType> result = Result.For(data);
+```
+
+### ValidationMessages with severity
 The difference with Microsoft's default ValidationResult and ValidationMessages is that in this PR we support a severity: info, warning, or error.
+
+Those messages can be created via factory methods:
+``` CSharp
+var none = ValidationMessage.None;
+var info = ValidationMessage.Info(message, args);
+var warn = ValidationMessage.Warning(message, args);
+var error = ValidationMessage.Error(message, args);
+```
+
+Or contained by a Result or Result&lt;T&gt;:
+
+``` CSharp
+Result result = Result.WithMessage(messages);
+Result<DataType> result = Result.WithMessage<DataType>(messages);
+```

--- a/src/Qowaiv.ComponentModel/Result.cs
+++ b/src/Qowaiv.ComponentModel/Result.cs
@@ -54,5 +54,15 @@ namespace Qowaiv.ComponentModel
 
         /// <summary>Gets all messages with <see cref="ValidationSeverity.Info"/>.</summary>
         public IEnumerable<ValidationResult> Infos => Messages.GetInfos();
+
+
+        /// <summary>Creates a <see cref="Result{T}"/> for the data.</summary>
+        public static Result<T> For<T>(T data) => new Result<T>(data);
+
+        /// <summary>Creates a result with messages.</summary>
+        public static Result WithMessages(params ValidationResult[] messages) => new Result(messages);
+
+        /// <summary>Creates a result with messages.</summary>
+        public static Result<T> WithMessages<T>(params ValidationResult[] messages) => new Result<T>(default(T), messages);
     }
 }

--- a/src/Qowaiv.ComponentModel/Result.cs
+++ b/src/Qowaiv.ComponentModel/Result.cs
@@ -57,7 +57,7 @@ namespace Qowaiv.ComponentModel
 
 
         /// <summary>Creates a <see cref="Result{T}"/> for the data.</summary>
-        public static Result<T> For<T>(T data) => new Result<T>(data);
+        public static Result<T> For<T>(T data, params ValidationResult[] messages) => new Result<T>(data, messages);
 
         /// <summary>Creates a result with messages.</summary>
         public static Result WithMessages(params ValidationResult[] messages) => new Result(messages);

--- a/test/Qowaiv.ComponentModel.UnitTests/ResultTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/ResultTest.cs
@@ -19,7 +19,7 @@ namespace Qowaiv.ComponentModel.Tests
         [Test]
         public void IsValid_TestMesages_False()
         {
-            var result = new Result(TestMessages);
+            var result = Result.WithMessages(TestMessages);
             var act = result.IsValid;
             Assert.IsFalse(act);
         }
@@ -27,7 +27,7 @@ namespace Qowaiv.ComponentModel.Tests
         [Test]
         public void IsValid_SomeNoneErrorsMesages_True()
         {
-            var result = new Result(new[] { Warning1, Info1, Info2 });
+            var result = Result.WithMessages<int>(Warning1, Info1, Info2);
             var act = result.IsValid;
             Assert.True(act);
         }
@@ -35,7 +35,7 @@ namespace Qowaiv.ComponentModel.Tests
         [Test]
         public void Errors_2Items()
         {
-            var result = new Result(TestMessages);
+            var result = Result.WithMessages(TestMessages);
             var act = result.Errors;
             var exp = new[] { Error1, Error2 };
             Assert.AreEqual(exp, act);
@@ -44,7 +44,7 @@ namespace Qowaiv.ComponentModel.Tests
         [Test]
         public void Warnings_2Items()
         {
-            var result = new Result(TestMessages);
+            var result = Result.WithMessages(TestMessages);
             var act = result.Warnings;
             var exp = new[] { Warning1, Warning2 };
             Assert.AreEqual(exp, act);
@@ -53,7 +53,7 @@ namespace Qowaiv.ComponentModel.Tests
         [Test]
         public void Infos_2Items()
         {
-            var result = new Result(TestMessages);
+            var result = Result.WithMessages(TestMessages);
             var act = result.Infos;
             var exp = new[] { Info1, Info2 };
             Assert.AreEqual(exp, act);
@@ -93,21 +93,21 @@ namespace Qowaiv.ComponentModel.Tests
         [Test]
         public void WithError_IsNotValid()
         {
-            var actual = new Result(new[] { ValidationMessage.Error("This should not be valid") });
+            var actual = Result.WithMessages(ValidationMessage.Error("This should not be valid"));
             Assert.False(actual.IsValid);
         }
 
         [Test]
         public void WithWarning_IsValid()
         {
-            var actual = new Result(new[] { ValidationMessage.Warning("This should valid") });
+            var actual = Result.WithMessages(ValidationMessage.Warning("This should valid"));
             Assert.True(actual.IsValid);
         }
 
         [Test]
         public void WithInfo_IsValid()
         {
-            var actual = new Result(new[] { ValidationMessage.Info("This should be valid") });
+            var actual = Result.WithMessages(ValidationMessage.Info("This should be valid"));
             Assert.True(actual.IsValid);
         }
     }


### PR DESCRIPTION
As described in the (updated) README.md

---------------------------------------

### Result model
Also we propose a Result model that includes the validation messages, and Result which can contain both an object and validation messages. This can be a helpful return type for methods that need to return objects but first have to validate them.

``` CSharp
Result<DataType> result = Result.For(data);
```

### ValidationMessages with severity
The difference with Microsoft's default ValidationResult and ValidationMessages is that in this PR we support a severity: info, warning, or error.

Those messages can be created via factory methods:
``` CSharp
var none = ValidationMessage.None;
var info = ValidationMessage.Info(message, args);
var warn = ValidationMessage.Warning(message, args);
var error = ValidationMessage.Error(message, args);
```

Or contained by a Result or Result&lt;T&gt;:

``` CSharp
Result result = Result.WithMessage(messages);
Result<DataType> result = Result.WithMessage<DataType>(messages);
```