### PR TITLE
JSON Newtonsoft support should be package containing a file (only)

### DIFF
--- a/src/Qowaiv.Json.Newtonsoft/Qowaiv.Json.Newtonsoft.csproj
+++ b/src/Qowaiv.Json.Newtonsoft/Qowaiv.Json.Newtonsoft.csproj
@@ -1,25 +1,28 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\props\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>3.2.5</Version>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Qowaiv.Json.NewtonSoft.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Qowaiv.Json.NewtonSoft.xml</DocumentationFile>
-  </PropertyGroup>
-
 
   <ItemGroup>
     <Compile Include="..\Shared\ProductInfo.cs" Link="Properties\ProductInfo.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="QowaivJsonConverter.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)\QowaivJsonConverter.cs" Pack="true" PackagePath="contentFiles" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Qowaiv.Json.Newtonsoft/QowaivJsonConverter.cs
+++ b/src/Qowaiv.Json.Newtonsoft/QowaivJsonConverter.cs
@@ -119,18 +119,20 @@ namespace Qowaiv.Json
             {
                 writer.WriteNull();
             }
-
-            var json = Guard.IsTypeOf<IJsonSerializable>(value, nameof(value));
-
-            var jsonValue = json.ToJson();
-
-            if (jsonValue is null)
-            {
-                writer.WriteNull();
-            }
             else
             {
-                writer.WriteValue(jsonValue);
+                var json = Guard.IsTypeOf<IJsonSerializable>(value, nameof(value));
+
+                var jsonValue = json.ToJson();
+
+                if (jsonValue is null)
+                {
+                    writer.WriteNull();
+                }
+                else
+                {
+                    writer.WriteValue(jsonValue);
+                }
             }
         }
     }

--- a/src/Qowaiv.Web/Qowaiv.Web.csproj
+++ b/src/Qowaiv.Web/Qowaiv.Web.csproj
@@ -23,7 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Qowaiv.Json.Newtonsoft\Qowaiv.Json.Newtonsoft.csproj" />
     <ProjectReference Include="..\Qowaiv\Qowaiv.csproj" />
   </ItemGroup>
 

--- a/test/Qowaiv.Json.Newtonsoft.UnitTests/Qowaiv.Json.Newtonsoft.UnitTests.csproj
+++ b/test/Qowaiv.Json.Newtonsoft.UnitTests/Qowaiv.Json.Newtonsoft.UnitTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\test.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>Qowaiv.Json.UnitTests</RootNamespace>
   </PropertyGroup>
 

--- a/test/Qowaiv.Json.Newtonsoft.UnitTests/QowaivJsonConverterTest.cs
+++ b/test/Qowaiv.Json.Newtonsoft.UnitTests/QowaivJsonConverterTest.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using NUnit.Framework;
+using System.IO;
 
 namespace Qowaiv.Json.UnitTests
 {
@@ -52,6 +53,20 @@ namespace Qowaiv.Json.UnitTests
             var converter = new QowaivJsonConverter();
 
             Assert.IsFalse(converter.CanConvert(typeof(bool?)));
+        }
+
+        [Test]
+        public void Write_null_ShouldNotWriteAnything()
+        {
+            var conveter = new QowaivJsonConverter();
+
+            using (var stream = new MemoryStream())
+            {
+                var writer = new JsonTextWriter(new StreamWriter(stream));
+                conveter.WriteJson(writer, null, new JsonSerializer());
+
+                Assert.IsEmpty(stream.ToArray());
+            }
         }
 
         [Test]


### PR DESCRIPTION
The current solution has a dependency on a fixed Newtonsoft version. Potentially, choosing for Qowaiv implies that you have to change the version of Newtonsoft, or have to deal with suppressions. Given that we only provide a 'Newtonsoft.Json.JsonConverter` and a simple `QowaivJsonConverter.Register()`, helper method, that might be overkill.

The idea is to only provide the file, ideally still with a NuGet package.

