### PR TITLE
Extend support for display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ case-insensitve.
 
 ``` C#
 var email = EmailAddress.Parse("Test Account <TEST@qowaiv.org>");
+var quoted = EmailAddress.Parse("\"Joe Smith\" email@qowaiv.org");
 var ip_based = EmailAddress.Parse("test@[172.16.254.1]");
 
 email.ToString(); // test@qowaiv.org
+quoted.ToString(); // email@qowaiv.org
 ip_based.IsIPBased; // true
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ var ip_based = EmailAddress.Parse("test@[172.16.254.1]");
 email.ToString(); // test@qowaiv.org
 quoted.ToString(); // email@qowaiv.org
 ip_based.IsIPBased; // true
+ip_based.WithDisplayName("Jimi Hendrix"); // Jimi Hendrix <test@[172.16.254.1]>
+
 ```
 
 ### Email address collection

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -106,6 +106,22 @@ namespace Qowaiv
         /// <summary>Returns true if the email address is empty or unknown, otherwise false.</summary>
         public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
 
+        /// <summary>Gets the email address with a (prefix) display name.</summary>
+        /// <param name="displayName"></param>
+        /// <returns></returns>
+        public string WithDisplayName(string displayName)
+        {
+            if (IsEmptyOrUnknown())
+            {
+                throw new InvalidOperationException(QowaivMessages.InvalidOperationException_WithDisplayName);
+            }
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                return ToString();
+            }
+            return string.Format(CultureInfo.CurrentCulture, "{0} <{1}>", displayName.Trim(), this);
+        }
+
         #endregion
 
         #region (XML) (De)serialization

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -107,8 +107,15 @@ namespace Qowaiv
         public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
 
         /// <summary>Gets the email address with a (prefix) display name.</summary>
-        /// <param name="displayName"></param>
-        /// <returns></returns>
+        /// <param name="displayName">
+        /// The display name.
+        /// </param>
+        /// <returns>
+        /// An email address with a display name.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// When the email address is empty or unknown.
+        /// </exception>
         public string WithDisplayName(string displayName)
         {
             if (IsEmptyOrUnknown())

--- a/src/Qowaiv/EmailParser.cs
+++ b/src/Qowaiv/EmailParser.cs
@@ -262,12 +262,42 @@ namespace Qowaiv
             }
             if (buffer.First() == '"')
             {
-                var end = buffer.IndexOf('"', 1);
-                if (end == CharBuffer.NotFound)
+                var escape = false;
+
+                var pos = 1;
+                var end = buffer.Length - 1;
+
+                while(pos < end)
                 {
-                    return buffer.Clear();
+                    var ch = buffer[pos++];
+
+                    // The escape character is found.
+                    if (ch == '\\')
+                    {
+                        // toggle state.
+                        escape = !escape;
+                    }
+                    // The (potential) and character.
+                    else if (ch == '"')
+                    {
+                        // if not escaped.
+                        if (!escape)
+                        {
+                            // if followd by a whitespace.
+                            if (char.IsWhiteSpace(buffer[pos++]))
+                            {
+                                return buffer.RemoveRange(0, pos).Trim();
+                            }
+                            return buffer.Clear();
+                        }
+                        escape = false;
+                    }
+                    else
+                    {
+                        escape = false;
+                    }
                 }
-                return buffer.RemoveRange(0, end + 1).TrimLeft();
+                return buffer.Clear();
             }
             return buffer;
         }

--- a/src/Qowaiv/EmailParser.cs
+++ b/src/Qowaiv/EmailParser.cs
@@ -29,7 +29,7 @@ namespace Qowaiv
                 .RemoveComment()
                 .RemoveDisplayName();
 
-            if(str.Empty())
+            if (str.Empty())
             {
                 return null;
             }
@@ -105,14 +105,14 @@ namespace Qowaiv
                     if (ch == Dot)
                     {
                         // No -.
-                        if(prev == Dash)
+                        if (prev == Dash)
                         {
                             return null;
                         }
                         dot = domain.Length;
                     }
                     // No .-
