### PR TITLE
Introduction of the ImmutableAttribute to decorate properties that should not be changed after initialization

### DIFF
--- a/src/Qowaiv.ComponentModel/DataAnnotations/ImmutableAttribute.cs
+++ b/src/Qowaiv.ComponentModel/DataAnnotations/ImmutableAttribute.cs
@@ -1,0 +1,69 @@
+﻿using Qowaiv.ComponentModel.Messages;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace Qowaiv.ComponentModel.DataAnnotations
+{
+    /// <summary>Specifies that a data field value is immutable.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class ImmutableAttribute : ValidationAttribute
+    {
+        /// <summary>Creates a new instance of an <see cref="ImmutableAttribute"/>.</summary>
+        public ImmutableAttribute()
+            : base(() => QowaivComponentModelMessages.ImmutableAttribute_ErrorMessage) { }
+
+        /// <summary>Creates a new instance of an <see cref="ImmutableAttribute"/>.</summary>
+        /// <param name="errorMessage">
+        /// The error message to associate with a validation control.
+        /// </param>
+        public ImmutableAttribute(string errorMessage)
+            : base(errorMessage) { }
+
+        /// <inheritdoc />
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            Guard.NotNull(validationContext, nameof(validationContext));
+
+            var current = GetCurrent(validationContext);
+
+            return IsDefaultValue(current) || current.Equals(value)
+                ? ValidationMessage.None
+                : ValidationMessage.Error(FormatErrorMessage(validationContext.MemberName), validationContext.MemberName);
+        }
+
+        /// <summary>Gets the current value of the involved member (property or field).</summary>
+        private object GetCurrent(ValidationContext validationContext)
+        {
+            var member = validationContext.MemberName;
+            var type = validationContext.ObjectType;
+            var instance = validationContext.ObjectInstance;
+
+            var property = type.GetProperty(member, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property != null)
+            {
+                return property.GetValue(instance);
+            }
+
+            var field = type.GetField(member, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field != null)
+            {
+                return field.GetValue(instance);
+            }
+
+            throw new ArgumentException(string.Format(QowaivComponentModelMessages.ArgumentException_MemberCouldNotBeResolvedForType, member, type), nameof(validationContext));
+        }
+
+        /// <summary>Returns true if the value equals null or the default of its type.</summary>
+        private static bool IsDefaultValue(object value)
+        {
+            if (value is null)
+            {
+                return true;
+            }
+            var type = value.GetType();
+
+            return type.IsValueType && Activator.CreateInstance(type).Equals(value);
+        }
+    }
+}

--- a/src/Qowaiv.ComponentModel/Qowaiv.ComponentModel.csproj
+++ b/src/Qowaiv.ComponentModel/Qowaiv.ComponentModel.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\props\common.props" />
 
