### PR TITLE
Some rework on Validation.Abstractions

### DIFF
--- a/src/Qowaiv.Validation.Abstractions/IValidationMessage.cs
+++ b/src/Qowaiv.Validation.Abstractions/IValidationMessage.cs
@@ -7,7 +7,7 @@
         ValidationSeverity Severity { get; }
 
         /// <summary>The name of the property.</summary>
-        string MemberName { get; }
+        string PropertyName { get; }
 
         /// <summary>Gets the (<see cref="string"/>) message.</summary>
         string Message { get; }

--- a/src/Qowaiv.Validation.Abstractions/InvalidModelException.cs
+++ b/src/Qowaiv.Validation.Abstractions/InvalidModelException.cs
@@ -51,9 +51,9 @@ namespace Qowaiv.Validation.Abstractions
             foreach(var error in Errors)
             {
                 sb.Append(error.Message);
-                if (!string.IsNullOrEmpty(error.MemberName))
+                if (!string.IsNullOrEmpty(error.PropertyName))
                 {
-                    sb.Append(" (").Append(error.MemberName).AppendLine(")");
+                    sb.Append(" (").Append(error.PropertyName).AppendLine(")");
                 }
                 else
                 {

--- a/src/Qowaiv.Validation.Abstractions/README.md
+++ b/src/Qowaiv.Validation.Abstractions/README.md
@@ -73,7 +73,7 @@ namespace Qowaiv.Validation.Abstractions
     public interface IValidationMessage
     {
         ValidationSeverity Severity { get; }
-        string MemberName { get; }
+        string PropertyName { get; }
         string Message { get; }
     }
 }

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 namespace Qowaiv.Validation.Abstractions
 {
     /// <summary>Represents a result of a validation, executed command, etcetera.</summary>
-    public sealed class Result<T> : Result
+    public sealed class Result<TModel> : Result
     {
         /// <summary>Creates a new instance of a <see cref="Result{T}"/>.</summary>
         /// <param name="data">
@@ -13,23 +13,32 @@ namespace Qowaiv.Validation.Abstractions
         /// <param name="messages">
         /// The messages related to the result.
         /// </param>
-        internal Result(T data, IEnumerable<IValidationMessage> messages) : base(messages)
+        internal Result(TModel data, IEnumerable<IValidationMessage> messages) : base(messages)
         {
-            _value =  IsValid ? data : default;
+            _value = IsValid ? data : default;
         }
 
         /// <summary>Gets the value related to result.</summary>
-        public T Value => IsValid
+        public TModel Value => IsValid
             ? _value
-            : throw InvalidModelException.For<T>(Errors);
+            : throw InvalidModelException.For<TModel>(Errors);
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        internal readonly T _value;
+        internal readonly TModel _value;
 
         /// <summary>Implicitly casts a model to the <see cref="Result"/>.</summary>
-        public static implicit operator Result<T>(T model) => For(model);
+        public static implicit operator Result<TModel>(TModel model) => For(model);
+
+        /// <summary>Throws an <see cref="InvalidModelException"/> if the result is not valid.</summary>
+        public void ThrowIfInvalid()
+        {
+            if (!IsValid)
+            {
+                throw InvalidModelException.For<TModel>(Errors);
+            }
+        }
 
         /// <summary>Explicitly casts the <see cref="Result"/> to the type of the related model.</summary>
-        public static explicit operator T(Result<T> result) => result == null ? default : result.Value;
+        public static explicit operator TModel(Result<TModel> result) => result == null ? default : result.Value;
     }
 }

--- a/src/Qowaiv.Validation.Abstractions/Validator.cs
+++ b/src/Qowaiv.Validation.Abstractions/Validator.cs
@@ -1,0 +1,16 @@
+﻿namespace Qowaiv.Validation.Abstractions
+{
+    /// <summary>Static validator helper class.</summary>
+    public static class Validator
+    {
+        /// <summary>Gets an empty <see cref="IValidator{TModel}"/>.</summary>
+        public static IValidator<TModel> Empty<TModel>() => new EmptyValidator<TModel>();
+
+        /// <summary>Implementation of an empty validator.</summary>
+        private sealed class EmptyValidator<TModel> : IValidator<TModel>
+        {
+            /// <inheritdoc />
+            public Result<TModel> Validate(TModel model) => Result.For(model);
+        }
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/ValidationMessage.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/ValidationMessage.cs
@@ -44,7 +44,7 @@ namespace Qowaiv.Validation.DataAnnotations
         public ValidationSeverity Severity { get; }
 
         /// <inheritdoc />
-        public string MemberName => MemberNames.FirstOrDefault();
+        public string PropertyName => MemberNames.FirstOrDefault();
 
         /// <inheritdoc />
         public string Message => ErrorMessage;

--- a/src/Qowaiv.Validation.Fluent/FluentModelValidator.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentModelValidator.cs
@@ -1,0 +1,16 @@
+﻿using Qowaiv.Validation.Abstractions;
+
+namespace Qowaiv.Validation.Fluent
+{
+    /// <summary>Base class for an <see cref="IValidator{TModel}"/> using FluentValidation.NET.</summary>
+    public abstract class FluentModelValidator<TModel> : FluentValidation.AbstractValidator<TModel>, IValidator<TModel>
+    {
+        /// <inheritdoc />
+        Result<TModel> IValidator<TModel>.Validate(TModel model)
+        {
+            var context = new FluentValidation.ValidationContext<TModel>(model);
+            var result = Validate(context);
+            return Result.For(model, ValidationMessage.For(result.Errors));
+        }
+    }
+}

--- a/src/Qowaiv.Validation.Fluent/ValidationMessage.cs
+++ b/src/Qowaiv.Validation.Fluent/ValidationMessage.cs
@@ -8,41 +8,21 @@ using System.Linq;
 namespace Qowaiv.Validation.Fluent
 {
     [Serializable]
-    public class ValidationMessage : IValidationMessage
+    public class ValidationMessage : ValidationFailure, IValidationMessage
     {
-        /// <inheritdoc />
-        public ValidationSeverity Severity { get; set; }
+        /// <summary>Creates a new instance of a <see cref="ValidationMessage"/>.</summary>
+        protected ValidationMessage(string propertyName, string errorMessage)
+            : base(propertyName, errorMessage) { }
 
         /// <inheritdoc />
-        public string MemberName { get; set; }
+        ValidationSeverity IValidationMessage.Severity => Severity.ToValidationSeverity();
 
         /// <inheritdoc />
-        public string Message { get; set; }
-
-        /// <summary>The property value that caused the failure.</summary>
-        public object AttemptedValue { get; set; }
-
-        /// <summary>Custom state associated with the failure.</summary>
-        public object CustomState { get; set; }
-
-        /// <summary>Gets or sets the error code.</summary>
-        public string ErrorCode { get; set; }
-
-        /// <summary>Gets or sets the formatted message arguments. These are values for custom formatted
-        /// message in validator resource files Same formatted message can be reused in UI
-        /// and with same number of format placeholders Like "Value {0} that you entered
-        /// should be {1}"
-        /// </summary>
-        public object[] FormattedMessageArguments { get; set; }
-
-        /// <summary>Gets or sets the formatted message placeholder values.</summary>
-        public Dictionary<string, object> FormattedMessagePlaceholderValues { get; set; }
-
-        /// <summary>The resource name used for building the message.</summary>
-        public string ResourceName { get; set; }
-
-        /// <inheritdoc />
-        public override string ToString() => Message;
+        public string Message
+        {
+            get => ErrorMessage;
+            set => ErrorMessage = value;
+        }
 
         /// <summary>Gets a collection of <see cref="ValidationMessage"/>s 
         /// based on a collection of <see cref="ValidationFailure"/>s.
@@ -54,25 +34,29 @@ namespace Qowaiv.Validation.Fluent
             return messages.Select(message => For(message));
         }
 
+        /// <summary>Creates an error message.</summary>
+        public static ValidationMessage Error(string message, string propertyName) => new ValidationMessage(propertyName, message) { Severity = Severity.Error };
+
+        /// <summary>Creates a warning message.</summary>
+        public static ValidationMessage Warn(string message, string propertyName) => new ValidationMessage(propertyName, message) { Severity = Severity.Warning };
+
+        /// <summary>Creates an info message.</summary>
+        public static ValidationMessage Info(string message, string propertyName) => new ValidationMessage(propertyName, message) { Severity = Severity.Info };
+
         /// <summary>Gets a <see cref="ValidationMessage"/> based on a <see cref="ValidationFailure"/>.</summary>
         public static ValidationMessage For(ValidationFailure message)
         {
             Guard.NotNull(message, nameof(message));
 
-            return new ValidationMessage
+            return new ValidationMessage(message.PropertyName, message.ErrorMessage)
             {
-                Severity = message.Severity.ToValidationSeverity(),
-                MemberName = message.PropertyName,
-                Message = message.ErrorMessage,
-
                 AttemptedValue = message.AttemptedValue,
                 CustomState = message.CustomState,
                 ErrorCode = message.ErrorCode,
                 FormattedMessageArguments = message.FormattedMessageArguments,
-                FormattedMessagePlaceholderValues =message.FormattedMessagePlaceholderValues,
+                FormattedMessagePlaceholderValues = message.FormattedMessagePlaceholderValues,
                 ResourceName = message.ResourceName,
             };
-
         }
     }
 }

--- a/src/Shared/ProductInfo.cs
+++ b/src/Shared/ProductInfo.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/ValidationMessage.cs
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/ValidationMessage.cs
@@ -7,7 +7,7 @@ namespace Qowaiv.Validation.Abstractions.UnitTests
     {
         public ValidationSeverity Severity { get; set; }
 
-        public string MemberName  {get;set;}
+        public string PropertyName  {get;set;}
 
         public string Message { get; set; }
 
@@ -15,12 +15,12 @@ namespace Qowaiv.Validation.Abstractions.UnitTests
         public override bool Equals(object obj) => obj is ValidationMessage other && Equals(other);
         public bool Equals(ValidationMessage other) => ToString() == other?.ToString();
 
-        public override string ToString() => $"{Severity} Message: {Message}, Member: {MemberName}";
+        public override string ToString() => $"{Severity} Message: {Message}, Member: {PropertyName}";
 
         public static ValidationMessage None => new ValidationMessage();
-        public static ValidationMessage Info(string message, string member = null) => new ValidationMessage { Severity = ValidationSeverity.Info, Message = message, MemberName = member };
-        public static ValidationMessage Warn(string message, string member = null) => new ValidationMessage { Severity = ValidationSeverity.Warning, Message = message, MemberName = member };
-        public static ValidationMessage Error(string message, string member = null) => new ValidationMessage { Severity = ValidationSeverity.Error, Message = message, MemberName = member };
+        public static ValidationMessage Info(string message, string member = null) => new ValidationMessage { Severity = ValidationSeverity.Info, Message = message, PropertyName = member };
+        public static ValidationMessage Warn(string message, string member = null) => new ValidationMessage { Severity = ValidationSeverity.Warning, Message = message, PropertyName = member };
+        public static ValidationMessage Error(string message, string member = null) => new ValidationMessage { Severity = ValidationSeverity.Error, Message = message, PropertyName = member };
 
     }
 }

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/NoIPBasedEmailAddressTest.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/NoIPBasedEmailAddressTest.cs
@@ -19,7 +19,8 @@ namespace Qowaiv.Validation.Fluent.UnitTests.Validators
         {
             var model = new NoIPBasedEmailAddressModel { Email = EmailAddress.Parse("qowaiv@172.16.254.1") };
             FluentValidatorAssert.WithErrors<NoIPBasedEmailAddressModelValidator, NoIPBasedEmailAddressModel>(model,
-                new ValidationMessage {  Severity = ValidationSeverity.Error, Message = "'Email' has a IP address based domain.", MemberName = "Email" });
+                ValidationMessage.Error("'Email' has a IP address based domain.", "Email")
+            );
         }
     }
 }

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/NotUnknownValidatorTest.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/NotUnknownValidatorTest.cs
@@ -14,7 +14,7 @@ namespace Qowaiv.Validation.Fluent.UnitTests.Validators
             var model = new NotUnknownModel();
 
             FluentValidatorAssert.WithErrors<NotUnknownModelValidator, NotUnknownModel>(model,
-                new ValidationMessage() { Severity = ValidationSeverity.Error, Message = "'Email' must not be empty.", MemberName = "Email" }
+                ValidationMessage.Error("'Email' must not be empty.", "Email")
             );
         }
 
