### PR TITLE
MandatoryAttribute should by default not be valid for unknown values

### DIFF
--- a/src/Qowaiv.ComponentModel/DataAnnotations/MandatoryAttribute.cs
+++ b/src/Qowaiv.ComponentModel/DataAnnotations/MandatoryAttribute.cs
@@ -21,12 +21,13 @@ namespace Qowaiv.ComponentModel.DataAnnotations
             if (value != null)
             {
                 var type = value.GetType();
+
+                if (!AllowUnknownValue && value.Equals(Unknown.Value(type)))
+                {
+                    return false;
+                }
                 if (type.IsValueType)
                 {
-                    if (!AllowUnknownValue && value.Equals(Unknown.Value(type)))
-                    {
-                        return false;
-                    }
                     return !value.Equals(Activator.CreateInstance(value.GetType()));
                 }
             }

--- a/src/Qowaiv.ComponentModel/DataAnnotations/MandatoryAttribute.cs
+++ b/src/Qowaiv.ComponentModel/DataAnnotations/MandatoryAttribute.cs
@@ -7,14 +7,28 @@ namespace Qowaiv.ComponentModel.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class MandatoryAttribute : RequiredAttribute
     {
+        /// <summary>Gets or sets a value that indicates whether an empty string is allowed.</summary>
+        public bool AllowUnknownValue { get; set; }
+
         /// <summary>Returns true if the value is not null and value types are
         /// not equal to their default value, otherwise false.
         /// </summary>
+        /// <remarks>
+        /// The unknown value is expected to be static field or property of the type with the name "Unknown".
+        /// </remarks>
         public override bool IsValid(object value)
         {
-            if (value != null && value.GetType().IsValueType)
+            if (value != null)
             {
-                return !value.Equals(Activator.CreateInstance(value.GetType()));
+                var type = value.GetType();
+                if (type.IsValueType)
+                {
+                    if (!AllowUnknownValue && value.Equals(Unknown.Value(type)))
+                    {
+                        return false;
+                    }
+                    return !value.Equals(Activator.CreateInstance(value.GetType()));
+                }
             }
             return base.IsValid(value);
         }

--- a/src/Qowaiv/Guard.cs
+++ b/src/Qowaiv/Guard.cs
@@ -85,23 +85,6 @@ namespace Qowaiv
             throw new ArgumentException(string.Format(QowaivMessages.ArgumentException_Must, typeof(T)), paramName);
         }
 
-        /// <summary>Guards the parameter to be of the value type, otherwise throws an argument exception.</summary>
-        /// <param name="param">
-        /// The parameter to guard.
-        /// </param>
-        /// <param name="paramName">
-        /// The name of the parameter.
-        /// </param>
-        [DebuggerStepThrough]
-        public static Type IsValueType([ValidatedNotNull]Type param, string paramName)
-        {
-            if(NotNull(param, paramName).IsValueType)
-            {
-                return param;
-            }
-            throw new ArgumentException(string.Format(QowaivMessages.ArgumentException_NoValueType, param), paramName);
-        }
-
         /// <summary>Guards the parameter if the type is not null and implements the specified interface,
         /// otherwise throws an argument (null) exception.
         /// </summary>

--- a/src/Qowaiv/Guard.cs
+++ b/src/Qowaiv/Guard.cs
@@ -85,6 +85,23 @@ namespace Qowaiv
             throw new ArgumentException(string.Format(QowaivMessages.ArgumentException_Must, typeof(T)), paramName);
         }
 
+        /// <summary>Guards the parameter to be of the value type, otherwise throws an argument exception.</summary>
+        /// <param name="param">
+        /// The parameter to guard.
+        /// </param>
+        /// <param name="paramName">
+        /// The name of the parameter.
+        /// </param>
+        [DebuggerStepThrough]
+        public static Type IsValueType([ValidatedNotNull]Type param, string paramName)
+        {
+            if(NotNull(param, paramName).IsValueType)
+            {
+                return param;
+            }
+            throw new ArgumentException(string.Format(QowaivMessages.ArgumentException_NoValueType, param), paramName);
+        }
+
         /// <summary>Guards the parameter if the type is not null and implements the specified interface,
         /// otherwise throws an argument (null) exception.
         /// </summary>

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -26,4 +26,19 @@
     <Compile Include="..\Shared\ProductInfo.cs" Link="Properties\ProductInfo.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="QowaivMessages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>QowaivMessages.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="QowaivMessages.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>QowaivMessages.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -19,7 +19,7 @@ namespace Qowaiv {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class QowaivMessages {
