### PR TITLE
Introduction of validation attributes that limits the values of enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ We're extending the DataAnnotations from Microsoft with some more attributes:
 * [AllowedValues] and 
 * [ForbiddenValues] make it easy to validate string values, or objects/value types that have a string representation.
 * [Any] Tells that a collection should have at least one item.
+* [DefinedEnumValuesOnly] limits the allowed enum values to those defined by the enum.
 
 ### Result model
 Also we propose a Result model that includes the validation messages, and Result which can contain both an object and validation messages. This can be a helpful return type for methods that need to return objects but first have to validate them.

--- a/src/Qowaiv.ComponentModel/DataAnnotations/DefinedEnumValuesOnlyAttribute.cs
+++ b/src/Qowaiv.ComponentModel/DataAnnotations/DefinedEnumValuesOnlyAttribute.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+
+namespace Qowaiv.ComponentModel.DataAnnotations
+{
+    /// <summary>Validates if the decorated enum has a value that is a defined.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public class DefinedEnumValuesOnlyAttribute : ValidationAttribute
+    {
+        /// <summary>Creates a new instance of a <see cref="DefinedEnumValuesOnlyAttribute"/>.</summary>
+        public DefinedEnumValuesOnlyAttribute()
+        : base(() => QowaivComponentModelMessages.AllowedValuesAttribute_ValidationError) { }
+
+        /// <summary>If true, for flag enums, also combinations of defined single values are allowed, that are not defined themselves explicitly.</summary>
+        public bool AllowUndefinedFlagCombinations { get; set; } = true;
+
+        /// <summary>Returns true if the value is defined for the enum, otherwise false.</summary>
+        /// <exception cref="ArgumentException">
+        /// If the type of the value is not an enum.
+        /// </exception>
+        public override bool IsValid(object value)
+        {
+            // Might be a nullable enum, we just don't know.
+            if(value is null)
+            {
+                return true;
+            }
+
+            var enumType = value.GetType();
+
+            if(AllowUndefinedFlagCombinations && enumType.IsEnum && enumType.GetCustomAttributes<FlagsAttribute>().Any())
+            {
+                dynamic dyn = value;
+                var max = Enum.GetValues(enumType)
+                    .Cast<dynamic>()
+                    .Aggregate((e1, e2) => e1 | e2);
+
+                return (max & dyn) == dyn;
+            }
+
+
+            return Enum.IsDefined(enumType, value);
+        }
+    }
+}

--- a/src/Qowaiv.ComponentModel/DataAnnotations/DefinedEnumValuesOnlyAttribute.cs
+++ b/src/Qowaiv.ComponentModel/DataAnnotations/DefinedEnumValuesOnlyAttribute.cs
@@ -14,7 +14,11 @@ namespace Qowaiv.ComponentModel.DataAnnotations
         : base(() => QowaivComponentModelMessages.AllowedValuesAttribute_ValidationError) { }
 
         /// <summary>If true, for flag enums, also combinations of defined single values are allowed, that are not defined themselves explicitly.</summary>
-        public bool AllowUndefinedFlagCombinations { get; set; } = true;
+        /// <remarks>
+        /// When enabled, the logic falls back on <see cref="Enum.IsDefined(Type, object)"/>, as
+        /// that is stricter than, our implementation.
+        /// </remarks>
+        public bool OnlyAllowDefinedFlagsCombinations { get; set; }
 
         /// <summary>Returns true if the value is defined for the enum, otherwise false.</summary>
         /// <exception cref="ArgumentException">
@@ -30,7 +34,7 @@ namespace Qowaiv.ComponentModel.DataAnnotations
 
             var enumType = value.GetType();
 
-            if(AllowUndefinedFlagCombinations && enumType.IsEnum && enumType.GetCustomAttributes<FlagsAttribute>().Any())
+            if(!OnlyAllowDefinedFlagsCombinations && enumType.IsEnum && enumType.GetCustomAttributes<FlagsAttribute>().Any())
             {
                 dynamic dyn = value;
                 var max = Enum.GetValues(enumType)

--- a/src/Qowaiv.ComponentModel/Qowaiv.ComponentModel.csproj
+++ b/src/Qowaiv.ComponentModel/Qowaiv.ComponentModel.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\props\common.props" />
 
@@ -19,6 +19,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/DefinedEnumValuesOnlyAttributeTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/DefinedEnumValuesOnlyAttributeTest.cs
@@ -30,21 +30,21 @@ namespace Qowaiv.ComponentModel.UnitTests.DataAnnotations
         [Test]
         public void IsValid_FlagsEnumMixed_IsTrue()
         {
-            var attribute = new DefinedEnumValuesOnlyAttribute { AllowUndefinedFlagCombinations = false };
+            var attribute = new DefinedEnumValuesOnlyAttribute();
             Assert.IsTrue(attribute.IsValid(Flag.American));
         }
 
         [Test]
         public void IsValid_FlagsEnumMixedAllowUndefinedFlagCombinations_IsTrue()
         {
-            var attribute = new DefinedEnumValuesOnlyAttribute { AllowUndefinedFlagCombinations = true };
+            var attribute = new DefinedEnumValuesOnlyAttribute { OnlyAllowDefinedFlagsCombinations = false };
             Assert.IsTrue(attribute.IsValid(Flag.UnionJack | Flag.StarsAndStripes));
         }
 
         [Test]
         public void IsValid_FlagsEnumMixed_IsFalse()
         {
-            var attribute = new DefinedEnumValuesOnlyAttribute { AllowUndefinedFlagCombinations = false };
+            var attribute = new DefinedEnumValuesOnlyAttribute { OnlyAllowDefinedFlagsCombinations = true };
             Assert.IsFalse(attribute.IsValid(Flag.UnionJack | Flag.StarsAndStripes));
         }
 
@@ -70,14 +70,14 @@ namespace Qowaiv.ComponentModel.UnitTests.DataAnnotations
         }
 
 