@@ -38,9 +38,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Update="QowaivComponentModelMessages.nl.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
     <EmbeddedResource Update="QowaivComponentModelMessages.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>QowaivComponentModelMessages.Designer.cs</LastGenOutput>

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
@@ -70,6 +70,24 @@ namespace Qowaiv.ComponentModel {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The member &apos;{0}&apos; could not be resolved for the type &apos;{1}&apos;..
+        /// </summary>
+        internal static string ArgumentException_MemberCouldNotBeResolvedForType {
+            get {
+                return ResourceManager.GetString("ArgumentException_MemberCouldNotBeResolvedForType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The {0} field is immutable..
+        /// </summary>
+        internal static string ImmutableAttribute_ErrorMessage {
+            get {
+                return ResourceManager.GetString("ImmutableAttribute_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The postal code {0} is not valid for {1}..
         /// </summary>
         internal static string PostalCodeValidator_ErrorMessage {

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
@@ -79,7 +79,7 @@ namespace Qowaiv.ComponentModel {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The {0} field is immutable..
+        ///   Looks up a localized string similar to The {0} field is immutable and can not be changed..
         /// </summary>
         internal static string ImmutableAttribute_ErrorMessage {
             get {

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.nl.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.nl.resx
@@ -62,7 +62,7 @@
     <value>De waarde van het veld {0} is niet toegestaan.</value>
   </data>
   <data name="ImmutableAttribute_ErrorMessage" xml:space="preserve">
-    <value>Het veld {0} is onveranderlijk.</value>
+    <value>Het veld {0} is immutable en kan niet worden geweizigd.</value>
   </data>
   <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
     <value>De postcode {0} is niet geldig voor {1}.</value>

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.nl.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.nl.resx
@@ -61,6 +61,9 @@
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van het veld {0} is niet toegestaan.</value>
   </data>
+  <data name="ImmutableAttribute_ErrorMessage" xml:space="preserve">
+    <value>Het veld {0} is onveranderlijk.</value>
+  </data>
   <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
     <value>De postcode {0} is niet geldig voor {1}.</value>
   </data>

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -66,7 +65,7 @@
     <value>The member '{0}' could not be resolved for the type '{1}'.</value>
   </data>
   <data name="ImmutableAttribute_ErrorMessage" xml:space="preserve">
-    <value>The {0} field is immutable.</value>
+    <value>The {0} field is immutable and can not be changed.</value>
   </data>
   <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
     <value>The postal code {0} is not valid for {1}.</value>

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
@@ -1,64 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
+  
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -119,6 +61,12 @@
   </resheader>
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not allowed.</value>
+  </data>
+  <data name="ArgumentException_MemberCouldNotBeResolvedForType" xml:space="preserve">
+    <value>The member '{0}' could not be resolved for the type '{1}'.</value>
+  </data>
+  <data name="ImmutableAttribute_ErrorMessage" xml:space="preserve">
+    <value>The {0} field is immutable.</value>
   </data>
   <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
     <value>The postal code {0} is not valid for {1}.</value>

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -1,7 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\props\common.props" />
-
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
@@ -24,6 +23,14 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\ProductInfo.cs" Link="Properties\ProductInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="QowaivMessages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>QowaivMessages.resx</DependentUpon>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/src/Shared/ProductInfo.cs
+++ b/src/Shared/ProductInfo.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 

--- a/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/ImmutableAttributeTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/ImmutableAttributeTest.cs
@@ -13,7 +13,7 @@ namespace Qowaiv.ComponentModel.UnitTests.DataAnnotations
         {
             var attribute = new ImmutableAttribute();
             var context = new ValidationContext(new TestClass() { Id = 4 }) { MemberName = nameof(TestClass.Id) };
-            ValidationAssert.WithError("The Id field is immutable.", attribute, 3, context);
+            ValidationAssert.WithError("The Id field is immutable and can not be changed.", attribute, 3, context);
         }
 
         [Test]
@@ -21,7 +21,7 @@ namespace Qowaiv.ComponentModel.UnitTests.DataAnnotations
         {
             var attribute = new ImmutableAttribute();
             var context = new ValidationContext(new TestClass() { _Id = 4 }) { MemberName = nameof(TestClass._Id) };
-            ValidationAssert.WithError("The _Id field is immutable.", attribute, 3, context);
+            ValidationAssert.WithError("The _Id field is immutable and can not be changed.", attribute, 3, context);
         }
 
         [Test]

--- a/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/ImmutableAttributeTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/ImmutableAttributeTest.cs
@@ -1,0 +1,74 @@
+﻿using NUnit.Framework;
+using Qowaiv.ComponentModel.DataAnnotations;
+using Qowaiv.TestTools.ComponentModel;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Qowaiv.ComponentModel.UnitTests.DataAnnotations
+{
+    public class ImmutableAttributeTest
+    {
+        [Test]
+        public void GetValidationResult_PropertyId_WithError()
+        {
+            var attribute = new ImmutableAttribute();
+            var context = new ValidationContext(new TestClass() { Id = 4 }) { MemberName = nameof(TestClass.Id) };
+            ValidationAssert.WithError("The Id field is immutable.", attribute, 3, context);
+        }
+
+        [Test]
+        public void GetValidationResult_FieldId_WithError()
+        {
+            var attribute = new ImmutableAttribute();
+            var context = new ValidationContext(new TestClass() { _Id = 4 }) { MemberName = nameof(TestClass._Id) };
+            ValidationAssert.WithError("The _Id field is immutable.", attribute, 3, context);
+        }
+
+        [Test]
+        public void GetValidationResult_KeepSameValue_IsSuccessful()
+        {
+            var attribute = new ImmutableAttribute();
+            var context = new ValidationContext(new TestClass() { Id = 4 }) { MemberName = nameof(TestClass.Id) };
+            ValidationAssert.IsSuccessful(attribute, 4, context);
+        }
+
+        [Test]
+        public void GetValidationResult_PropertyId_IsSuccessful()
+        {
+            var attribute = new ImmutableAttribute();
+            var context = new ValidationContext(new TestClass()) { MemberName = nameof(TestClass.Id) };
+            ValidationAssert.IsSuccessful(attribute, 3, context);
+        }
+
+        [Test]
+        public void GetValidationResult_FieldId_IsSuccessful()
+        {
+            var attribute = new ImmutableAttribute();
+            var context = new ValidationContext(new TestClass()) { MemberName = nameof(TestClass._Id) };
+            ValidationAssert.IsSuccessful(attribute, 3, context);
+        }
+
+        [Test]
+        public void GetValidationResult_NonExsitingMember_Throws()
+        {
+            var attribute = new ImmutableAttribute();
+            var exception = Assert.Throws<ArgumentException>(() =>
+            {
+                var context = new ValidationContext(new TestClass()) { MemberName = "NonExsitingMember" };
+                attribute.GetValidationResult(3, context);
+            });
+            Assert.AreEqual(
+                @"The member 'NonExsitingMember' could not be resolved for the type 'Qowaiv.ComponentModel.UnitTests.DataAnnotations.TestClass'.
+Parameter name: validationContext", 
+                exception.Message);
+        }
+    }
+    internal class TestClass
+    {
+        [Immutable]
+        public int Id { get; set; }
+
+        [Immutable]
+        public int _Id;
+    }
+}

--- a/test/Qowaiv.ComponentModel.UnitTests/Qowaiv.ComponentModel.UnitTests.csproj
+++ b/test/Qowaiv.ComponentModel.UnitTests/Qowaiv.ComponentModel.UnitTests.csproj
@@ -1,12 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\props\test.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
+   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 

--- a/tooling/Qowaiv.TestTools/ComponentModel/ValidationAssert.cs
+++ b/tooling/Qowaiv.TestTools/ComponentModel/ValidationAssert.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+using Qowaiv.ComponentModel.Messages;
+using System.ComponentModel.DataAnnotations;
+
+namespace Qowaiv.TestTools.ComponentModel
+{
+    public static class ValidationAssert
+    {
+
+        public static void WithError(string error, ValidationAttribute attribute, object value, ValidationContext context)
+        {
+            Assert.IsNotNull(attribute, nameof(attribute));
+            Assert.IsNotNull(context, nameof(context));
+
+            var result = attribute.GetValidationResult(value, context);
+
+            Assert.AreEqual(
+                string.Format("{0}: {1}", ValidationSeverity.Error, error),
+                string.Format("{0}: {1}", result.GetSeverity(), result.ErrorMessage));
+        }
+
+        public static void IsSuccessful(ValidationAttribute attribute, object value, ValidationContext context)
+        {
+            Assert.IsNotNull(attribute, nameof(attribute));
+            Assert.IsNotNull(context, nameof(context));
+
+            var result = attribute.GetValidationResult(value, context);
+
+            Assert.AreEqual(ValidationMessage.None, result);
+        }
+    }
+}

--- a/tooling/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/tooling/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -1,17 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\props\common.props" />
-  
+
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Qowaiv\Qowaiv.csproj" />
+    <ProjectReference Include="..\..\src\Qowaiv.ComponentModel\Qowaiv.ComponentModel.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.11.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It is a prerequisite for #28, where an ID should be decorated as such, but it deserves a change set on its own.