-                    else if(ch == Dash && prev == Dot)
+                    else if (ch == Dash && prev == Dot)
                     {
                         return null;
                     }
@@ -168,13 +168,13 @@ namespace Qowaiv
 
         public static bool IsValidDomain(this CharBuffer buffer, int dot)
         {
-            if(buffer.IndexOf(Colon) != NotFound)
+            if (buffer.IndexOf(Colon) != NotFound)
             {
                 return false;
             }
 
             var start = dot + 1;
-            if(buffer.Length - start < 2)
+            if (buffer.Length - start < 2)
             {
                 return false;
             }
@@ -201,7 +201,7 @@ namespace Qowaiv
             var level = 0;
             var length = 0;
 
-            for(var pos = buffer.Length -1; pos > -1; pos--)
+            for (var pos = buffer.Length - 1; pos > -1; pos--)
             {
                 var ch = buffer[pos];
                 if (ch == ')')
@@ -223,12 +223,12 @@ namespace Qowaiv
                     }
                     else { buffer.Clear(); }
                 }
-                else if(level == 1)
+                else if (level == 1)
                 {
                     length++;
                 }
             }
-            if(level != 0)
+            if (level != 0)
             {
                 return buffer.Clear();
             }
@@ -244,11 +244,11 @@ namespace Qowaiv
         /// </remarks>
         private static CharBuffer RemoveDisplayName(this CharBuffer buffer)
         {
-            if(buffer.Empty())
+            if (buffer.Empty())
             {
                 return buffer;
             }
-            if(buffer.Last() == '>')
+            if (buffer.Last() == '>')
             {
                 var lt = buffer.IndexOf('<');
 
@@ -259,6 +259,15 @@ namespace Qowaiv
                 return buffer
                     .RemoveFromEnd(1)
                     .RemoveRange(0, lt + 1);
+            }
+            if (buffer.First() == '"')
+            {
+                var end = buffer.IndexOf('"', 1);
+                if (end == CharBuffer.NotFound)
+                {
+                    return buffer.Clear();
+                }
+                return buffer.RemoveRange(0, end + 1).TrimLeft();
             }
             return buffer;
         }

