### PR TITLE
Introduction of DistinctValuesAttribute.

### DIFF
--- a/src/Qowaiv.ComponentModel/DataAnnotations/DistinctValuesAttribute.cs
+++ b/src/Qowaiv.ComponentModel/DataAnnotations/DistinctValuesAttribute.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace Qowaiv.ComponentModel.DataAnnotations
+{
+    /// <summary>Specifies that all values are distinct.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class DistinctValuesAttribute : ValidationAttribute
+    {
+        /// <summary>Creates a new instance of <see cref="DistinctValuesAttribute"/>.</summary>
+        /// <remarks>
+        /// The type of the custom <see cref="IEqualityComparer"/> or <see cref="IEqualityComparer{T}"/> (for <see cref="object"/>).
+        /// </remarks>
+        public DistinctValuesAttribute(Type comparer = null)
+            : base(() => QowaivComponentModelMessages.DistinctValuesAttribute_ValidationError)
+        {
+            EqualityComparer = CreateComparer(comparer);
+        }
+
+        /// <summary>Gets and set a custom <see cref="IEqualityComparer"/>.</summary>
+        public IEqualityComparer<object> EqualityComparer { get; }
+
+        /// <summary>True if all items in the collection are distinct, otherwise false.</summary>
+        public override bool IsValid(object value)
+        {
+            if (value is null)
+            {
+                return true;
+            }
+
+            var collection = Guard.IsTypeOf<IEnumerable>(value, nameof(value)).Cast<object>();
+            var checker = new HashSet<object>(EqualityComparer);
+
+            return collection.All(checker.Add);
+        }
+
+        /// <summary>Creates the Comparer to do the distinct with.</summary>
+        private static IEqualityComparer<object> CreateComparer(Type comparer)
+        {
+            if (comparer is null)
+            {
+                return EqualityComparer<object>.Default;
+            }
+            if(typeof(IEqualityComparer<object>).IsAssignableFrom(comparer))
+            {
+                return (IEqualityComparer<object>)Activator.CreateInstance(comparer);
+            }
+            if (typeof(IEqualityComparer).IsAssignableFrom(comparer))
+            {
+                return new WrappedComparer((IEqualityComparer)Activator.CreateInstance(comparer));
+            }
+            throw new ArgumentException(string.Format(QowaivComponentModelMessages.ArgumentException_TypeIsNotEqualityComparer, comparer), nameof(comparer));
+        }
+
+        /// <summary>As there is no none generic hash set.</summary>
+        private class WrappedComparer : IEqualityComparer<object>
+        {
+            private readonly IEqualityComparer _comparer;
+            public WrappedComparer(IEqualityComparer comparer) => _comparer = comparer;
+            public new bool Equals(object x, object y) => _comparer.Equals(x, y);
+            public int GetHashCode(object obj) => _comparer.GetHashCode(obj);
+        }
+    }
+}

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.Designer.cs
@@ -70,6 +70,24 @@ namespace Qowaiv.ComponentModel {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The type {0} does not implement IEqualityComparer or IEqualityComarer&lt;object&gt;..
+        /// </summary>
+        internal static string ArgumentException_TypeIsNotEqualityComparer {
+            get {
+                return ResourceManager.GetString("ArgumentException_TypeIsNotEqualityComparer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All values of the {0} field should be distinct..
+        /// </summary>
+        internal static string DistinctValuesAttribute_ValidationError {
+            get {
+                return ResourceManager.GetString("DistinctValuesAttribute_ValidationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} model can not be operated on as it is invalid..
         /// </summary>
         internal static string InvalidModelException {

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.nl.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.nl.resx
@@ -61,6 +61,9 @@
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van het veld {0} is niet toegestaan.</value>
   </data>
+  <data name="DistinctValuesAttribute_ValidationError" xml:space="preserve">
+    <value>Alle waarden van het veld {0} zouden verschillend moeten zijn.</value>
+  </data>
   <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
     <value>De postcode {0} is niet geldig voor {1}.</value>
   </data>

--- a/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
+++ b/src/Qowaiv.ComponentModel/QowaivComponentModelMessages.resx
@@ -61,6 +61,12 @@
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not allowed.</value>
   </data>
+  <data name="ArgumentException_TypeIsNotEqualityComparer" xml:space="preserve">
+    <value>The type {0} does not implement IEqualityComparer or IEqualityComarer&lt;object&gt;.</value>
+  </data>
+  <data name="DistinctValuesAttribute_ValidationError" xml:space="preserve">
+    <value>All values of the {0} field should be distinct.</value>
+  </data>
   <data name="InvalidModelException" xml:space="preserve">
     <value>The {0} model can not be operated on as it is invalid.</value>
   </data>

--- a/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/DistinctValuesAttributeTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/DistinctValuesAttributeTest.cs
@@ -1,0 +1,80 @@
+﻿using NUnit.Framework;
+using Qowaiv.ComponentModel.DataAnnotations;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Qowaiv.ComponentModel.UnitTests.DataAnnotations
+{
+    public class DistinctValuesAttributeTest
+    {
+        [Test]
+        public void Ctor_TypeIsNotAEqualityComparer_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => new DistinctValuesAttribute(typeof(string)));
+        }
+
+        [Test]
+        public void IsValid_WithCustomComparerOfObject_IsTrue()
+        {
+            var attribute = new DistinctValuesAttribute(typeof(ObjectEqualityComparer));
+            Assert.IsTrue(attribute.IsValid(new[] { 14, 42 }));
+        }
+
+        [Test]
+        public void IsValid_WithCustomComparer_IsFalse()
+        {
+            var attribute = new DistinctValuesAttribute(typeof(NoSharedPrimeEqualityComparer));
+            Assert.IsFalse(attribute.IsValid(new[] { 14, 42 }));
+        }
+        [Test]
+        public void IsValid_WithoutCustomComparer_IsTrue()
+        {
+            var attribute = new DistinctValuesAttribute();
+            Assert.IsTrue(attribute.IsValid(new[] { 14, 42 }));
+        }
+
+        [Test]
+        public void IsValid_Null_IsTrue()
+        {
+            var attribute = new DistinctValuesAttribute();
+            Assert.IsTrue(attribute.IsValid(null));
+        }
+
+        [Test]
+        public void IsValid_EmptyString_IsTrue()
+        {
+            var attribute = new DistinctValuesAttribute();
+            Assert.IsTrue(attribute.IsValid(""));
+        }
+
+        [Test]
+        public void IsValid_NoEnumerable_Throws()
+        {
+            var attribute = new DistinctValuesAttribute();
+            Assert.Throws<ArgumentException>(() => attribute.IsValid(7));
+        }
+    }
+
+    internal class NoSharedPrimeEqualityComparer : IEqualityComparer
+    {
+        private static readonly int[] primes = { 2, 3, 5, 7, 11, 13, 17, 23, 29, 31 };
+
+        bool IEqualityComparer.Equals(object x, object y)
+        {
+            int a = (int)x;
+            int b = (int)y;
+            return primes.Any(prime => a % prime == 0 && b % prime == 0);
+        }
+
+        public int GetHashCode(object obj) => 0;
+    }
+
+    internal class ObjectEqualityComparer : IEqualityComparer<object>
+    {
+        public new bool Equals(object x, object y) => object.Equals(x, y);
+        public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+}

--- a/test/Qowaiv.UnitTests/Qowaiv.UnitTests.csproj
+++ b/test/Qowaiv.UnitTests/Qowaiv.UnitTests.csproj
@@ -17,12 +17,4 @@
     <ProjectReference Include="..\..\src\Qowaiv\Qowaiv.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Web" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
To be able to decorate a collection to be distinct.

It might be true that in a lot of cases you could and should prevent this with a HashSet<T> or a Dictionary<TKey, TItem>, but in this case it is way easier to inform the user what is wrong.