### PR TITLE
Prevent the data/model of the Result<T> being accessed once invalid

### DIFF
--- a/src/Qowaiv.ComponentModel/InvalidModelException.cs
+++ b/src/Qowaiv.ComponentModel/InvalidModelException.cs
@@ -1,0 +1,92 @@
+﻿using Qowaiv.ComponentModel.Messages;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Qowaiv.ComponentModel
+{
+    /// <summary>Represents an exception that is shown once tried to access the invalid model of a <see cref="Result{T}"/>.</summary>
+    [Serializable]
+    public class InvalidModelException : InvalidOperationException
+    {
+        /// <summary>Creates a new instance of an <see cref="InvalidModelException"/>.</summary>
+        public InvalidModelException() { }
+
+        /// <summary>Creates a new instance of an <see cref="InvalidModelException"/>.</summary>
+        public InvalidModelException(string message)
+            : base(message) { }
+
+        /// <summary>Creates a new instance of an <see cref="InvalidModelException"/>.</summary>
+        public InvalidModelException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        /// <summary>Creates a new instance of an <see cref="InvalidModelException"/>.</summary>
+        public InvalidModelException(string message, Exception innerException, IEnumerable<ValidationResult> messages)
+            :this(message, innerException)
+        {
+            var errors = new List<ValidationMessage>();
+
+            if(messages != null)
+            {
+                foreach(var error in messages.Where(e => e.GetSeverity() >= ValidationSeverity.Error))
+                {
+                    // As validationResult is not ISerializable and ValidationMessage is.
+                    var serializable = error as ValidationMessage
+                        ?? ValidationMessage.Error(error.ErrorMessage, error.MemberNames.ToArray());
+
+                    errors.Add(serializable);
+                }
+            }
+            Errors = new ReadOnlyCollection<ValidationMessage>(errors);
+        }
+
+        /// <summary>Creates a new instance of an <see cref="InvalidModelException"/>.</summary>
+        protected InvalidModelException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            var errors = info.GetValue(nameof(Errors), typeof(ValidationMessage[])) as ValidationMessage[];
+            Errors = new ReadOnlyCollection<ValidationMessage>(errors);
+        }
+
+        /// <inheritdoc />
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(Errors), Errors.ToArray());
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var sb = new StringBuilder().AppendLine(base.ToString());
+            foreach(var error in Errors)
+            {
+                sb.Append(error.ErrorMessage);
+                if (error.MemberNames.Any())
+                {
+                    sb.Append(" (")
+                        .Append(string.Join(", ", error.MemberNames))
+                        .AppendLine(")");
+                }
+                else
+                {
+                    sb.AppendLine();
+                }
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>The related validation error(s).</summary>
+        public IReadOnlyList<ValidationMessage> Errors { get; } = new ReadOnlyCollection<ValidationMessage>(new ValidationMessage[0]);
+
+        /// <summary>Creates an <see cref="InvalidModelException"/> for the model.</summary>
+        public static InvalidModelException For<T>(IEnumerable<ValidationResult> messages)
+        {
+            return new InvalidModelException(string.Format(QowaivComponentModelMessages.InvalidModelException, typeof(T)), null, messages);
+        }
+    }
+}