@@ -97,6 +97,15 @@ namespace Qowaiv {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The argument {0} is not a value type..
+        /// </summary>
+        public static string ArgumentException_NoValueType {
+            get {
+                return ResourceManager.GetString("ArgumentException_NoValueType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value cannot be an empty string..
         /// </summary>
         public static string ArgumentException_StringEmpty {
@@ -111,6 +120,15 @@ namespace Qowaiv {
         public static string ArgumentException_TimestampArrayShouldHaveSize8 {
             get {
                 return ResourceManager.GetString("ArgumentException_TimestampArrayShouldHaveSize8", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        public static string ArgumentException_TypeOf {
+            get {
+                return ResourceManager.GetString("ArgumentException_TypeOf", resourceCulture);
             }
         }
         

--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -97,15 +97,6 @@ namespace Qowaiv {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The argument {0} is not a value type..
-        /// </summary>
-        public static string ArgumentException_NoValueType {
-            get {
-                return ResourceManager.GetString("ArgumentException_NoValueType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Value cannot be an empty string..
         /// </summary>
         public static string ArgumentException_StringEmpty {

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -1,64 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -251,8 +192,5 @@
   </data>
   <data name="ArgumentException_TypeOf" xml:space="preserve">
     <value />
-  </data>
-  <data name="ArgumentException_NoValueType" xml:space="preserve">
-    <value>The argument {0} is not a value type.</value>
   </data>
 </root>

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -252,4 +252,7 @@
   <data name="ArgumentException_TypeOf" xml:space="preserve">
     <value />
   </data>
+  <data name="ArgumentException_NoValueType" xml:space="preserve">
+    <value>The argument {0} is not a value type.</value>
+  </data>
 </root>

--- a/src/Qowaiv/Unknown.cs
+++ b/src/Qowaiv/Unknown.cs
@@ -79,8 +79,6 @@ namespace Qowaiv
         /// </remarks>
         public static object Value(Type type)
         {
-            Guard.IsValueType(type, nameof(type));
-
             if (UnknownValues.TryGetValue(type, out object unknown))
             {
                 return unknown;
@@ -90,14 +88,14 @@ namespace Qowaiv
                 if (!UnknownValues.TryGetValue(type, out unknown))
                 {
                     var field = type.GetField(nameof(Unknown), BindingFlags.Public | BindingFlags.Static);
-                    if (field != null)
+                    if (field?.FieldType == type)
                     {
                         unknown = field.GetValue(null);
                     }
                     else
                     {
                         var property = type.GetProperty(nameof(Unknown), BindingFlags.Public | BindingFlags.Static);
-                        if (property != null)
+                        if (property?.PropertyType == type)
                         {
                             unknown = property.GetValue(null);
                         }

--- a/src/Qowaiv/Unknown.cs
+++ b/src/Qowaiv/Unknown.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Resources;
 
 namespace Qowaiv
@@ -38,19 +40,20 @@ namespace Qowaiv
 
             var c = culture ?? CultureInfo.InvariantCulture;
 
-            string[] values;
-
-            lock (locker)
+            if (!StringValues.TryGetValue(c, out string[] values))
             {
-                if (!StringValues.TryGetValue(c, out values))
+                lock (addCulturelocker)
                 {
-                    values = ResourceManager
-                        .GetString("Values", c)
-                        .Split(';')
-                        .Select(v=> v.ToUpper(c))
-                        .ToArray();
+                    if (!StringValues.TryGetValue(c, out values))
+                    {
+                        values = ResourceManager
+                            .GetString("Values", c)
+                            .Split(';')
+                            .Select(v => v.ToUpper(c))
+                            .ToArray();
 
-                    StringValues[c] = values;
+                        StringValues[c] = values;
+                    }
                 }
             }
             return
@@ -61,16 +64,63 @@ namespace Qowaiv
                 );
         }
 
+        /// <summary>Gets the value that represents set but unknown.</summary>
+        /// <param name="type">
+        /// The type that should could have an unknown value.
+        /// </param>
+        /// <returns>
+        /// null, if not defined, otherwise the unknown value for a type.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// if type is not a value type.
+        /// </exception>
+        /// <remarks>
+        /// The unknown value is expected to be static field or property of the type with the name "Unknown".
+        /// </remarks>
+        public static object Value(Type type)
+        {
+            Guard.IsValueType(type, nameof(type));
+
+            if (UnknownValues.TryGetValue(type, out object unknown))
+            {
+                return unknown;
+            }
+            lock (addUknownValuelocker)
+            {
+                if (!UnknownValues.TryGetValue(type, out unknown))
+                {
+                    var field = type.GetField(nameof(Unknown), BindingFlags.Public | BindingFlags.Static);
+                    if (field != null)
+                    {
+                        unknown = field.GetValue(null);
+                    }
+                    else
+                    {
+                        var property = type.GetProperty(nameof(Unknown), BindingFlags.Public | BindingFlags.Static);
+                        if (property != null)
+                        {
+                            unknown = property.GetValue(null);
+                        }
+                    }
+                    UnknownValues[type] = unknown;
+                }
+            }
+            return unknown;
+        }
+
         /// <summary>The resource manager managing the culture based string values.</summary>
-        private static Dictionary<CultureInfo, string[]> StringValues = new Dictionary<CultureInfo, string[]>()
+        private readonly static Dictionary<CultureInfo, string[]> StringValues = new Dictionary<CultureInfo, string[]>()
         {
             { CultureInfo.InvariantCulture, new []{ "?", "UNKNOWN", "NOT KNOWN", "NOTKNOWN" } },
         };
+
+        private static readonly Dictionary<Type, object> UnknownValues = new Dictionary<Type, object>();
 
         /// <summary>The resource manager managing the culture based string values.</summary>
         private static readonly ResourceManager ResourceManager = new ResourceManager("Qowaiv.UnknownLabels", typeof(Unknown).Assembly);
 
         /// <summary>The locker for adding a culture.</summary>
-        private static volatile object locker = new object();
+        private static readonly object addCulturelocker = new object();
+        private static readonly object addUknownValuelocker = new object();
     }
 }

--- a/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/MandatoryAttributeTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/MandatoryAttributeTest.cs
@@ -37,5 +37,20 @@ namespace Qowaiv.ComponentModel.Tests.DataAnnotations
             var act = attr.IsValid(EmailAddress.Empty);
             Assert.IsFalse(act);
         }
+
+        [Test]
+        public void IsValid_EmailAddressUnknown_True()
+        {
+            var attr = new MandatoryAttribute { AllowUnknownValue = true };
+            var act = attr.IsValid(EmailAddress.Unknown);
+            Assert.IsTrue(act);
+        }
+        [Test]
+        public void IsValid_EmailAddressUnknown_False()
+        {
+            var attr = new MandatoryAttribute();
+            var act = attr.IsValid(EmailAddress.Unknown);
+            Assert.IsFalse(act);
+        }
     }
 }

--- a/test/Qowaiv.UnitTests/UnknownTest.cs
+++ b/test/Qowaiv.UnitTests/UnknownTest.cs
@@ -44,21 +44,26 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void Value_ReferenceType_Throws()
+        public void Value_ValueTypeWithUnkown_UnknownValue()
         {
-            Assert.Throws<ArgumentException>(() => Unknown.Value(typeof(object)));
+            Assert.AreEqual(PostalCode.Unknown, Unknown.Value(typeof(PostalCode)));
         }
 
         [Test]
-        public void Value_TypeWithUnkown_UnknownValue()
+        public void Value_ReferenceTypeWithUnkown_UnknownValue()
         {
-            Assert.AreEqual(PostalCode.Unknown, Unknown.Value(typeof(PostalCode)));
+            Assert.AreEqual(ClassWithUnknownValue.Unknown, Unknown.Value(typeof(ClassWithUnknownValue)));
         }
 
         [Test]
         public void Value_TypeWithoutUnkown_IsNull()
         {
             Assert.IsNull(Unknown.Value(typeof(Uuid)));
+        }
+
+        private class ClassWithUnknownValue
+        {
+            public static ClassWithUnknownValue Unknown { get; } = new ClassWithUnknownValue();
         }
     }
 }

--- a/test/Qowaiv.UnitTests/UnknownTest.cs
+++ b/test/Qowaiv.UnitTests/UnknownTest.cs
@@ -42,5 +42,23 @@ namespace Qowaiv.UnitTests
         {
             Assert.IsFalse(Unknown.IsUnknown("Vreemd", CultureInfo.InvariantCulture));
         }
+
+        [Test]
+        public void Value_ReferenceType_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => Unknown.Value(typeof(object)));
+        }
+
+        [Test]
+        public void Value_TypeWithUnkown_UnknownValue()
+        {
+            Assert.AreEqual(PostalCode.Unknown, Unknown.Value(typeof(PostalCode)));
+        }
+
+        [Test]
+        public void Value_TypeWithoutUnkown_IsNull()
+        {
+            Assert.IsNull(Unknown.Value(typeof(Uuid)));
+        }
     }
 }


### PR DESCRIPTION
In 99% of the cases a model should not be valid is a property is mandatory, and the value represents its _unknown_ value.

**Solution**
Check if the value represents the _unknown_ value and mark it is as invalid, unless you explicitly set the `AllowUnknownValue ` property to `true`.