### PR TITLE
Introduction of the extension method Percent().

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ and UTC-based date times.
 Represents a month in the range [1-12].
 
 ### Percentage
-Represents a percentage/per mile/per ten thousand.
+Represents a percentage. It supports parsing from per mile and per ten thousand
+too. The basic thought is that `Percentage.Parse("14%")` has the same result
+as `double.Parse("14%")`, which is `0.14`.
 
 ``` C#
 // Creation
@@ -91,6 +93,8 @@ var p = Percentage.Parse("31.4‰"); // Parse: 3.14%;
 var p = 3.14.Percent(); // Extension on double: 3.14%;
 
 // Manipulation
+var p = 13.2.Percent();
+p++; // 14.2%;
 var total = 400;
 total *= (Percentage)0.5; // Total = 200;
 var value = 50.0;

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ Represents a month in the range [1-12].
 ### Percentage
 Represents a percentage/per mile/per ten thousand.
 
+``` C#
+// Creation
+Percentage p = 0.0314; // implict cast: 3.14%
+var p = Percentage.Parse("3.14"); //  Parse: 3.14%;
+var p = Percentage.Parse("3.14%"); // Parse: 3.14%;
+var p = Percentage.Parse("31.4‰"); // Parse: 3.14%;
+var p = 3.14.Percent(); // Extension on double: 3.14%;
+
+// Manipulation
+var total = 400;
+total *= (Percentage)0.5; // Total = 200;
+var value = 50.0;
+value += (Percentage)0.1; // value 55;
+```
+
 ### Postal code
 Represents a postal code. It supports validation for all countries.
 

--- a/src/Qowaiv/PercentageExtensions.cs
+++ b/src/Qowaiv/PercentageExtensions.cs
@@ -360,5 +360,18 @@ namespace Qowaiv
         public static UInt16 Divide(this UInt16 d, Percentage p) { return (UInt16)((Decimal)d).Divide(p); }
 
         #endregion
+
+        #region Percent()
+
+        /// <summary>Interpertates the <see cref="int"/> if it was written with a '%' sign.</summary>
+        public static Percentage Percent(this int number) => number * 0.01m;
+        
+        /// <summary>Interpertates the <see cref="double"/> if it was written with a '%' sign.</summary>
+        public static Percentage Percent(this double number) => number * 0.01;
+
+        /// <summary>Interpertates the <see cref="decimal"/> if it was written with a '%' sign.</summary>
+        public static Percentage Percent(this decimal number) => number * 0.01m;
+
+        #endregion
     }
 }

--- a/src/Qowaiv/PercentageExtensions.cs
+++ b/src/Qowaiv/PercentageExtensions.cs
@@ -363,13 +363,13 @@ namespace Qowaiv
 
         #region Percent()
 
-        /// <summary>Interpertates the <see cref="int"/> if it was written with a '%' sign.</summary>
+        /// <summary>Interprets the <see cref="int"/> if it was written with a '%' sign.</summary>
         public static Percentage Percent(this int number) => number * 0.01m;
-        
-        /// <summary>Interpertates the <see cref="double"/> if it was written with a '%' sign.</summary>
+
+        /// <summary>Interprets the <see cref="double"/> if it was written with a '%' sign.</summary>
         public static Percentage Percent(this double number) => number * 0.01;
 
-        /// <summary>Interpertates the <see cref="decimal"/> if it was written with a '%' sign.</summary>
+        /// <summary>Interprets the <see cref="decimal"/> if it was written with a '%' sign.</summary>
         public static Percentage Percent(this decimal number) => number * 0.01m;
 
         #endregion

--- a/test/Qowaiv.UnitTests/PercentageTest.cs
+++ b/test/Qowaiv.UnitTests/PercentageTest.cs
@@ -1529,6 +1529,31 @@ namespace Qowaiv.UnitTests
         #region Properties
         #endregion
 
+        #region Percent()
+
+        [Test]
+        public void Percent_Int_IsPercentage()
+        {
+            var p = 3.Percent();
+            Assert.AreEqual("3%", p.ToString(CultureInfo.InvariantCulture));
+        }
+
+        [Test]
+        public void Percent_Double_IsPercentage()
+        {
+            var p = 3.14.Percent();
+            Assert.AreEqual("3.14%", p.ToString(CultureInfo.InvariantCulture));
+        }
+
+        [Test]
+        public void Percent_Decimal_IsPercentage()
+        {
+            var p = 3.14m.Percent();
+            Assert.AreEqual("3.14%", p.ToString(CultureInfo.InvariantCulture));
+        }
+
+        #endregion
+
         #region Type converter tests
 
         [Test]


### PR DESCRIPTION
Currently percentages can be created as follows:
``` C#
Percentage p = 0.0314; // implict cast: 3.14%
var p = Percentage.Parse("3.14"); //  Parse: 3.14%;
var p = Percentage.Parse("3.14%"); // Parse: 3.14%;
```
This is convenient (to a high extend) as it makes casting both ways (from and to floating points) predictable, and easy. However, for defining `static readonly`  values in code, it is not ideal.

To overcome this, it might worth to consider the following:

``` C#
var p = 3.14.Percent();
```