-        [Flags]
-        public enum Flag
-        {
-            UnionJack = 1,
-            StarsAndStripes = 2,
-            MapleLeaf = 4,
-            American = StarsAndStripes | MapleLeaf,
-        }
+[Flags]
+public enum Flag
+{
+    UnionJack = 1,
+    StarsAndStripes = 2,
+    MapleLeaf = 4,
+    American = StarsAndStripes | MapleLeaf,
+}
 
         public enum Number
         {

--- a/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/DefinedEnumValuesOnlyAttributeTest.cs
+++ b/test/Qowaiv.ComponentModel.UnitTests/DataAnnotations/DefinedEnumValuesOnlyAttributeTest.cs
@@ -1,0 +1,88 @@
+﻿using NUnit.Framework;
+using Qowaiv.ComponentModel.DataAnnotations;
+using System;
+
+namespace Qowaiv.ComponentModel.UnitTests.DataAnnotations
+{
+    public class DefinedEnumValuesOnlyAttributeTest
+    {
+        [Test]
+        public void IsValid_null_IsTrue()
+        {
+            var attribute = new DefinedEnumValuesOnlyAttribute();
+            Assert.IsTrue(attribute.IsValid(null));
+        }
+
+        [Test]
+        public void IsValid_NotAnEnum_Throws()
+        {
+            var attribute = new DefinedEnumValuesOnlyAttribute();
+            Assert.Throws<ArgumentException>(() => attribute.IsValid(1));
+        }
+
+        [Test]
+        public void IsValid_FlagsEnumSingle_IsTrue()
+        {
+            var attribute = new DefinedEnumValuesOnlyAttribute();
+            Assert.IsTrue(attribute.IsValid(Flag.UnionJack));
+        }
+
+        [Test]
+        public void IsValid_FlagsEnumMixed_IsTrue()
+        {
+            var attribute = new DefinedEnumValuesOnlyAttribute { AllowUndefinedFlagCombinations = false };
+            Assert.IsTrue(attribute.IsValid(Flag.American));
+        }
+
+        [Test]
+        public void IsValid_FlagsEnumMixedAllowUndefinedFlagCombinations_IsTrue()
+        {
+            var attribute = new DefinedEnumValuesOnlyAttribute { AllowUndefinedFlagCombinations = true };
+            Assert.IsTrue(attribute.IsValid(Flag.UnionJack | Flag.StarsAndStripes));
+        }
+
+        [Test]
+        public void IsValid_FlagsEnumMixed_IsFalse()
+        {
+            var attribute = new DefinedEnumValuesOnlyAttribute { AllowUndefinedFlagCombinations = false };
+            Assert.IsFalse(attribute.IsValid(Flag.UnionJack | Flag.StarsAndStripes));
+        }
+
+        [Test]
+        public void IsValid_FlagsRandomIntValue_IsFalse()
+        {
+            var attribute = new DefinedEnumValuesOnlyAttribute();
+            Assert.IsFalse(attribute.IsValid((Flag)666));
+        }
+
+        [Test]
+        public void IsValid_EnumDefined_IsTrue()
+        {
+            var attribute = new DefinedEnumValuesOnlyAttribute();
+            Assert.IsTrue(attribute.IsValid(Number.Zero));
+        }
+
+        [Test]
+        public void IsValid_EnumNotDefined_IsFalse()
+        {
+            var attribute = new DefinedEnumValuesOnlyAttribute();
+            Assert.IsFalse(attribute.IsValid((Number)17));
+        }
+
+
+        [Flags]
+        public enum Flag
+        {
+            UnionJack = 1,
+            StarsAndStripes = 2,
+            MapleLeaf = 4,
+            American = StarsAndStripes | MapleLeaf,
+        }
+
+        public enum Number
+        {
+            Zero,
+            One,
+        }
+    }
+}


### PR DESCRIPTION
To limit enum values. Looks like:

``` C#
public class MyClass
{
    [DefinedEnumValuesOnly(OnlyAllowDefinedFlagsCombinations = true)]
    public MyEnum Property { get; set; }
}
```
By decorating it as such, only values defined by the enums are allowed. For flags, it has two modes. One (default) where also not by itself defined combinations of defined flags are allowed, and on that also prohibits that.

``` C#
[Flags]
public enum Flag
{
    UnionJack = 1,
    StarsAndStripes = 2,
    MapleLeaf = 4,
    American = StarsAndStripes | MapleLeaf,
}
```

So, for the following enum, when enabled, `Flag.UnionJack | Flag.StarsAndStripes` is also allowed, without, it is not, where `Flag.American` is allowed in both cases.