@@ -26,7 +26,7 @@ namespace Qowaiv.Validation.Fluent.UnitTests.Validators
                 var model = new NotUnknownModel { Email = EmailAddress.Unknown };
 
                 FluentValidatorAssert.WithErrors<NotUnknownModelValidator, NotUnknownModel>(model,
-                    new ValidationMessage() { Severity = ValidationSeverity.Error, Message = "'Email' mag niet onbekend zijn.", MemberName = "Email" }
+                    ValidationMessage.Error("'Email' mag niet onbekend zijn.", "Email")
                 );
             }
         }

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/PostalCodeValidatorTest.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/PostalCodeValidatorTest.cs
@@ -36,7 +36,8 @@ namespace Qowaiv.Validation.Fluent.UnitTests.Validators
             {
                 var model = new PostalCodeModel { Country = Country.NL, PostalCode = PostalCode.Parse("12345") };
                 FluentValidatorAssert.WithErrors<PostalCodeModelValidator, PostalCodeModel>(model,
-                    new ValidationMessage() { Severity = ValidationSeverity.Error, Message = "'Postal Code' 12345 is niet geldig voor Nederland.", MemberName = "PostalCode" });
+                    ValidationMessage.Error("'Postal Code' 12345 is niet geldig voor Nederland.", "PostalCode")
+                );
             }
         }
     }