--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -358,6 +358,15 @@ namespace Qowaiv {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An not set email address can not be shown with a display name..
+        /// </summary>
+        public static string InvalidOperationException_WithDisplayName {
+            get {
+                return ResourceManager.GetString("InvalidOperationException_WithDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to JSON deserialization from a date is not supported..
         /// </summary>
         public static string JsonSerialization_DateTimeNotSupported {

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -1,64 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -245,5 +186,8 @@
   </data>
   <data name="FormatExceptionInternetMediaType" xml:space="preserve">
     <value>Not a valid internet media type</value>
+  </data>
+  <data name="InvalidOperationException_WithDisplayName" xml:space="preserve">
+    <value>An not set email address can not be shown with a display name.</value>
   </data>
 </root>

--- a/src/Qowaiv/Text/CharBuffer.cs
+++ b/src/Qowaiv/Text/CharBuffer.cs
@@ -51,9 +51,9 @@ namespace Qowaiv.Text
         /// <returns>
         /// -1 if not found, otherwise the index of the <see cref="char"/>.
         /// </returns>
-        public int IndexOf(char ch, int start = 0)
+        public int IndexOf(char ch)
         {
-            for (var i = start; i < Length; i++)
+            for (var i = 0; i < Length; i++)
             {
                 if (buffer[i] == ch)
                 {

--- a/src/Qowaiv/Text/CharBuffer.cs
+++ b/src/Qowaiv/Text/CharBuffer.cs
@@ -51,9 +51,9 @@ namespace Qowaiv.Text
         /// <returns>
         /// -1 if not found, otherwise the index of the <see cref="char"/>.
         /// </returns>
-        public int IndexOf(char ch)
+        public int IndexOf(char ch, int start = 0)
         {
-            for (var i = 0; i < Length; i++)
+            for (var i = start; i < Length; i++)
             {
                 if (buffer[i] == ch)
                 {

--- a/test/Qowaiv.UnitTests/EmailAddressTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressTest.cs
@@ -847,6 +847,31 @@ namespace Qowaiv.UnitTests
 
         #endregion
 
+        #region Methods
+
+        [Test]
+        public void WithDisplayName_UnknownEmailAddress_Throws()
+        {
+            var x = Assert.Catch<InvalidOperationException>(() => EmailAddress.Unknown.WithDisplayName("Jimi Hendrix"));
+            Assert.AreEqual("An not set email address can not be shown with a display name.", x.Message);
+        }
+
+        [Test]
+        public void WithDisplayName_EmptyString_EmailAddressOnly()
+        {
+            var str = TestStruct.WithDisplayName(string.Empty);
+            Assert.AreEqual("svo@qowaiv.org", str);
+        }
+
+        [Test]
+        public void WithDisplayName_JimiHendrix_WithDisplayName()
+        {
+            var str = TestStruct.WithDisplayName(" Jimi Hendrix  ");
+            Assert.AreEqual("Jimi Hendrix <svo@qowaiv.org>", str);
+        }
+
+        #endregion
+
         #region Type converter tests
 
         [Test]
@@ -987,6 +1012,7 @@ namespace Qowaiv.UnitTests
         [TestCase("email(with @ in comment)plus.com")]
         [TestCase(@"""Joe Smith email@domain.com")]
         [TestCase(@"""Joe Smith' email@domain.com")]
+        [TestCase(@"""Joe Smith""email@domain.com")]
         [TestCase("ReDoSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
         public void InvalidEmailAddresses(string email)
         {
@@ -1058,6 +1084,8 @@ namespace Qowaiv.UnitTests
         [TestCase("Joe Smith <email@domain.com>")]
         [TestCase("email@domain.com (joe Smith)")]
         [TestCase(@"""Joe Smith"" email@domain.com")]
+        [TestCase(@"""Joe\\tSmith"" email@domain.com")]
+        [TestCase(@"""Joe\""Smith"" email@domain.com")]
         [TestCase("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
         public void ValidEmailAddresses(string email)
         {

--- a/test/Qowaiv.UnitTests/EmailAddressTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressTest.cs
@@ -150,6 +150,13 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        public void Parse_WithQuotedDisplayName_WithoutDisplayName()
+        {
+            var email = EmailAddress.Parse("\"Joe Smith\" email@domain.com");
+            Assert.AreEqual("email@domain.com", email.ToString());
+        }
+
+        [Test]
         public void Parse_WithCommentAtTheEnd_WithoutComment()
         {
             var email = EmailAddress.Parse("email@domain.com (Joe Smith)");
@@ -978,6 +985,8 @@ namespace Qowaiv.UnitTests
         [TestCase("email)mirror(@plus.com")]
         [TestCase("email@plus.com (not closed comment")]
         [TestCase("email(with @ in comment)plus.com")]
+        [TestCase(@"""Joe Smith email@domain.com")]
+        [TestCase(@"""Joe Smith' email@domain.com")]
         [TestCase("ReDoSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
         public void InvalidEmailAddresses(string email)
         {
@@ -1048,6 +1057,7 @@ namespace Qowaiv.UnitTests
         [TestCase("+local++name+with+@equality.com")]
         [TestCase("Joe Smith <email@domain.com>")]
         [TestCase("email@domain.com (joe Smith)")]
+        [TestCase(@"""Joe Smith"" email@domain.com")]
         [TestCase("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
         public void ValidEmailAddresses(string email)
         {


### PR DESCRIPTION
Qowaiv supports email addresses with a display name: 
* `Joe Smith <email@qowaiv.org>`
* `(Joe Smith) email@qowaiv.org` (in fact as comment)

The change includes:
* `"Joe Smith" email@qowaiv.org`

Questions to answer: 
* Should also `'Joe Smith' email@qowaiv.org` be supported?
* Which escape character(s) for the quote should be supported, if any?
* Should a space character after the end quote be mandatory?

See: #68