### PR TITLE
Email address display name should support '<' character

### DIFF
--- a/src/Qowaiv/EmailParser.cs
+++ b/src/Qowaiv/EmailParser.cs
@@ -250,7 +250,7 @@ namespace Qowaiv
             }
             if (buffer.Last() == '>')
             {
-                var lt = buffer.IndexOf('<');
+                var lt = buffer.LastIndexOf('<');
 
                 if (lt == CharBuffer.NotFound)
                 {

--- a/src/Qowaiv/Text/CharBuffer.cs
+++ b/src/Qowaiv/Text/CharBuffer.cs
@@ -63,6 +63,22 @@ namespace Qowaiv.Text
             return NotFound;
         }
 
+        /// <summary>Gets the last index of the <see cref="char"/> in the buffer.</summary>
+        /// <returns>
+        /// -1 if not found, otherwise the index of the <see cref="char"/>.
+        /// </returns>
+        public int LastIndexOf(char ch)
+        {
+            for (var i = Length -1; i >= 0; i--)
+            {
+                if (buffer[i] == ch)
+                {
+                    return i;
+                }
+            }
+            return NotFound;
+        }
+
         /// <summary>Counts the occurrences of the <see cref="char"/> in the buffer.</summary>
         public int Count(char ch)
         {

--- a/test/Qowaiv.UnitTests/EmailAddressTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressTest.cs
@@ -1086,6 +1086,7 @@ namespace Qowaiv.UnitTests
         [TestCase(@"""Joe Smith"" email@domain.com")]
         [TestCase(@"""Joe\\tSmith"" email@domain.com")]
         [TestCase(@"""Joe\""Smith"" email@domain.com")]
+        [TestCase(@"Test |<gaaf <email@domain.com>")]
         [TestCase("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
         public void ValidEmailAddresses(string email)
         {


### PR DESCRIPTION
 Because the parse took the first occurrence of the '<' and not the last one, the Display name could not contain a '<'.