--- a/tooling/Qowaiv.TestTools/Validation/ValidationMessageAssert.cs
+++ b/tooling/Qowaiv.TestTools/Validation/ValidationMessageAssert.cs
@@ -82,9 +82,9 @@ namespace Qowaiv.TestTools.Validiation
             sb.AppendFormat("- {0,-7} ", message.Severity.ToString().ToUpperInvariant())
                 .Append(message.Message);
 
-            if (!string.IsNullOrEmpty(message.MemberName))
+            if (!string.IsNullOrEmpty(message.PropertyName))
             {
-                sb.Append(" Member: ").AppendLine(message.MemberName);
+                sb.Append(" Prop: ").AppendLine(message.PropertyName);
             }
         }
     }

--- a/tooling/Qowaiv.TestTools/Validation/ValidationMessageComparer.cs
+++ b/tooling/Qowaiv.TestTools/Validation/ValidationMessageComparer.cs
@@ -15,7 +15,7 @@ namespace Qowaiv.TestTools.Validiation
             }
             return x.Message == y.Message
                 && x.Severity == y.Severity
-                && x.MemberName == y.MemberName;;
+                && x.PropertyName == y.PropertyName;;
         }
 
         /// <inheritdoc />
@@ -24,7 +24,7 @@ namespace Qowaiv.TestTools.Validiation
             if (obj is null) { return 0; }
 
             return (obj.Message ?? "").GetHashCode()
-                ^ (obj.MemberName ?? "").GetHashCode()
+                ^ (obj.PropertyName ?? "").GetHashCode()
                 ^ (int)obj.Severity;
         }
     }


### PR DESCRIPTION
* IValidationMessage.PropertyName instead of MemberName
* Fluent.ValidationMessage inherits from ValidationFailure
* Added Validator.Empty<TModel>
* Added FluentModelValidator<TModel> : FluentValidation.AbstractValidator<TModel>, IValidator<TModel>