--- a/src/Qowaiv.ComponentModel/Messages/ValidationErrorMessage.cs
+++ b/src/Qowaiv.ComponentModel/Messages/ValidationErrorMessage.cs
@@ -1,11 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Qowaiv.ComponentModel.Messages
 {
     /// <summary>Represents a validation error message.</summary>
+    [Serializable]
     public class ValidationErrorMessage : ValidationMessage
     {
-        /// <summary>Creates a new instance of a <see cref="ValidationMessage"/>.</summary>
+        /// <summary>Creates a new instance of a <see cref="ValidationErrorMessage"/>.</summary>
         /// <param name="message">
         /// The validation message.
         /// </param>
@@ -14,6 +17,10 @@ namespace Qowaiv.ComponentModel.Messages
         /// </param>
         internal ValidationErrorMessage(string message, IEnumerable<string> memberNames)
             : base(message, memberNames) { }
+
+        /// <summary>Creates a new instance of <see cref="ValidationErrorMessage"/>.</summary>
+        protected ValidationErrorMessage(SerializationInfo info, StreamingContext context) :
+            base(info, context){ }
 
         /// <summary>Gets the Severity (Error) of the message.</summary>
         public sealed override ValidationSeverity Severity => ValidationSeverity.Error;

--- a/src/Qowaiv.ComponentModel/Messages/ValidationInfoMessage.cs
+++ b/src/Qowaiv.ComponentModel/Messages/ValidationInfoMessage.cs
@@ -1,11 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Qowaiv.ComponentModel.Messages
 {
     /// <summary>Represents a validation info message.</summary>
+    [Serializable]
     public class ValidationInfoMessage : ValidationMessage
     {
-        /// <summary>Creates a new instance of a <see cref="ValidationMessage"/>.</summary>
+        /// <summary>Creates a new instance of a <see cref="ValidationInfoMessage"/>.</summary>
         /// <param name="message">
         /// The validation message.
         /// </param>
@@ -14,6 +17,10 @@ namespace Qowaiv.ComponentModel.Messages
         /// </param>
         internal ValidationInfoMessage(string message, IEnumerable<string> memberNames)
             : base(message, memberNames) { }
+
+        /// <summary>Creates a new instance of <see cref="ValidationInfoMessage"/>.</summary>
+        protected ValidationInfoMessage(SerializationInfo info, StreamingContext context) :
+            base(info, context){ }
 
         /// <summary>Gets the Severity (Info) of the message.</summary>
         public sealed override ValidationSeverity Severity => ValidationSeverity.Info;

--- a/src/Qowaiv.ComponentModel/Messages/ValidationMessage.cs
+++ b/src/Qowaiv.ComponentModel/Messages/ValidationMessage.cs
@@ -8,7 +8,7 @@ namespace Qowaiv.ComponentModel.Messages
 {
     /// <summary>Represents a validation message.</summary>
     /// <remarks>
-    /// To support messages with different severities.
+    /// To support serialization and messages with different severities.
     /// </remarks>
     [Serializable]
     public abstract class ValidationMessage : ValidationResult, ISerializable

--- a/src/Qowaiv.ComponentModel/Messages/ValidationWarningMessage.cs
+++ b/src/Qowaiv.ComponentModel/Messages/ValidationWarningMessage.cs
@@ -1,11 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Qowaiv.ComponentModel.Messages
 {
     /// <summary>Represents a validation warning message.</summary>
+    [Serializable]
     public class ValidationWarningMessage : ValidationMessage
     {
-        /// <summary>Creates a new instance of a <see cref="ValidationMessage"/>.</summary>
+        /// <summary>Creates a new instance of a <see cref="ValidationWarningMessage"/>.</summary>
         /// <param name="message">
         /// The validation message.
         /// </param>
@@ -14,6 +17,10 @@ namespace Qowaiv.ComponentModel.Messages
         /// </param>
         internal ValidationWarningMessage(string message, IEnumerable<string> memberNames)
             : base(message, memberNames) { }
+
+        /// <summary>Creates a new instance of <see cref="ValidationWarningMessage"/>.</summary>
+        protected ValidationWarningMessage(SerializationInfo info, StreamingContext context) :
+            base(info, context) { }
 
         /// <summary>Gets the Severity (Warning) of the message.</summary>
         public sealed override ValidationSeverity Severity => ValidationSeverity.Warning;

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
@@ -70,11 +70,11 @@ namespace Qowaiv.ComponentModel {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The model can not be executed. It is invalid..
+        ///   Looks up a localized string similar to The {0} model can not be operated on as it is invalid..
         /// </summary>
-        internal static string InvalidOperationException_InvalidModel {
+        internal static string InvalidModelException {
             get {
-                return ResourceManager.GetString("InvalidOperationException_InvalidModel", resourceCulture);
+                return ResourceManager.GetString("InvalidModelException", resourceCulture);
             }
         }
         

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
@@ -70,6 +70,15 @@ namespace Qowaiv.ComponentModel {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The model can not be executed. It is invalid..
+        /// </summary>
+        internal static string InvalidOperationException_InvalidModel {
+            get {
+                return ResourceManager.GetString("InvalidOperationException_InvalidModel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The postal code {0} is not valid for {1}..
         /// </summary>
         internal static string PostalCodeValidator_ErrorMessage {

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
@@ -61,8 +61,8 @@
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not allowed.</value>
   </data>
-  <data name="InvalidOperationException_InvalidModel" xml:space="preserve">
-    <value>The model can not be executed. It is invalid.</value>
+  <data name="InvalidModelException" xml:space="preserve">
+    <value>The {0} model can not be operated on as it is invalid.</value>
   </data>
   <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
     <value>The postal code {0} is not valid for {1}.</value>

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
@@ -1,64 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -119,6 +60,9 @@
   </resheader>
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not allowed.</value>
+  </data>
+  <data name="InvalidOperationException_InvalidModel" xml:space="preserve">
+    <value>The model can not be executed. It is invalid.</value>
   </data>
   <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
     <value>The postal code {0} is not valid for {1}.</value>

--- a/src/Qowaiv.ComponentModel/Result.cs
+++ b/src/Qowaiv.ComponentModel/Result.cs
@@ -1,5 +1,6 @@
 ﻿using Qowaiv.ComponentModel.Messages;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
@@ -9,39 +10,17 @@ namespace Qowaiv.ComponentModel
     public class Result
     {
         /// <summary>Creates a new instance of a <see cref="Result"/>.</summary>
-        public Result()
-        {
-            Messages = new List<ValidationResult>();
-        }
-        /// <summary>Creates a new instance of a <see cref="Result"/>.</summary>
         /// <param name="messages">
         /// The messages related to the result.
         /// </param>
-        public Result(IEnumerable<ValidationResult> messages) : this()
+        protected Result(IEnumerable<ValidationResult> messages)
         {
             Guard.NotNull(messages, nameof(messages));
-            AddRange(messages);
+            Messages = new ReadOnlyCollection<ValidationResult>(messages.GetWithSeverity().ToList());
         }
 
         /// <summary>Gets the messages related to the result.</summary>
-        public IList<ValidationResult> Messages { get; }
-
-        /// <summary>Adds a <see cref="ValidationResult"/> to the <see cref="Result"/>.</summary>
-        public bool Add(ValidationResult message)
-        {
-            if (message.GetSeverity() == ValidationSeverity.None)
-            {
-                return false;
-            }
-            Messages.Add(message);
-            return true;
-        }
-
-        /// <summary>Adds a range of <see cref="ValidationResult"/>s to the <see cref="Result"/>.</summary>
-        public void AddRange(IEnumerable<ValidationResult> messages)
-        {
-            ((List<ValidationResult>)Messages).AddRange(messages.GetWithSeverity());
-        }
+        public IReadOnlyList<ValidationResult> Messages { get; }
 
         /// <summary>Return true if there are no error messages, otherwise false.</summary>
         public bool IsValid => !Errors.Any();
@@ -55,6 +34,11 @@ namespace Qowaiv.ComponentModel
         /// <summary>Gets all messages with <see cref="ValidationSeverity.Info"/>.</summary>
         public IEnumerable<ValidationResult> Infos => Messages.GetInfos();
 
+        /// <summary>Creates an OK <see cref="Result"/>.</summary>
+        public static Result OK => new Result(Enumerable.Empty<ValidationResult>());
+
+        /// <summary>Creates a <see cref="Result{T}"/> for the data.</summary>
+        public static Result<T> For<T>(T data, IEnumerable<ValidationResult> messages) => new Result<T>(data, messages);
 
         /// <summary>Creates a <see cref="Result{T}"/> for the data.</summary>
         public static Result<T> For<T>(T data, params ValidationResult[] messages) => new Result<T>(data, messages);

--- a/src/Qowaiv.ComponentModel/Result.cs
+++ b/src/Qowaiv.ComponentModel/Result.cs
@@ -13,7 +13,7 @@ namespace Qowaiv.ComponentModel
         /// <param name="messages">
         /// The messages related to the result.
         /// </param>
-        protected Result(IEnumerable<ValidationResult> messages)
+        internal Result(IEnumerable<ValidationResult> messages)
         {
             Guard.NotNull(messages, nameof(messages));
             Messages = new ReadOnlyCollection<ValidationResult>(messages.GetWithSeverity().ToList());

--- a/src/Qowaiv.ComponentModel/Result_T.cs
+++ b/src/Qowaiv.ComponentModel/Result_T.cs
@@ -12,12 +12,6 @@ namespace Qowaiv.ComponentModel
         /// <param name="data">
         /// The data related to the result.
         /// </param>
-        internal Result(T data) : this(data, Enumerable.Empty<ValidationResult>()) { }
-
-        /// <summary>Creates a new instance of a <see cref="Result{T}"/>.</summary>
-        /// <param name="data">
-        /// The data related to the result.
-        /// </param>
         /// <param name="messages">
         /// The messages related to the result.
         /// </param>
@@ -35,7 +29,7 @@ namespace Qowaiv.ComponentModel
         internal readonly T _value;
 
         /// <summary>Implicitly casts a model to the <see cref="Result"/>.</summary>
-        public static implicit operator Result<T>(T model) => new Result<T>(model);
+        public static implicit operator Result<T>(T model) => For(model);
 
         /// <summary>Explicitly casts the <see cref="Result"/> to the type of the related model.</summary>
         public static explicit operator T(Result<T> result) => result == null ? default(T) : result.Value;

--- a/src/Qowaiv.ComponentModel/Result_T.cs
+++ b/src/Qowaiv.ComponentModel/Result_T.cs
@@ -7,16 +7,13 @@ using System.Linq;
 namespace Qowaiv.ComponentModel
 {
     /// <summary>Represents a result of a validation, executed command, etcetera.</summary>
-    public class Result<T> : Result
+    public sealed class Result<T> : Result
     {
-        /// <summary>Creates a new instance of a <see cref="Result{T}"/>.</summary>
-        public Result(IEnumerable<ValidationResult> messages) : this(default(T), messages) { }
-
         /// <summary>Creates a new instance of a <see cref="Result{T}"/>.</summary>
         /// <param name="data">
         /// The data related to the result.
         /// </param>
-        public Result(T data) : this(data, Enumerable.Empty<ValidationResult>()) { }
+        internal Result(T data) : this(data, Enumerable.Empty<ValidationResult>()) { }
 
         /// <summary>Creates a new instance of a <see cref="Result{T}"/>.</summary>
         /// <param name="data">
@@ -25,15 +22,15 @@ namespace Qowaiv.ComponentModel
         /// <param name="messages">
         /// The messages related to the result.
         /// </param>
-        public Result(T data, IEnumerable<ValidationResult> messages) : base(messages)
+        internal Result(T data, IEnumerable<ValidationResult> messages) : base(messages)
         {
-            _data = data;
+            _data =  IsValid ? data : default(T);
         }
 
         /// <summary>Gets the data related to result.</summary>
-        public T Data => IsValid 
-            ? _data 
-            : throw new InvalidOperationException(QowaivComponentModelMessages.InvalidOperationException_InvalidModel);
+        public T Data => IsValid
+            ? _data
+            : throw InvalidModelException.For<T>(Errors);
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         internal readonly T _data;

--- a/src/Qowaiv.ComponentModel/Result_T.cs
+++ b/src/Qowaiv.ComponentModel/Result_T.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Linq;
@@ -24,21 +23,21 @@ namespace Qowaiv.ComponentModel
         /// </param>
         internal Result(T data, IEnumerable<ValidationResult> messages) : base(messages)
         {
-            _data =  IsValid ? data : default(T);
+            _value =  IsValid ? data : default(T);
         }
 
-        /// <summary>Gets the data related to result.</summary>
-        public T Data => IsValid
-            ? _data
+        /// <summary>Gets the value related to result.</summary>
+        public T Value => IsValid
+            ? _value
             : throw InvalidModelException.For<T>(Errors);
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        internal readonly T _data;
+        internal readonly T _value;
 
         /// <summary>Implicitly casts a model to the <see cref="Result"/>.</summary>
         public static implicit operator Result<T>(T model) => new Result<T>(model);
 
         /// <summary>Explicitly casts the <see cref="Result"/> to the type of the related model.</summary>
-        public static explicit operator T(Result<T> result) => result == null ? default(T) : result.Data;
+        public static explicit operator T(Result<T> result) => result == null ? default(T) : result.Value;
     }
 }

--- a/src/Qowaiv.ComponentModel/Result_T.cs
+++ b/src/Qowaiv.ComponentModel/Result_T.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Qowaiv.ComponentModel
@@ -25,11 +27,16 @@ namespace Qowaiv.ComponentModel
         /// </param>
         public Result(T data, IEnumerable<ValidationResult> messages) : base(messages)
         {
-            Data = data;
+            _data = data;
         }
 
         /// <summary>Gets the data related to result.</summary>
-        public T Data { get; }
+        public T Data => IsValid 
+            ? _data 
+            : throw new InvalidOperationException(QowaivComponentModelMessages.InvalidOperationException_InvalidModel);
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal readonly T _data;
 
         /// <summary>Implicitly casts a model to the <see cref="Result"/>.</summary>
         public static implicit operator Result<T>(T model) => new Result<T>(model);

--- a/src/Qowaiv.ComponentModel/Validation/AnnotatedModelValidator.cs
+++ b/src/Qowaiv.ComponentModel/Validation/AnnotatedModelValidator.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace Qowaiv.ComponentModel.Validation
 {
@@ -51,54 +52,59 @@ namespace Qowaiv.ComponentModel.Validation
         public Result<T> Validate<T>(T model)
         {
             var validationContext = new ValidationContext(model, ServiceProvider, Items);
-            var annotatedModel = AnnotatedModelStore.Instance.GetAnnotededModel(ResolveType(model));
-            return Validate(new Result<T>(model), validationContext, annotatedModel);
-        }
+            var annotations = AnnotatedModelStore.Instance.GetAnnotededModel(model.GetType());
+            var result = Result.For(model);
 
-        /// <summary>Resolves the type of the model.</summary>
-        /// <remarks>
-        /// For scenarios where we don't actually know T and specify <see cref="object"/>.
-        /// </remarks>
-        internal static Type ResolveType<T>(T model)
-        {
-            if (model != null && typeof(T) == typeof(object))
-            {
-                return model.GetType();
-            }
-            return typeof(T);
-        }
+            result.AddRange(ValidateProperties(model, annotations, validationContext));
+            result.AddRange(ValidateType(model, annotations, validationContext));
+            result.AddRange(ValidateValidatableObject(model, annotations, validationContext));
 
-        private Result<T> Validate<T>(Result<T> result, ValidationContext validationContext, AnnotatedModel annotations)
-        {
-            foreach (var property in annotations.Properties)
-            {
-                ValidateProperty(result, validationContext, property);
-            }
-            foreach (var attribute in annotations.TypeAttributes)
-            {
-                result.Add(attribute.GetValidationResult(result.Data, validationContext));
-            }
-            if (annotations.IsIValidatableObject)
-            {
-                result.AddRange(((IValidatableObject)result.Data).Validate(validationContext));
-            }
             return result;
         }
 
-        private static void ValidateProperty<T>(Result<T> result, ValidationContext validationContext, AnnotatedProperty property)
+        /// <summary>Gets the results for validating the (annotated )properties.</summary>
+        private static IEnumerable<ValidationResult> ValidateProperties(object model, AnnotatedModel annotations, ValidationContext validationContext)
         {
-            var value = property.GetValue(result.Data);
-            var propertyContext = property.CreateValidationContext(result.Data, validationContext);
+            return annotations.Properties.SelectMany(prop => ValidateProperty(prop, model, validationContext));
+        }
 
-            // The required condition was not met.
-            if (result.Add(property.RequiredAttribute.GetValidationResult(value, propertyContext)))
+        /// <summary>Gets the results for validating a single annotated property.</summary>
+        /// <remarks>
+        /// It creates a sub validation context.
+        /// </remarks>
+        private static IEnumerable<ValidationResult> ValidateProperty(AnnotatedProperty property, object model, ValidationContext validationContext)
+        {
+            var value = property.GetValue(model);
+            var propertyContext = property.CreateValidationContext(model, validationContext);
+
+            var isRequiredMessage = property.RequiredAttribute.GetValidationResult(value, propertyContext);
+            yield return isRequiredMessage;
+
+            // Only validate the other properties if the required condition was not met.
+            if (isRequiredMessage.GetSeverity() != ValidationSeverity.Error)
             {
-                return;
+                foreach (var attribute in property.ValidationAttributes)
+                {
+                    yield return attribute.GetValidationResult(value, propertyContext);
+                }
             }
-            foreach (var attribute in property.ValidationAttributes)
-            {
-                result.Add(attribute.GetValidationResult(value, propertyContext));
-            }
+        }
+
+        /// <summary>Gets the results for validating the attributes declared on the type of the model.</summary>
+        private static IEnumerable<ValidationResult> ValidateType(object model, AnnotatedModel annotations, ValidationContext validationContext)
+        {
+            return annotations.TypeAttributes.Select(attr => attr.GetValidationResult(model, validationContext));
+        }
+
+        /// <summary>Gets the results for validating <see cref="IValidatableObject.Validate(ValidationContext)"/>.</summary>
+        /// <remarks>
+        /// If the model is not <see cref="IValidatableObject"/> nothing is done.
+        /// </remarks>
+        private static IEnumerable<ValidationResult> ValidateValidatableObject(object model, AnnotatedModel annotations, ValidationContext validationContext)
+        {
+            return annotations.IsIValidatableObject
+                ? ((IValidatableObject)model).Validate(validationContext)
+                : Enumerable.Empty<ValidationResult>();
         }
     }
 }

--- a/src/Qowaiv.ComponentModel/Validation/AnnotatedModelValidator.cs
+++ b/src/Qowaiv.ComponentModel/Validation/AnnotatedModelValidator.cs
@@ -53,13 +53,13 @@ namespace Qowaiv.ComponentModel.Validation
         {
             var validationContext = new ValidationContext(model, ServiceProvider, Items);
             var annotations = AnnotatedModelStore.Instance.GetAnnotededModel(model.GetType());
-            var result = Result.For(model);
+            var messages = new List<ValidationResult>();
 
-            result.AddRange(ValidateProperties(model, annotations, validationContext));
-            result.AddRange(ValidateType(model, annotations, validationContext));
-            result.AddRange(ValidateValidatableObject(model, annotations, validationContext));
+            messages.AddRange(ValidateProperties(model, annotations, validationContext));
+            messages.AddRange(ValidateType(model, annotations, validationContext));
+            messages.AddRange(ValidateValidatableObject(model, annotations, validationContext));
 
-            return result;
+            return Result.For(model, messages);
         }
 
         /// <summary>Gets the results for validating the (annotated )properties.</summary>

--- a/test/Qowaiv.ComponentModel.UnitTests/InvalidModelExceptionTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/InvalidModelExceptionTest.cs
@@ -1,0 +1,38 @@
+﻿using NUnit.Framework;
+using Qowaiv.ComponentModel.Messages;
+using Qowaiv.ComponentModel.Tests.TestTools;
+using Qowaiv.TestTools;
+using System.ComponentModel.DataAnnotations;
+
+namespace Qowaiv.ComponentModel.UnitTests
+{
+    public class InvalidModelExceptionTest
+    {
+        [Test]
+        public void Serializable_ExceptionWithErrors_Successful()
+        {
+            var expected = InvalidModelException.For<int>(new ValidationResult[]
+                {
+                    ValidationMessage.None,
+                    ValidationMessage.Error("Not a prime", "_value"),
+                    ValidationMessage.Warning("Small", "_value"),
+                    ValidationMessage.Info("Not my favorite", "_value"),
+                    new ValidationResult("Not serializable", new []{ "this" })
+                });
+
+            var actual = SerializationTest.SerializeDeserialize(expected);
+
+            Assert.AreEqual(expected.Message, actual.Message);
+            Assert.IsNull(actual.InnerException);
+
+            var actualErrors = actual.Errors.ForAssertion();
+
+            Assert.AreEqual(new[]
+            {
+                ValidationTestMessage.Error("Not a prime", "_value"),
+                ValidationTestMessage.Error("Not serializable", "this")
+            },
+            actualErrors);
+        }
+    }
+}

--- a/test/Qowaiv.ComponentModel.UnitTests/Messages/ValidationMessageTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/Messages/ValidationMessageTest.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using Qowaiv.ComponentModel.Messages;
+using Qowaiv.TestTools;
+
+namespace Qowaiv.ComponentModel.UnitTests.Messages
+{
+    public class ValidationMessageTest
+    {
+
+        [Test]
+        public void Serializable_SomeMessage_Successful()
+        {
+            var message = ValidationMessage.Error("Can be serialized", "ErrorMessage", "MemberNames");
+
+            var actual = SerializationTest.SerializeDeserialize(message);
+
+            Assert.AreEqual(message.ErrorMessage, actual.ErrorMessage);
+            Assert.AreEqual(message.MemberNames, actual.MemberNames);
+        }
+    }
+}

--- a/test/Qowaiv.ComponentModel.UnitTests/Messages/ValidationMessageTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/Messages/ValidationMessageTest.cs
@@ -6,9 +6,30 @@ namespace Qowaiv.ComponentModel.UnitTests.Messages
 {
     public class ValidationMessageTest
     {
+        [Test]
+        public void Serializable_SomeInfoMessage_Successful()
+        {
+            var message = ValidationMessage.Info("Can be serialized", "ErrorMessage", "MemberNames");
+
+            var actual = SerializationTest.SerializeDeserialize(message);
+
+            Assert.AreEqual(message.ErrorMessage, actual.ErrorMessage);
+            Assert.AreEqual(message.MemberNames, actual.MemberNames);
+        }
 
         [Test]
-        public void Serializable_SomeMessage_Successful()
+        public void Serializable_SomeWarningMessage_Successful()
+        {
+            var message = ValidationMessage.Warning("Can be serialized", "ErrorMessage", "MemberNames");
+
+            var actual = SerializationTest.SerializeDeserialize(message);
+
+            Assert.AreEqual(message.ErrorMessage, actual.ErrorMessage);
+            Assert.AreEqual(message.MemberNames, actual.MemberNames);
+        }
+
+        [Test]
+        public void Serializable_SomeErrorMessage_Successful()
         {
             var message = ValidationMessage.Error("Can be serialized", "ErrorMessage", "MemberNames");
 

--- a/test/Qowaiv.ComponentModel.UnitTests/Qowaiv.ComponentModel.UnitTests.csproj
+++ b/test/Qowaiv.ComponentModel.UnitTests/Qowaiv.ComponentModel.UnitTests.csproj
@@ -1,12 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\props\test.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 

--- a/test/Qowaiv.ComponentModel.UnitTests/ResultTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/ResultTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using Qowaiv.ComponentModel.Messages;
+using System;
 
 namespace Qowaiv.ComponentModel.Tests
 {
@@ -30,6 +31,14 @@ namespace Qowaiv.ComponentModel.Tests
             var result = Result.WithMessages<int>(Warning1, Info1, Info2);
             var act = result.IsValid;
             Assert.True(act);
+        }
+
+        [Test]
+        public void WithError_DoesNotAllowAccessToTheModel()
+        {
+            var result = Result.For(new object(), ValidationMessage.Error("Not OK"));
+
+            Assert.Throws<InvalidModelException>(() => Console.WriteLine(result.Data));
         }
 
         [Test]

--- a/test/Qowaiv.ComponentModel.UnitTests/ResultTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/ResultTest.cs
@@ -63,7 +63,7 @@ namespace Qowaiv.ComponentModel.Tests
         public void Ctor_WithData_HasBeenSet()
         {
             var exp = 2;
-            var result = new Result<int>(exp);
+            var result = Result.For(exp);
             var act = result.Data;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.ComponentModel.UnitTests/ResultTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/ResultTest.cs
@@ -38,7 +38,7 @@ namespace Qowaiv.ComponentModel.Tests
         {
             var result = Result.For(new object(), ValidationMessage.Error("Not OK"));
 
-            Assert.Throws<InvalidModelException>(() => Console.WriteLine(result.Data));
+            Assert.Throws<InvalidModelException>(() => Console.WriteLine(result.Value));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace Qowaiv.ComponentModel.Tests
         {
             var exp = 2;
             var result = Result.For(exp);
-            var act = result.Data;
+            var act = result.Value;
 
             Assert.AreEqual(exp, act);
         }
@@ -82,14 +82,14 @@ namespace Qowaiv.ComponentModel.Tests
         public void Implicit_Result_ToType()
         {
             Result<bool> result = true;
-            Assert.IsTrue(result.Data);
+            Assert.IsTrue(result.Value);
         }
 
         [Test]
         public void Implicit_Null_ToType()
         {
             Result<bool> result = false;
-            Assert.IsFalse(result.Data);
+            Assert.IsFalse(result.Value);
         }
 
         [Test]


### PR DESCRIPTION
You could/should argue that accessing an invalid model of a `Result<T>` should be forbidden. Being able to do so might be even bug, although changing it might feel like breaking a contract.

The other thing is which exception to throw: This StackOverflow topic gives a nice point of view: https://stackoverflow.com/questions/12669805/when-to-use-invalidoperationexception-or-notsupportedexception

Given that argument a `NotSupportedException` should be thrown instead of an 'InvalidOperationException'. However, I think I prefer the last one, or even an derived exception that potentially contains the (error) messages too.