### PR TITLE
Introduction of Percentage.Round().

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ total *= (Percentage)0.5; // Total = 200;
 var value = 50.0;
 value += (Percentage)0.1; // value 55;
 
+var rounded = 17.56.Percent().Round(1); // 17.6%;
+
 var max = Percentage.Max(1.4.Percent(), 1.8.Percent()); // 1.8%;
 var min = Percentage.Min(1.7.Percent(), 1.9.Percent()); // 1.7%;
 ```

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -449,6 +449,61 @@ namespace Qowaiv
         /// </returns>
         public static Percentage Min(params Percentage[] values) => Guard.NotNull(values, nameof(values)).Min();
 
+        /// <summary>Rounds the percentage.</summary>
+        /// <returns>
+        /// The percentage nearest to the percentage that contains zero
+        /// fractional digits. If the percentage has no fractional digits,
+        /// the percentage is returned unchanged.
+        /// </returns>
+        public Percentage Round() => Round(0);
+
+        /// <summary>Rounds the percentage to a specified number of fractional digits.</summary>
+        /// <param name="decimals">
+        /// The number of decimal places in the return value.
+        /// </param>
+        /// <returns>
+        /// The percentage nearest to the percentage that contains a number of
+        /// fractional digits equal to <paramref name="decimals"/>. If the
+        /// percentage has fewer fractional digits than <paramref name="decimals"/>,
+        /// the percentage is returned unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="decimals"/> is less than 0 or greater than 26.
+        /// </exception>
+        public Percentage Round(int decimals) => Round(decimals, default);
+
+        /// <summary>Rounds the percentage to a specified number of fractional
+        /// digits. A parameter specifies how to round the value if it is midway
+        /// between two numbers.
+        /// </summary>
+        /// <param name="decimals">
+        /// The number of decimal places in the return value.
+        /// </param>
+        /// <param name="mode">
+        /// Specification for how to round if it is midway between two other numbers.
+        /// </param>
+        /// <returns>
+        /// The percentage nearest to the percentage that contains a number of
+        /// fractional digits equal to <paramref name="decimals"/>. If the
+        /// percentage has fewer fractional digits than <paramref name="decimals"/>,
+        /// the percentage is returned unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="decimals"/> is less than 0 or greater than 26.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///  <paramref name="mode"/> is not a valid value of <see cref="MidpointRounding"/>.
+        /// </exception>
+        public Percentage Round(int decimals, MidpointRounding mode)
+        {
+            if ((decimals < 0) || (decimals > 26))
+            {
+                throw new ArgumentOutOfRangeException(nameof(decimals), QowaivMessages.ArgumentOutOfRange_PercentagelRound);
+            }
+
+            return Math.Round(m_Value, decimals + 2, mode);
+        }
+
         #endregion
 
         #region (XML) (De)serialization

--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -97,6 +97,15 @@ namespace Qowaiv {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Percentages can only round to between 0 and 26 digits of precision..
+        /// </summary>
+        public static string ArgumentOutOfRange_PercentagelRound {
+            get {
+                return ResourceManager.GetString("ArgumentOutOfRange_PercentagelRound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} operation could not be applied. There is a mismatch between {1} and {2}..
         /// </summary>
         public static string CurrencyMismatchException {

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -190,4 +190,7 @@
   <data name="InvalidOperationException_WithDisplayName" xml:space="preserve">
     <value>An not set email address can not be shown with a display name.</value>
   </data>
+  <data name="ArgumentOutOfRange_PercentagelRound" xml:space="preserve">
+    <value>Percentages can only round to between 0 and 26 digits of precision.</value>
+  </data>
 </root>

--- a/test/Qowaiv.UnitTests/PercentageTest.cs
+++ b/test/Qowaiv.UnitTests/PercentageTest.cs
@@ -1549,6 +1549,47 @@ namespace Qowaiv.UnitTests
             Assert.AreEqual(TestStruct, actual);
         }
 
+        [Test]
+        public void Round_Minus1Digits_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TestStruct.Round(-1));
+        }
+
+        [Test]
+        public void Round_27Digits_Throws()
+        {
+            var exception = Assert.Catch<ArgumentOutOfRangeException>(() => TestStruct.Round(27));
+            Assert.AreEqual("Percentages can only round to between 0 and 26 digits of precision.\r\nParameter name: decimals", exception.Message);
+        }
+
+        [Test]
+        public void Round_18Percent()
+        {
+            var actual = TestStruct.Round();
+            Assert.AreEqual(18.Percent(), actual);
+        }
+
+        [Test]
+        public void Round_1decimal_17d5Percent()
+        {
+            var actual = TestStruct.Round(1);
+            Assert.AreEqual(17.5.Percent(), actual);
+        }
+
+        [Test]
+        public void Round_AwayFromZero_17Percent()
+        {
+            var actual = 16.5.Percent().Round(0, MidpointRounding.AwayFromZero);
+            Assert.AreEqual(17.Percent(), actual);
+        }
+
+        [Test]
+        public void Round_ToEven_16Percent()
+        {
+            var actual = 16.5.Percent().Round(0, MidpointRounding.ToEven);
+            Assert.AreEqual(16.Percent(), actual);
+        }
+
         #endregion
 
         #region Casting tests


### PR DESCRIPTION
As suggested in #72 it would be nice if you can round a percentage, directly without having to think about casting (using `Math.Round()`) nor considering that compared to floating points, you want to keep two digits extra, to have the right result.

So: `((Percentage)0.1234).Round(1)` results in `(Percentage)0.123`, (12.3%), and not in `0.1` (10%).