### PR TITLE
Update packages that caused a security warning

### DIFF
--- a/props/analytics.props
+++ b/props/analytics.props
@@ -2,7 +2,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="7.3.1.5982">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="7.7.0.7192">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Qowaiv.TypeScript/Qowaiv.TypeScript.csproj
+++ b/src/Qowaiv.TypeScript/Qowaiv.TypeScript.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
   </PropertyGroup>
 
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Qowaiv.TypeScript.UnitTests/Qowaiv.TypeScript.UnitTests.csproj
+++ b/test/Qowaiv.TypeScript.UnitTests/Qowaiv.TypeScript.UnitTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
   </PropertyGroup>
 
@@ -11,7 +11,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   

--- a/tooling/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/tooling/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix alert reported by GitHub:

"Microsoft.AspNetCore.All vulnerabilities found in …/Qowaiv.TypeScript/Qowaiv.TypeScript.csproj: Upgrade Microsoft.AspNetCore.All to version 2.0.9 or later."