### PR TITLE
Fixed two issues with  yes-no be culture dependent

### DIFF
--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -591,6 +591,8 @@ namespace Qowaiv
                     { "TRUE", 2 },
                     { "NO", 1 },
                     { "YES", 2 },
+                    { "N", 1 },
+                    { "Y", 2 },
                 }
             }
         };

--- a/test/Qowaiv.UnitTests/YesNoTest.cs
+++ b/test/Qowaiv.UnitTests/YesNoTest.cs
@@ -501,10 +501,13 @@ namespace Qowaiv.Fiancial.UnitTests
         [Test]
         public void ToString_CustomFormatter_SupportsCustomFormatting()
         {
-            var act = TestStruct.ToString("Unit Test Format", new UnitTestFormatProvider());
-            var exp = "Unit Test Formatter, value: 'yes', format: 'Unit Test Format'";
+            using (CultureInfoScope.NewInvariant())
+            {
+                var act = TestStruct.ToString("Unit Test Format", new UnitTestFormatProvider());
+                var exp = "Unit Test Formatter, value: 'yes', format: 'Unit Test Format'";
 
-            Assert.AreEqual(exp, act);
+                Assert.AreEqual(exp, act);
+            }
         }
 
         [TestCase("en-GB", null, "Yes", "yes")]


### PR DESCRIPTION
* One test failed if you environment turned out not to be set to English.
* 'Y' and 'N' could not be parsed if not for English.