### PR TITLE
Clock supports NowWithOffset (DateTimeOffset.Now equivalent)

### DIFF
--- a/src/Qowaiv/Clock.cs
+++ b/src/Qowaiv/Clock.cs
@@ -65,16 +65,10 @@ namespace Qowaiv
         /// </param>
         public static DateTimeOffset NowWithOffset(TimeZoneInfo timeZone)
         {
-            var now = Now(timeZone);
-
-            var offset = timeZone.BaseUtcOffset;
-            var rule = timeZone.GetAdjustmentRules().LastOrDefault(r => r.DateStart < now.Date && r.DateEnd >= now.Date);
-
-            if (rule != null && timeZone.IsDaylightSavingTime(now))
-            {
-                offset = offset.Add(rule.DaylightDelta);
-            }
-            return new DateTimeOffset(now, offset);
+            Guard.NotNull(timeZone, nameof(timeZone));
+            var utcNow = UtcNow();
+            var now = TimeZoneInfo.ConvertTimeFromUtc(utcNow, timeZone);
+            return new DateTimeOffset(now, now - utcNow);
         }
 
         /// <summary>Gets the yesterday for the local <see cref="DateTime"/>.</summary>

--- a/src/Qowaiv/Clock.cs
+++ b/src/Qowaiv/Clock.cs
@@ -32,8 +32,17 @@ namespace Qowaiv
         /// To be able to stub the clock, this simple class can be used. 
         /// 
         /// The core if this clock it UTC, see: https://en.wikipedia.org/wiki/Coordinated_Universal_Time)
+        /// 
+        /// To prevent unexpected behaviour, the result is always converted to
+        /// <see cref="DateTimeKind.Utc"/> if needed.
         /// </remarks>
-        public static DateTime UtcNow() => (threadUtcNow ?? globalUtcNow).Invoke();
+        public static DateTime UtcNow()
+        {
+            var utcNow = (threadUtcNow ?? globalUtcNow).Invoke();
+            return utcNow.Kind == DateTimeKind.Utc
+                ? utcNow
+                : new DateTime(utcNow.Ticks, DateTimeKind.Utc);
+        }
 
         /// <summary>Gets the time zone of the <see cref="Clock"/>.</summary>
         public static TimeZoneInfo TimeZone => threadTimeZone ?? globalTimeZone;

--- a/src/Qowaiv/Clock.cs
+++ b/src/Qowaiv/Clock.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace Qowaiv
 {
@@ -37,14 +38,35 @@ namespace Qowaiv
         /// <summary>Gets the time zone of the <see cref="Clock"/>.</summary>
         public static TimeZoneInfo TimeZone => threadTimeZone ?? globalTimeZone;
 
-        /// <summary>Gets the current local <see cref="DateTime"/>.</summary>
-        public static DateTime Now() => Now(TimeZone);
+        /// <summary>Gets the current <see cref="LocalDateTime"/>.</summary>
+        public static LocalDateTime Now() => Now(TimeZone);
 
-        /// <summary>Gets the current <see cref="DateTime"/> for the specified time zone.</summary>
+        /// <summary>Gets the current <see cref="LocalDateTime"/> for the specified time zone.</summary>
         /// <param name="timeZone">
         /// The specified time zone.
         /// </param>
-        public static DateTime Now(TimeZoneInfo timeZone) => TimeZoneInfo.ConvertTimeFromUtc(UtcNow(), Guard.NotNull(timeZone, nameof(timeZone)));
+        public static LocalDateTime Now(TimeZoneInfo timeZone) => TimeZoneInfo.ConvertTimeFromUtc(UtcNow(), Guard.NotNull(timeZone, nameof(timeZone)));
+
+        /// <summary>Gets the current <see cref="DateTimeOffset"/>.</summary>
+        public static DateTimeOffset NowWithOffset() => NowWithOffset(TimeZone);
+
+        /// <summary>Gets the current <see cref="DateTimeOffset"/> for the specified time zone.</summary>
+        /// <param name="timeZone">
+        /// The specified time zone.
+        /// </param>
+        public static DateTimeOffset NowWithOffset(TimeZoneInfo timeZone)
+        {
+            var now = Now(timeZone);
+
+            var offset = timeZone.BaseUtcOffset;
+            var rule = timeZone.GetAdjustmentRules().LastOrDefault(r => r.DateStart < now.Date && r.DateEnd >= now.Date);
+
+            if (rule != null && timeZone.IsDaylightSavingTime(now))
+            {
+                offset = offset.Add(rule.DaylightDelta);
+            }
+            return new DateTimeOffset(now, offset);
+        }
 
         /// <summary>Gets the yesterday for the local <see cref="DateTime"/>.</summary>
         public static Date Yesterday() => Yesterday(TimeZone);

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -41,7 +41,9 @@ namespace Qowaiv
         /// ticks is less than System.DateTime.MinValue or greater than System.DateTime.MaxValue.
         /// </exception>
         public LocalDateTime(long ticks)
-            : this(new DateTime(ticks)) { }
+        {
+            m_Value = new DateTime(ticks, DateTimeKind.Local);
+        }
 
         /// <summary>Initializes a new instance of the local date time structure based on a System.DateTime.
         /// </summary>
@@ -51,7 +53,7 @@ namespace Qowaiv
         /// <remarks>
         /// The date of the date time is taken.
         /// </remarks>
-        private LocalDateTime(DateTime dt) : this(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, dt.Millisecond) { }
+        private LocalDateTime(DateTime dt) : this(dt.Ticks) { }
 
         /// <summary>Initializes a new instance of the date structure to the specified year, month, and day.</summary>
         /// <param name="year">
@@ -161,9 +163,7 @@ namespace Qowaiv
         /// more than date.MaxValue.
         /// </exception>
         public LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)