``` C#
using Newtonsoft.Json;
using Qowaiv.Reflection;
using System;
using System.Globalization;
using System.Linq;

namespace Qowaiv.Json
{
    /// <summary>The Qowaiv JSON converter converts types from and to JSON that implement the Qowaiv.Json.IJsonSerializable.</summary>
    public class QowaivJsonConverter : JsonConverter
    {
        /// <summary>Registers the Qowaiv JSON converter.</summary>
        public static void Register()
        {
            if (JsonConvert.DefaultSettings is null)
            {
                JsonConvert.DefaultSettings = () => new JsonSerializerSettings { Converters = { new QowaivJsonConverter() } };
            }
            else
            {
                var settings = JsonConvert.DefaultSettings.Invoke();
                if (!settings.Converters.Any(c => c.GetType() == typeof(QowaivJsonConverter)))
                {
                    settings.Converters.Add(new QowaivJsonConverter());
                }
            }
        }

        /// <summary>Returns true if the object type is (nullable) IJsonSerializable.</summary>
        /// <param name="objectType">
        /// The object type to convert.
        /// </param>
        public override bool CanConvert(Type objectType)
        {
            return objectType != null && (QowaivType.IsIJsonSerializable(objectType) || QowaivType.IsNullableIJsonSerializable(objectType));
        }

        /// <summary>Reads the JSON representation of an IJsonSerializable.</summary>
        /// <param name="reader">
        /// The Newtonsoft.Json.JsonReader to read from.
        /// </param>
        /// <param name="objectType">
        /// The type of the object.
        /// </param>
        /// <param name="existingValue">
        /// The existing value of object being read.
        /// </param>
        /// <param name="serializer">
        /// The calling serializer.
        /// </param>
        /// <returns>
        /// The object value.
        /// </returns>
        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
        {
            Guard.NotNull(reader, nameof(reader));
            Guard.NotNull(objectType, nameof(objectType));

            var isNullable = QowaivType.IsNullable(objectType);
            var resultType = isNullable ? objectType.GetGenericArguments()[0] : objectType;
            var result = (IJsonSerializable)Activator.CreateInstance(resultType);

            try
            {
                switch (reader.TokenType)
                {
                    // Empty value for null-ables.
                    case JsonToken.Null:
                        if (isNullable) { return null; }
                        result.FromJson();
                        break;

                    // A number without digits.
                    case JsonToken.Integer:
                        result.FromJson((long)reader.Value);
                        break;

                    // A number with digits.
                    case JsonToken.Float:
                        result.FromJson((double)reader.Value);
                        break;

                    // A string.
                    case JsonToken.String:
                        result.FromJson((string)reader.Value);
                        break;
                    // Other scenario's are not supported.    
                    default:
                        throw new JsonSerializationException(string.Format(CultureInfo.CurrentCulture, QowaivMessages.JsonSerialization_TokenNotSupported, objectType.FullName, reader.TokenType));
                }
            }
            // We want to communicate exceptions as JSON serialization exceptions.
            catch (Exception x)
            {
                if (x is JsonSerializationException || x is JsonReaderException)
                {
                    throw;
                }
                throw new JsonSerializationException(x.Message, x);
            }
            return result;
        }

        /// <summary>Writes the JSON representation of an IJsonSerializable.</summary>
        /// <param name="writer">
        /// The Newtonsoft.Json.JsonWriter to write to.
        /// </param>
        /// <param name="value">
        /// The value.
        /// </param>
        /// <param name="serializer">
        /// The calling serializer.
        /// </param>
        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
        {
            Guard.NotNull(writer, nameof(writer));

            if (value is null)
            {
                writer.WriteNull();
            }

            var json = Guard.IsTypeOf<IJsonSerializable>(value, nameof(value));

            var jsonValue = json.ToJson();

            if (jsonValue is null)
            {
                writer.WriteNull();
            }
            else
            {
                writer.WriteValue(jsonValue);
            }
        }
    }
}
```