### PR TITLE
Introduction of typed validation rules

### DIFF
--- a/src/Qowaiv.ComponentModel/DataAnnotations/AnyAttribute.cs
+++ b/src/Qowaiv.ComponentModel/DataAnnotations/AnyAttribute.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.ComponentModel.DataAnnotations;
 
 namespace Qowaiv.ComponentModel.DataAnnotations
@@ -12,11 +11,16 @@ namespace Qowaiv.ComponentModel.DataAnnotations
         /// </summary>
         public override bool IsValid(object value)
         {
-            if (value is IEnumerable enumerable)
+            if (IsApplicable(value))
             {
-                return enumerable.GetEnumerator().MoveNext();
+                return ((IEnumerable)value).GetEnumerator().MoveNext();
             }
             return base.IsValid(value);
+        }
+
+        internal static bool IsApplicable(object value)
+        {
+            return value is IEnumerable && !(value is string);
         }
     }
 }

--- a/src/Qowaiv.ComponentModel/DataAnnotations/MandatoryAttribute.cs
+++ b/src/Qowaiv.ComponentModel/DataAnnotations/MandatoryAttribute.cs
@@ -12,11 +12,16 @@ namespace Qowaiv.ComponentModel.DataAnnotations
         /// </summary>
         public override bool IsValid(object value)
         {
-            if (value != null && value.GetType().IsValueType)
+            if (IsApplicable(value))
             {
                 return !value.Equals(Activator.CreateInstance(value.GetType()));
             }
             return base.IsValid(value);
+        }
+
+        internal static bool IsApplicable(object value)
+        {
+            return value != null && value.GetType().IsValueType;
         }
     }
 }