-        {
-            m_Value = new DateTime(year, month, day, hour, minute, second, millisecond, DateTimeKind.Local);
-        }
+            : this(new DateTime(year, month, day, hour, minute, second, millisecond, DateTimeKind.Local)) { }
 
         #endregion
 

--- a/test/Qowaiv.UnitTests/ClockTest.cs
+++ b/test/Qowaiv.UnitTests/ClockTest.cs
@@ -75,12 +75,33 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        public void NowWithOffset_WestEuropeanWithoutDaylightSaving_Plus1()
+        {
+            using (Clock.SetTimeAndTimeZoneForCurrentThread(() => new DateTime(2019, 02, 14), TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time")))
+            {
+                var act = Clock.NowWithOffset();
+                var exp = new DateTimeOffset(new LocalDateTime(2019, 02, 14, 1, 0, 0), TimeSpan.FromHours(+1));
+                Assert.AreEqual(exp, act);
+            }
+        }
+        [Test]
+        public void NowWithOffset_WestEuropeanWithDaylightSaving_Plus2()
+        {
+            using (Clock.SetTimeAndTimeZoneForCurrentThread(() => new DateTime(2019, 04, 01), TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time")))
+            {
+                var act = Clock.NowWithOffset();
+                var exp = new DateTimeOffset(new LocalDateTime(2019, 04, 01, 2, 0, 0), TimeSpan.FromHours(+2));
+                Assert.AreEqual(exp, act);
+            }
+        }
+
+        [Test]
         public void Now_TestTimeZone_10HoursLaterThanUtc()
         {
             using (Clock.SetTimeAndTimeZoneForCurrentThread(TestTimeFunction, TestTimeZone))
             {
                 var act = Clock.Now();
-                var exp = new DateTime(2017, 06, 11, 16, 15, 00);
+                var exp = new LocalDateTime(2017, 06, 11, 16, 15, 00);
 
                 Assert.AreEqual(exp, act);
             }

--- a/test/Qowaiv.UnitTests/LocalDateTimeTest.cs
+++ b/test/Qowaiv.UnitTests/LocalDateTimeTest.cs
@@ -632,10 +632,10 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void AddTicks_4000000000017_AreEqual()
+        public void AddTicks_4000001700000_AreEqual()
         {
-            var act = TestStruct.AddTicks(4000000000017L);
-            var exp = new LocalDateTime(1988, 06, 18, 13, 16, 45, 001);
+            var act = TestStruct.AddTicks(4000001700000L);
+            var exp = new LocalDateTime(1988, 06, 18, 13, 16, 45, 171);
 
             Assert.AreEqual(exp, act);
         }


### PR DESCRIPTION
Also changing the behaviour of `DateTimeOffset.Now` should be possible. That is accomplished by the introduction of `Clock.NowWithOffset(TimeZoneInfo)`.

Doing so, I noticed some tiny bugs that have been fixed too.