### PR TITLE
Email addresses should allow the mailto-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ players in competitor-versus-competitor games.
 Represents a (single) email address. Support:
 * Display names (are stripped)
 * Comments (are removed)
-* IP-based domains (normalized and surrounded by breakets)
+* IP-based domains (normalized and surrounded by brackets)
 
 Furthermore, the email address is normalized as a lowercase string, making it
-case-insensitve.
+case-insensitive.
 
 ``` C#
-var email = EmailAddress.Parse("Test Account <TEST@qowaiv.org>");
+var email = EmailAddress.Parse("Test Account <mailto:TEST@qowaiv.org>");
 var quoted = EmailAddress.Parse("\"Joe Smith\" email@qowaiv.org");
 var ip_based = EmailAddress.Parse("test@[172.16.254.1]");
 
@@ -86,7 +86,7 @@ as `double.Parse("14%")`, which is `0.14`.
 
 ``` C#
 // Creation
-Percentage p = 0.0314; // implict cast: 3.14%
+Percentage p = 0.0314; // implicit cast: 3.14%
 var p = Percentage.Parse("3.14"); //  Parse: 3.14%;
 var p = Percentage.Parse("3.14%"); // Parse: 3.14%;
 var p = Percentage.Parse("31.4‰"); // Parse: 3.14%;

--- a/src/Qowaiv/EmailParser.cs
+++ b/src/Qowaiv/EmailParser.cs
@@ -38,6 +38,7 @@ namespace Qowaiv
             var local = new CharBuffer(EmailAddress.MaxLength);
             var domain = new CharBuffer(EmailAddress.MaxLength);
 
+            var mailto = false;
             var noAt = true;
             var prev = default(char);
             var hasBrackets = false;
@@ -78,6 +79,14 @@ namespace Qowaiv
                 // Local part.
                 else if (noAt)
                 {
+                    // If no MailTo: detected yet, we should remove it.
+                    if (!mailto && ch == Colon && local.Equals(nameof(mailto)))
+                    {
+                        local.Clear();
+                        mailto = true;
+                        continue;
+                    }
+
                     // Don't start with a dot.
                     if (!IsValidLocal(ch) || ch == Dot && local.Empty())
                     {

--- a/src/Qowaiv/Text/CharBuffer.cs
+++ b/src/Qowaiv/Text/CharBuffer.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Text
 {
-    internal class CharBuffer
+    internal class CharBuffer: IEquatable<string>
     {
         public static readonly int NotFound = -1;
 
@@ -146,6 +146,23 @@ namespace Qowaiv.Text
         {
             Length = 0;
             return this;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(string other)
+        {
+            if(Length != other.Length)
+            {
+                return false;
+            }
+            for(var i = 0; i < Length; i++)
+            {
+                if(buffer[i] != other[i])
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         public static implicit operator string(CharBuffer buffer) => buffer?.ToString();

--- a/test/Qowaiv.UnitTests/EmailAddressTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressTest.cs
@@ -1013,8 +1013,10 @@ namespace Qowaiv.UnitTests
         [TestCase(@"""Joe Smith email@domain.com")]
         [TestCase(@"""Joe Smith' email@domain.com")]
         [TestCase(@"""Joe Smith""email@domain.com")]
+        [TestCase("email@mailto:domain.com")]
+        [TestCase("mailto:mailto:email@domain.com")]
         [TestCase("ReDoSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
-        public void InvalidEmailAddresses(string email)
+        public void IsInvalid(string email)
         {
             Assert.IsFalse(EmailAddress.IsValid(email), email);
         }
@@ -1087,8 +1089,11 @@ namespace Qowaiv.UnitTests
         [TestCase(@"""Joe\\tSmith"" email@domain.com")]
         [TestCase(@"""Joe\""Smith"" email@domain.com")]
         [TestCase(@"Test |<gaaf <email@domain.com>")]
+        [TestCase("MailTo:casesensitve@domain.com")]
+        [TestCase("mailto:email@domain.com")]
+        [TestCase("Joe Smith <mailto:email@domain.com>")]
         [TestCase("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
-        public void ValidEmailAddresses(string email)
+        public void IsValid(string email)
         {
             Assert.IsTrue(EmailAddress.IsValid(email), email);
         }


### PR DESCRIPTION
Email addresses should allow the mailto-prefix. So:
```
mailto:mail@domain.com
Display Name <mailto:mail@domain.com>
```
Should be  valid.

See #76 