--- a/src/Qowaiv.ComponentModel/DataAnnotations/ValidationContext_TModel.cs
+++ b/src/Qowaiv.ComponentModel/DataAnnotations/ValidationContext_TModel.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Qowaiv.ComponentModel.DataAnnotations
+{
+    /// <summary>Describes the context in which a validation check is performed.</summary>
+    public sealed class ValidationContext<TModel>
+        where TModel : class
+    {
+        private readonly ValidationContext _context;
+
+        /// <summary>Creates a new instance of a typed <see cref="ValidationContext"/>.</summary>
+        internal ValidationContext(ValidationContext context) => _context = context;
+
+        /// <summary>Gets the name of the member to validate.</summary>
+        public string DisplayName => _context.DisplayName;
+
+        /// summary>Gets the dictionary of key/value pairs that is associated with this context.</summary>
+        public IDictionary<object, object> Items => _context.Items;
+
+        /// <summary>Gets  the name of the member to validate.</summary>
+        public string MemberName => _context.MemberName;
+
+        /// <summary>Gets the model to validate.</summary>
+        public TModel Model => (TModel)_context.ObjectInstance;
+
+        /// <summary>Returns the service that provides custom validation.</summary>
+        public TService GetService<TService>() => _context.GetSevice<TService>();
+
+        /// <summary>Returns the service that provides custom validation.</summary>
+        public object GetService(Type serviceType) => _context.GetService(serviceType);
+
+        /// <summary>Casts a typed validation context to a not typed validation context.</summary>
+        public static implicit operator ValidationContext(ValidationContext<TModel> typed) => typed?._context;
+    }
+}

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
@@ -70,7 +70,7 @@ namespace Qowaiv.ComponentModel {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The postal code {0} is not valid for {1}..
+        ///   Looks up a localized string similar to The postal code {0} is not valid for {1:f}..
         /// </summary>
         internal static string PostalCodeValidator_ErrorMessage {
             get {

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.nl.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.nl.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -62,6 +121,6 @@
     <value>De waarde van het veld {0} is niet toegestaan.</value>
   </data>
   <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
-    <value>De postcode {0} is niet geldig voor {1}.</value>
+    <value>De postcode {0} is niet geldig voor {1:f}.</value>
   </data>
 </root>

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
@@ -121,7 +121,7 @@
     <value>The value of the {0} field is not allowed.</value>
   </data>
   <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
-    <value>The postal code {0} is not valid for {1}.</value>
+    <value>The postal code {0} is not valid for {1:f}.</value>
   </data>
   <data name="ValidationRule_ResourcePropertyNotStringType" xml:space="preserve">
     <value>The property '{1}' on resource type '{0}' is not a string type.</value>

--- a/src/Qowaiv.ComponentModel/Rules/ConditionalRequiredRule.cs
+++ b/src/Qowaiv.ComponentModel/Rules/ConditionalRequiredRule.cs
@@ -1,0 +1,89 @@
+﻿using Qowaiv.ComponentModel.DataAnnotations;
+using Qowaiv.ComponentModel.Messages;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Qowaiv.ComponentModel.Rules
+{
+    /// <summary>Helper for <see cref="ConditionalRequiredRule{TModel}"/>.</summary>
+    public static class ConditionalRequiredRule
+    {
+        /// <summary>Creates a conditional reqruied rule for the specified model.</summary>
+        /// <typeparam name="TModel">
+        /// The model to validate.
+        /// </typeparam>
+        /// <param name="condition">
+        /// The condition that makes the linked property/properties required.
+        /// </param>
+        /// <param name="properties">
+        /// The expressions to select properties that should be required.
+        /// </param>
+        public static ConditionalRequiredRule<TModel> For<TModel>
+        (
+            Func<ValidationContext<TModel>, bool> condition,
+            params Expression<Func<TModel, object>>[] properties
+        ) where TModel: class
+        {
+            Guard.NotNull(condition, nameof(condition));
+            Guard.HasAny(properties, nameof(properties));
+
+            var names = properties
+                .Select(prop => ExpressionRule.GetMemberName(prop))
+                .ToArray();
+
+            var getValues = properties
+                .Select(prop => prop.Compile())
+                .ToArray();
+
+            return new ConditionalRequiredRule<TModel>(condition, getValues, names);
+        }
+    }
+
+    /// <summary>Represents a conditional rule, that marks properties as being required based on a condition.</summary>
+    public class ConditionalRequiredRule<TModel> : ValidationRule<TModel>
+        where TModel : class
+    {
+        /// <summary>Creates a new instance of a <see cref="ConditionalRequiredRule{TModel}"/>.</summary>
+        internal ConditionalRequiredRule
+        (
+            Func<ValidationContext<TModel>, bool> condition, 
+            Func<TModel, object>[] getValues, 
+            string[] propertyNames
+        )
+            : base(propertyNames)
+        {
+            getCondition = condition;
+            GetValues = getValues;
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<ValidationResult> Validate(ValidationContext<TModel> validationContext)
+        {
+            if(getCondition(validationContext))
+            {
+                for(var index = 0; index < PropertyNames.Length; index++)
+                {
+                    var value = GetValues[index](validationContext.Model);
+                    var name = PropertyNames[index];
+
+                    if ((MandatoryAttribute.IsApplicable(value) && !mandatory.IsValid(value))
+                        || (AnyAttribute.IsApplicable(value) && !any.IsValid(value))
+                        || !required.IsValid(value))
+                    {
+                        yield return ValidationMessage.Error(required.FormatErrorMessage(name), name);
+                    }
+                }
+            }
+        }
+
+        private readonly Func<ValidationContext<TModel>, bool> getCondition;
+        private readonly Func<TModel, object>[] GetValues;
+
+        private readonly AnyAttribute any = new AnyAttribute();
+        private readonly MandatoryAttribute mandatory = new MandatoryAttribute();
+        private readonly RequiredAttribute required = new RequiredAttribute();
+    }
+}

--- a/src/Qowaiv.ComponentModel/Rules/ExpressionRule.cs
+++ b/src/Qowaiv.ComponentModel/Rules/ExpressionRule.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Qowaiv.ComponentModel.Rules
+{
+    public static class ExpressionRule
+    {
+        public static string GetMemberName(LambdaExpression expression)
+        {
+            Guard.NotNull(expression, nameof(expression));
+
+            switch (expression.Body)
+            {
+                case MemberExpression m:
+                    return m.Member.Name;
+                case UnaryExpression u when u.Operand is MemberExpression m:
+                    return m.Member.Name;
+
+                default:
+                    throw new NotSupportedException();
+            }
+
+        }
+    }
+}

--- a/src/Qowaiv.ComponentModel/Rules/Globalization/PostalCodeRule.cs
+++ b/src/Qowaiv.ComponentModel/Rules/Globalization/PostalCodeRule.cs
@@ -35,8 +35,8 @@ namespace Qowaiv.ComponentModel.Rules.Globalization
         }
     }
 
-    /// <summary>Rule that can validate a <see cref="Qowaiv.PostalCode"/> 
-    /// being valid for a specific <see cref="Qowaiv.Globalization.Country"/>.
+    /// <summary>Rule that can validate a <see cref="PostalCode"/> 
+    /// being valid for a specific <see cref="Country"/>.
     /// </summary>
     public class PostalCodeRule<TModel> : ValidationRule<TModel>
         where TModel : class

--- a/src/Qowaiv.ComponentModel/Rules/Globalization/PostalCodeRule.obsolete.cs
+++ b/src/Qowaiv.ComponentModel/Rules/Globalization/PostalCodeRule.obsolete.cs
@@ -1,0 +1,58 @@
+﻿using Qowaiv.ComponentModel.Messages;
+using Qowaiv.Globalization;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Qowaiv.ComponentModel.Rules.Globalization
+{
+    /// <summary>Rule that can validate a <see cref="Qowaiv.PostalCode"/> 
+    /// being valid for a specific <see cref="Qowaiv.Globalization.Country"/>.
+    /// </summary>
+    public partial class PostalCodeRule : ValidationRule
+    {
+        /// <summary>Creates a new instance of a <see cref="PostalCodeRule"/>.</summary>
+        /// <param name="postalCode">
+        /// The postal code to validate.
+        /// </param>
+        /// <param name="country">
+        /// The country to validate it for.
+        /// </param>
+        /// <param name="postalCodeName">
+        /// The name of the <see cref="Qowaiv.PostalCode"/> property in the model.
+        /// </param>
+        /// <param name="countryName">
+        /// The name of the <see cref="Qowaiv.Globalization.Country"/> property in the model.
+        /// </param>
+        [Obsolete("Use PostalCodeRule<TModel> instead.")]
+        public PostalCodeRule(PostalCode postalCode, Country country, string postalCodeName, string countryName)
+            : base(postalCodeName, countryName)
+        {
+            PostalCode = postalCode;
+            Country = country;
+        }
+
+        /// <summary>Gets the involved postal code.</summary>
+        public PostalCode PostalCode { get; }
+        /// <summary>Gets the involved country.</summary>
+        public Country Country { get; }
+
+        /// <summary>Returns true if postal code is valid (or if the postal code or country is empty or unknown).</summary>
+        protected override bool IsValid(ValidationContext validationContext)
+        {
+            return PostalCode.IsEmptyOrUnknown() || Country.IsEmptyOrUnknown() || PostalCode.IsValid(Country);
+        }
+
+        /// <summary>Gets the error message.</summary>
+        protected override Func<string> ErrorMessageString => () => string.Format(QowaivComponentModelMessages.PostalCodeValidator_ErrorMessage, PostalCode, Country.DisplayName);
+
+        /// <summary>Returns <see cref="ValidationMessage.None"/> if the <see cref="PostalCode"/> 
+        /// is valid for a specific <see cref="Country"/>, otherwise false.
+        /// </summary>
+        [Obsolete("Use PostalCodeRule.For<TModel> instead.")]
+        public static ValidationResult IsValid(PostalCode postalCode, Country country, string postalCodeName, string countryName)
+        {
+            var rule = new PostalCodeRule(postalCode, country, postalCodeName, countryName);
+            return rule.Validate(null);
+        }
+    }
+}

--- a/src/Qowaiv.ComponentModel/Rules/IValidationRule_TModel.cs
+++ b/src/Qowaiv.ComponentModel/Rules/IValidationRule_TModel.cs
@@ -1,0 +1,24 @@
+﻿using Qowaiv.ComponentModel.DataAnnotations;
+using Qowaiv.ComponentModel.Messages;
+using Qowaiv.ComponentModel.Validation;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Qowaiv.ComponentModel.Rules
+{
+    /// <summary>The rule equivalent of the <see cref="ValidationAttribute"/>.</summary>
+    /// <remarks>
+    /// Where the <see cref="ValidationAttribute"/> should apply on isolated
+    /// properties, an <see cref="IValidationRule"/> should be used to define
+    /// constraints that imply multiple properties.
+    /// </remarks>
+    public interface IValidationRule<TModel>
+        where TModel: class
+    {
+        /// <summary>Validates the rule.</summary>
+        /// <param name="validationContext">
+        /// The context to validate.
+        /// </param>
+        IEnumerable<ValidationResult> Validate(ValidationContext<TModel> validationContext);
+    }
+}

--- a/src/Qowaiv.ComponentModel/Rules/ValidationRuleSet.cs
+++ b/src/Qowaiv.ComponentModel/Rules/ValidationRuleSet.cs
@@ -1,0 +1,54 @@
+﻿using Qowaiv.ComponentModel.Messages;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace Qowaiv.ComponentModel.Rules
+{
+    /// <summary>Represents a set of <see cref="IValidationRule{TModel}"/>s.</summary>
+    public class ValidationRuleSet<TModel> : IEnumerable<IValidationRule<TModel>> where TModel : class
+    {
+        /// <summary>Creates a new instance of a <see cref="ValidationRuleSet{TModel}"/>.</summary>
+        public ValidationRuleSet(params IValidationRule<TModel>[] rules)
+        {
+            this.rules = Guard.NotNull(rules, nameof(rules)).ToArray();
+        }
+
+        /// <summary>Gets the number of rules in the rule set.</summary>
+        public int Count => rules.Length;
+
+        /// <summary>Validates all <see cref="IValidationRule{TModel}"/>s.</summary>
+
+        /// <param name="validationContext">
+        /// The <see cref="ValidationContext"/> 
+        /// The validation context
+        /// </param>
+        /// <returns>
+        /// All <see cref="ValidationResult"/> that are not equal to <see cref="ValidationMessage.None"/>.
+        /// </returns>
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            Guard.NotNull(validationContext, nameof(validationContext));
+
+            return rules
+                .SelectMany(rule => rule.Validate(validationContext.Typed<TModel>()))
+                .Where(message => message.GetSeverity() > ValidationSeverity.None);
+        }
+
+        #region IEnumerable
+
+        private readonly IValidationRule<TModel>[] rules;
+
+        /// <inheritdoc />
+        public IEnumerator<IValidationRule<TModel>> GetEnumerator()
+        {
+            return ((IEnumerable<IValidationRule<TModel>>)rules).GetEnumerator();
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        #endregion
+    }
+}

--- a/src/Qowaiv.ComponentModel/Rules/ValidationRule_TModel.cs
+++ b/src/Qowaiv.ComponentModel/Rules/ValidationRule_TModel.cs
@@ -1,4 +1,5 @@
-﻿using Qowaiv.ComponentModel.Messages;
+﻿using Qowaiv.ComponentModel.DataAnnotations;
+using Qowaiv.ComponentModel.Messages;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -11,8 +12,8 @@ namespace Qowaiv.ComponentModel.Rules
     /// <summary>Represents a validation rule that is intended to be validated
     /// during <see cref="IValidatableObject.Validate(ValidationContext)"/>.
     /// </summary>
-    [Obsolete("Use ValidationRule<TModel> instead.")]
-    public abstract class ValidationRule : IValidationRule
+    public abstract class ValidationRule<TModel> : IValidationRule<TModel>
+        where TModel : class
     {
         /// <summary>Creates a new instance of a <see cref="ValidationRule"/>.</summary>
         /// <param name="propertyNames">
@@ -89,49 +90,7 @@ namespace Qowaiv.ComponentModel.Rules
                 ErrorMessageResourceName));
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="validationContext"></param>
-        /// <returns></returns>
-        public virtual ValidationResult Validate(ValidationContext validationContext)
-        {
-            if (IsValid(validationContext))
-            {
-                return ValidationMessage.None;
-            }
-            return ValidationMessage.Error(string.Format(CultureInfo.CurrentCulture, ErrorMessageString(), PropertyNames), PropertyNames);
-        }
-
-        /// <Summary>Determines whether the specified value of the object is valid.</Summary>
-        /// <param name="validationContext">
-        /// </param>
-        /// <returns>
-        /// <code>true</code> if the specified value is valid, otherwise <code>false</code>.
-        /// </returns>
-        protected abstract bool IsValid(ValidationContext validationContext);
-
-        /// <summary>Creates an <see cref="IValidationRule"/> based on the expression.</summary>
-        /// <param name="isValid">
-        /// The isValid expression.
-        /// </param>
-        /// <param name="message">
-        /// The message to show when the rule is not valid.
-        /// </param>
-        /// <param name="propertyNames">
-        /// The involved property names.
-        /// </param>
-        /// <remarks>
-        /// If the <code>bool?</code> has no value, the rule is assumed not to be invalid.
-        /// This helps in scenario's like these:
-        /// <code>
-        /// ValidationRule.For((context) => context.GetService&lt;SomeService&gt;()?.IsValid(), "Error");
-        /// </code>
-        /// If The service could not be resolved, the rule will be ignored.
-        /// </remarks>
-        public static IValidationRule For(Func<ValidationContext, bool?> isValid, Func<string> message, params string[] propertyNames)
-        {
-            return new ValidationExpression(isValid, message, propertyNames);
-        }
+        /// <inheritdoc />
+        public abstract IEnumerable<ValidationResult> Validate(ValidationContext<TModel> validationContext);
     }
 }

--- a/src/Qowaiv.ComponentModel/Rules/ValidationRules.cs
+++ b/src/Qowaiv.ComponentModel/Rules/ValidationRules.cs
@@ -1,5 +1,6 @@
 ﻿using Qowaiv.ComponentModel.Messages;
 using Qowaiv.ComponentModel.Validation;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -7,6 +8,7 @@ using System.Linq;
 namespace Qowaiv.ComponentModel.Rules
 {
     /// <summary>Represents a <see cref="List{T}"/> of <see cref="IValidationRule"/>s.</summary>
+    [Obsolete("Use ValidationRuleSet instead.")]
     public class ValidationRules : List<IValidationRule>
     {
         /// <summary>Creates a new instance of <see cref="ValidationRules"/>.</summary>

--- a/src/Qowaiv.ComponentModel/System.ComponentModel.DataAnnotations/ValidationContextExtensions.cs
+++ b/src/Qowaiv.ComponentModel/System.ComponentModel.DataAnnotations/ValidationContextExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Qowaiv;
+using Qowaiv.ComponentModel.DataAnnotations;
 
 namespace System.ComponentModel.DataAnnotations
 {
@@ -6,10 +7,23 @@ namespace System.ComponentModel.DataAnnotations
     public static class ValidationContextExtensions
     {
         /// <summary>Returns the service that provides custom validation.</summary>
-        public static T GetSevice<T>(this ValidationContext validationContext)
+        public static TService GetSevice<TService>(this ValidationContext validationContext)
         {
             Guard.NotNull(validationContext, nameof(validationContext));
-            return (T)validationContext.GetService(typeof(T));
+            return (TService)validationContext.GetService(typeof(TService));
+        }
+
+        /// <summary>Casts a validation context to a typed validation context.</summary>
+        public static ValidationContext<TModel> Typed<TModel>(this ValidationContext validationContext)
+            where TModel: class
+        {
+            if (validationContext is null)
+            {
+                return null;
+            }
+            Guard.IsTypeOf<TModel>(validationContext.ObjectInstance, nameof(validationContext.ObjectInstance));
+
+            return new ValidationContext<TModel>(validationContext);
         }
     }
 }

--- a/test/Qowaiv.ComponentModel.UnitTests/Rules/ValidationRuleSetTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/Rules/ValidationRuleSetTest.cs
@@ -12,7 +12,33 @@ namespace Qowaiv.ComponentModel.UnitTests.Rules
     public class ValidationRuleSetTest
     {
         [Test]
-        public void Validate_()
+        public void Validate_NoPostalCodeForCountryWithouPostalCode_IsValid()
+        {
+            var model = new ComplexValidatableModel
+            {
+                PostalCode = PostalCode.Empty,
+                Country = Country.AE,
+            };
+
+            DataAnnotationsAssert.IsValid(model);
+        }
+
+        [Test]
+        public void Validate_NoPostalCode_WithErrors()
+        {
+            var model = new ComplexValidatableModel
+            {
+                PostalCode = PostalCode.Empty,
+                Country = Country.NL,
+            };
+
+            DataAnnotationsAssert.WithErrors(model,
+                new ValidationTestMessage(ValidationSeverity.Error, "The PostalCode field is required.", "PostalCode")
+            );
+        }
+
+        [Test]
+        public void Validate_NotValidForCountry_WithErrors()
         {
             var model = new ComplexValidatableModel
             {
@@ -36,7 +62,15 @@ namespace Qowaiv.ComponentModel.UnitTests.Rules
         private static readonly ValidationRuleSet<ComplexValidatableModel> ruleSet =
             new ValidationRuleSet<ComplexValidatableModel>
             (
-                PostalCodeRule.For<ComplexValidatableModel>(m => m.PostalCode, m=> m.Country)
+                PostalCodeRule.For<ComplexValidatableModel>
+                (
+                    m => m.PostalCode, m=> m.Country
+                ),
+                ConditionalRequiredRule.For<ComplexValidatableModel>
+                (
+                    c => PostalCodeCountryInfo.GetInstance(c.Model.Country).HasPostalCode,
+                    m => m.PostalCode
+                )
             );
 
         public PostalCode PostalCode { get; set; }

--- a/test/Qowaiv.ComponentModel.UnitTests/Rules/ValidationRuleSetTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/Rules/ValidationRuleSetTest.cs
@@ -1,0 +1,45 @@
+﻿using NUnit.Framework;
+using Qowaiv.ComponentModel.Messages;
+using Qowaiv.ComponentModel.Rules;
+using Qowaiv.ComponentModel.Rules.Globalization;
+using Qowaiv.ComponentModel.Tests.TestTools;
+using Qowaiv.Globalization;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Qowaiv.ComponentModel.UnitTests.Rules
+{
+    public class ValidationRuleSetTest
+    {
+        [Test]
+        public void Validate_()
+        {
+            var model = new ComplexValidatableModel
+            {
+                PostalCode = PostalCode.Parse("1234"),
+                Country = Country.NL,
+            };
+
+            DataAnnotationsAssert.WithErrors(model,
+                new ValidationTestMessage(ValidationSeverity.Error, "The postal code 1234 is not valid for Netherlands.", "PostalCode")
+            );
+        }
+    }
+
+    internal class ComplexValidatableModel : IValidatableObject
+    {
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            return ruleSet.Validate(validationContext);
+        }
+
+        private static readonly ValidationRuleSet<ComplexValidatableModel> ruleSet =
+            new ValidationRuleSet<ComplexValidatableModel>
+            (
+                PostalCodeRule.For<ComplexValidatableModel>(m => m.PostalCode, m=> m.Country)
+            );
+
+        public PostalCode PostalCode { get; set; }
+        public Country Country { get; set; }
+    }
+}


### PR DESCRIPTION
The main question is: is this more readable, and maintainable, then an ad-hoc approach?

``` CSharp
internal class ComplexValidatableModel : IValidatableObject
{
    public PostalCode PostalCode { get; set; }
    public Country Country { get; set; }

    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
    {
        return ruleSet.Validate(validationContext);
    }

    private static readonly ValidationRuleSet<ComplexValidatableModel> ruleSet =
        new ValidationRuleSet<ComplexValidatableModel>
        (
            PostalCodeRule.For<ComplexValidatableModel>(m => m.PostalCode, m=> m.Country)
        );
}
```