### PR TITLE
De-obfuscated tests who used TestStruct.ToString(CultureInfo.Invariant)

### DIFF
--- a/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
+++ b/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 

--- a/example/Qowaiv.Json.Newtonsoft.UnitTests/Qowaiv.Json.Newtonsoft.UnitTests.csproj
+++ b/example/Qowaiv.Json.Newtonsoft.UnitTests/Qowaiv.Json.Newtonsoft.UnitTests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/props/analytics.props
+++ b/props/analytics.props
@@ -2,7 +2,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="7.15.0.8572">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="7.16.0.8981">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Qowaiv.Data.SqlClient.UnitTests/Qowaiv.Data.SqlClient.UnitTests.csproj
+++ b/test/Qowaiv.Data.SqlClient.UnitTests/Qowaiv.Data.SqlClient.UnitTests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
 

--- a/test/Qowaiv.Data.SqlClient.UnitTests/Sql/TimestampTest.cs
+++ b/test/Qowaiv.Data.SqlClient.UnitTests/Sql/TimestampTest.cs
@@ -364,7 +364,7 @@ namespace Qowaiv.UnitTests.Sql
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Timestamp>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Timestamp>("123456789");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);
@@ -373,7 +373,7 @@ namespace Qowaiv.UnitTests.Sql
         [Test]
         public void FromJson_Int64Value_AreEqual()
         {
-            var act = JsonTester.Read<Timestamp>((Int64)((UInt64)TestStruct));
+            var act = JsonTester.Read<Timestamp>(123456789L);
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);
@@ -382,7 +382,7 @@ namespace Qowaiv.UnitTests.Sql
         [Test]
         public void FromJson_DoubleValue_AreEqual()
         {
-            var act = JsonTester.Read<Timestamp>((Double)(UInt64)TestStruct);
+            var act = JsonTester.Read<Timestamp>(123456789.0);
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.Data.SqlClient.UnitTests/Sql/TimestampTest.cs
+++ b/test/Qowaiv.Data.SqlClient.UnitTests/Sql/TimestampTest.cs
@@ -403,15 +403,13 @@ namespace Qowaiv.UnitTests.Sql
         {
             object act = JsonTester.Write(Timestamp.MinValue);
             object exp = "0x0000000000000000";
-
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "0x00000000075BCD15";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/DateTest.cs
+++ b/test/Qowaiv.UnitTests/DateTest.cs
@@ -379,7 +379,6 @@ namespace Qowaiv.UnitTests
         {
             object act = JsonTester.Write(default(Date));
             object exp = "0001-01-01";
-
             Assert.AreEqual(exp, act);
         }
         [Test]
@@ -387,7 +386,6 @@ namespace Qowaiv.UnitTests
         {
             var act = JsonTester.Write(TestStruct);
             var exp = "1970-02-14";
-
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/DateTest.cs
+++ b/test/Qowaiv.UnitTests/DateTest.cs
@@ -340,7 +340,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Date>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Date>("1970-02-14");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);
@@ -368,7 +368,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_DateTimeValue_AreEqual()
         {
-            var act = JsonTester.Read<Date>((DateTime)TestStruct);
+            var act = JsonTester.Read<Date>(new DateTime( 1970, 02, 14));
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/EmailAddressCollectionTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressCollectionTest.cs
@@ -269,19 +269,16 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(new EmailAddressCollection());
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(EmailAddressCollection.Parse("info@qowaiv.org, test@qowaiv.org"));
             var exp = "info@qowaiv.org,test@qowaiv.org";
-
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/EmailAddressTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressTest.cs
@@ -466,19 +466,16 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(EmailAddress));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "svo@qowaiv.org";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/EmailAddressTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressTest.cs
@@ -429,7 +429,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<EmailAddress>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<EmailAddress>("svo@qowaiv.org");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/Financial/AmountTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/AmountTest.cs
@@ -371,7 +371,6 @@ namespace Qowaiv.Financial.UnitTests
         {
             var act = JsonTester.Write(TestStruct);
             var exp = 42.17m;
-
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/Financial/AmountTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/AmountTest.cs
@@ -332,7 +332,7 @@ namespace Qowaiv.Financial.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Amount>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Amount>("42.17");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/Financial/BankIdentifierCodeTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/BankIdentifierCodeTest.cs
@@ -444,19 +444,16 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(BankIdentifierCode));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "AEGONL2UXXX";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/Financial/BankIdentifierCodeTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/BankIdentifierCodeTest.cs
@@ -407,7 +407,7 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<BankIdentifierCode>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<BankIdentifierCode>("AEGONL2UXXX");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/Financial/CurrencyTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/CurrencyTest.cs
@@ -503,19 +503,16 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(Currency));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "EUR";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/Financial/CurrencyTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/CurrencyTest.cs
@@ -467,7 +467,7 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Currency>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Currency>("EUR");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/Financial/InternationalBankAccountNumberTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/InternationalBankAccountNumberTest.cs
@@ -331,7 +331,7 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<InternationalBankAccountNumber>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<InternationalBankAccountNumber>("NL20INGB0001234567");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/Financial/InternationalBankAccountNumberTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/InternationalBankAccountNumberTest.cs
@@ -368,19 +368,16 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(InternationalBankAccountNumber));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "NL20INGB0001234567";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/Financial/MoneyTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/MoneyTest.cs
@@ -325,7 +325,7 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Money>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Money>("EUR 42.17");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/Financial/MoneyTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/MoneyTest.cs
@@ -363,8 +363,7 @@ namespace Qowaiv.UnitTests.Financial
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "€42.17";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/GenderTest.cs
+++ b/test/Qowaiv.UnitTests/GenderTest.cs
@@ -482,19 +482,16 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(Gender));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "Male";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/GenderTest.cs
+++ b/test/Qowaiv.UnitTests/GenderTest.cs
@@ -446,7 +446,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Gender>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Gender>("male");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);
@@ -1112,7 +1112,7 @@ namespace Qowaiv.UnitTests
         {
             using (new CultureInfoScope("en-GB"))
             {
-                TypeConverterAssert.ConvertFromEquals(GenderTest.TestStruct, GenderTest.TestStruct.ToString(CultureInfo.InvariantCulture));
+                TypeConverterAssert.ConvertFromEquals(TestStruct, "Male");
             }
         }
 
@@ -1127,7 +1127,7 @@ namespace Qowaiv.UnitTests
         {
             using (new CultureInfoScope("en-GB"))
             {
-                TypeConverterAssert.ConvertToStringEquals(GenderTest.TestStruct.ToString(), GenderTest.TestStruct);
+                TypeConverterAssert.ConvertToStringEquals("Male", TestStruct);
             }
         }
 

--- a/test/Qowaiv.UnitTests/Globalization/CountryTest.cs
+++ b/test/Qowaiv.UnitTests/Globalization/CountryTest.cs
@@ -477,7 +477,7 @@ namespace Qowaiv.UnitTests.Globalization
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Country>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Country>("VA");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/Globalization/CountryTest.cs
+++ b/test/Qowaiv.UnitTests/Globalization/CountryTest.cs
@@ -513,19 +513,16 @@ namespace Qowaiv.UnitTests.Globalization
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(Country));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "VA";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/HouseNumberTest.cs
+++ b/test/Qowaiv.UnitTests/HouseNumberTest.cs
@@ -490,19 +490,16 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(HouseNumber));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "123456789";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/HouseNumberTest.cs
+++ b/test/Qowaiv.UnitTests/HouseNumberTest.cs
@@ -455,7 +455,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<HouseNumber>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<HouseNumber>("123456789");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);
@@ -464,7 +464,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_Int64Value_AreEqual()
         {
-            var act = JsonTester.Read<HouseNumber>((Int64)TestStruct);
+            var act = JsonTester.Read<HouseNumber>(123456789L);
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/IO/StreamSizeTest.cs
+++ b/test/Qowaiv.UnitTests/IO/StreamSizeTest.cs
@@ -371,7 +371,7 @@ namespace Qowaiv.UnitTests.IO
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<StreamSize>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<StreamSize>("123456789");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);
@@ -380,7 +380,7 @@ namespace Qowaiv.UnitTests.IO
         [Test]
         public void FromJson_Int64Value_AreEqual()
         {
-            var act = JsonTester.Read<StreamSize>((Int64)TestStruct);
+            var act = JsonTester.Read<StreamSize>(123456789L);
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/IO/StreamSizeTest.cs
+++ b/test/Qowaiv.UnitTests/IO/StreamSizeTest.cs
@@ -406,11 +406,10 @@ namespace Qowaiv.UnitTests.IO
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsZero()
         {
             object act = JsonTester.Write(default(StreamSize));
             object exp = 0;
-
             Assert.AreEqual(exp, act);
         }
         [Test]
@@ -418,7 +417,6 @@ namespace Qowaiv.UnitTests.IO
         {
             var act = JsonTester.Write(TestStruct);
             var exp = 123456789L;
-
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/LocalDateTimeTest.cs
+++ b/test/Qowaiv.UnitTests/LocalDateTimeTest.cs
@@ -345,7 +345,6 @@ namespace Qowaiv.UnitTests
         {
             object act = JsonTester.Write(default(LocalDateTime));
             object exp = "0001-01-01 00:00:00";
-
             Assert.AreEqual(exp, act);
         }
         [Test]
@@ -353,7 +352,6 @@ namespace Qowaiv.UnitTests
         {
             var act = JsonTester.Write(TestStruct);
             var exp = "1988-06-13 22:10:05.001";
-
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/MonthTest.cs
+++ b/test/Qowaiv.UnitTests/MonthTest.cs
@@ -535,19 +535,16 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(Month));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "2";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/MonthTest.cs
+++ b/test/Qowaiv.UnitTests/MonthTest.cs
@@ -500,7 +500,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Month>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Month>("feb");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/PercentageTest.cs
+++ b/test/Qowaiv.UnitTests/PercentageTest.cs
@@ -389,7 +389,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Percentage>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Percentage>("17.51%");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/PercentageTest.cs
+++ b/test/Qowaiv.UnitTests/PercentageTest.cs
@@ -425,19 +425,17 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsZero()
         {
             object act = JsonTester.Write(default(Percentage));
             object exp = "0%";
-
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "17.51%";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/PostalCodeTest.cs
+++ b/test/Qowaiv.UnitTests/PostalCodeTest.cs
@@ -457,19 +457,16 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(PostalCode));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "H0H0H0";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/PostalCodeTest.cs
+++ b/test/Qowaiv.UnitTests/PostalCodeTest.cs
@@ -420,7 +420,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<PostalCode>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<PostalCode>("H0H0H0");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/Qowaiv.UnitTests.csproj
+++ b/test/Qowaiv.UnitTests/Qowaiv.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Qowaiv.UnitTests/Security/Cryptography/CryptographicSeedTest.cs
+++ b/test/Qowaiv.UnitTests/Security/Cryptography/CryptographicSeedTest.cs
@@ -351,7 +351,7 @@ namespace Qowaiv.Security.Cryptography.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<CryptographicSeed>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<CryptographicSeed>("Qowaiv==");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/Security/Cryptography/CryptographicSeedTest.cs
+++ b/test/Qowaiv.UnitTests/Security/Cryptography/CryptographicSeedTest.cs
@@ -388,19 +388,16 @@ namespace Qowaiv.Security.Cryptography.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(CryptographicSeed));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "Qowaig==";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/Statistics/EloTest.cs
+++ b/test/Qowaiv.UnitTests/Statistics/EloTest.cs
@@ -351,7 +351,6 @@ namespace Qowaiv.UnitTests.Statistics
         {
             var act = JsonTester.Write(TestStruct);
             var exp = 1732.4000000000001;
-
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/Statistics/EloTest.cs
+++ b/test/Qowaiv.UnitTests/Statistics/EloTest.cs
@@ -312,7 +312,7 @@ namespace Qowaiv.UnitTests.Statistics
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Elo>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Elo>("1732.4");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);
@@ -321,7 +321,7 @@ namespace Qowaiv.UnitTests.Statistics
         [Test]
         public void FromJson_Int64Value_AreEqual()
         {
-            Elo act = JsonTester.Read<Elo>((Int64)TestStruct);
+            Elo act = JsonTester.Read<Elo>(1732L);
             Elo exp = 1732;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/UuidTest.cs
+++ b/test/Qowaiv.UnitTests/UuidTest.cs
@@ -334,7 +334,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Uuid>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Uuid>("Qowaiv_SVOLibrary_GUIA");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/UuidTest.cs
+++ b/test/Qowaiv.UnitTests/UuidTest.cs
@@ -371,19 +371,16 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(Uuid));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "Qowaiv_SVOLibrary_GUIA";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/Web/InternetMediaTypeTest.cs
+++ b/test/Qowaiv.UnitTests/Web/InternetMediaTypeTest.cs
@@ -491,19 +491,16 @@ namespace Qowaiv.UnitTests.Web
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(InternetMediaType));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "application/x-chess-pgn";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/Web/InternetMediaTypeTest.cs
+++ b/test/Qowaiv.UnitTests/Web/InternetMediaTypeTest.cs
@@ -454,7 +454,7 @@ namespace Qowaiv.UnitTests.Web
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<InternetMediaType>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<InternetMediaType>("application/x-chess-pgn");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/WeekDateTest.cs
+++ b/test/Qowaiv.UnitTests/WeekDateTest.cs
@@ -412,7 +412,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<WeekDate>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<WeekDate>("1997-W14-6");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/WeekDateTest.cs
+++ b/test/Qowaiv.UnitTests/WeekDateTest.cs
@@ -452,15 +452,13 @@ namespace Qowaiv.UnitTests
         {
             object act = JsonTester.Write(default(WeekDate));
             object exp = "0001-W01-1";
-
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var exp = "1997-W14-6";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/YearTest.cs
+++ b/test/Qowaiv.UnitTests/YearTest.cs
@@ -491,27 +491,23 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(Year));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+             Assert.IsNull(act);
         }
         [Test]
         public void ToJson_Unknown_AreEqual()
         {
             var act = JsonTester.Write(Year.Unknown);
             var exp = "?";
-
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = (Int16)TestStruct;
-
+            var exp = (short)TestStruct;
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.UnitTests/YearTest.cs
+++ b/test/Qowaiv.UnitTests/YearTest.cs
@@ -456,7 +456,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<Year>(TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<Year>("1979");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/YesNoTest.cs
+++ b/test/Qowaiv.UnitTests/YesNoTest.cs
@@ -425,8 +425,7 @@ namespace Qowaiv.Fiancial.UnitTests
         [Test]
         public void FromJson_StringValue_AreEqual()
         {
-            var act = JsonTester.Read<YesNo>
-            (TestStruct.ToString(CultureInfo.InvariantCulture));
+            var act = JsonTester.Read<YesNo>("yes");
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);

--- a/test/Qowaiv.UnitTests/YesNoTest.cs
+++ b/test/Qowaiv.UnitTests/YesNoTest.cs
@@ -462,19 +462,16 @@ namespace Qowaiv.Fiancial.UnitTests
         }
 
         [Test]
-        public void ToJson_DefaultValue_AreEqual()
+        public void ToJson_DefaultValue_IsNull()
         {
             object act = JsonTester.Write(default(YesNo));
-            object exp = null;
-
-            Assert.AreEqual(exp, act);
+            Assert.IsNull(act);
         }
         [Test]
-        public void ToJson_TestStruct_AreEqual()
+        public void ToJson_Yes_AreEqual()
         {
-            var act = JsonTester.Write(TestStruct);
-            var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
+            var act = JsonTester.Write(YesNo.Yes);
+            var exp = "yes";
             Assert.AreEqual(exp, act);
         }
 

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Qowaiv.Validation.Abstractions.UnitTests.csproj
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Qowaiv.Validation.Abstractions.UnitTests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\props\test.props" />
+  
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 

--- a/test/Qowaiv.Validation.DataAnnotations.UnitTests/Qowaiv.Validation.DataAnnotations.UnitTests.csproj
+++ b/test/Qowaiv.Validation.DataAnnotations.UnitTests/Qowaiv.Validation.DataAnnotations.UnitTests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\props\test.props" />
+  
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Qowaiv.Validation.Fluent.UnitTests.csproj
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Qowaiv.Validation.Fluent.UnitTests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\props\test.props" />
+  
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 

--- a/tooling/Qowaiv.CodeGenerator/Generators/Svo/Templates/SvoStruct_UnitTest.cshtml
+++ b/tooling/Qowaiv.CodeGenerator/Generators/Svo/Templates/SvoStruct_UnitTest.cshtml
@@ -551,20 +551,17 @@ namespace @(Model.Namespace).UnitTests
     }
 
     [Test]
-    public void ToJson_DefaultValue_AreEqual()
+    public void ToJson_DefaultValue_IsNull()
     {
-    object act = JsonTester.Write(default(@Model.ClassName));
-    object exp = null;
-
-    Assert.AreEqual(exp, act);
+        object act = JsonTester.Write(default(@Model.ClassName));
+        Assert.IsNull(act);
     }
     [Test]
     public void ToJson_TestStruct_AreEqual()
     {
-    var act = JsonTester.Write(TestStruct);
-    var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
-    Assert.AreEqual(exp, act);
+        var act = JsonTester.Write(TestStruct);
+        var exp = "Some JSON string";
+        Assert.AreEqual(exp, act);
     }
 
     #endregion

--- a/tooling/Qowaiv.CodeGenerator/Generators/Svo/Templates/SvoStruct_UnitTest.cshtml
+++ b/tooling/Qowaiv.CodeGenerator/Generators/Svo/Templates/SvoStruct_UnitTest.cshtml
@@ -480,21 +480,15 @@ namespace @(Model.Namespace).UnitTests
     [Test]
     public void FromJson_StringValue_AreEqual()
     {
-    var act = JsonTester.Read<@(Model.ClassName)>
-    (TestStruct.ToString(CultureInfo.InvariantCulture));
-    var exp = TestStruct;
-
-    Assert.AreEqual(exp, act);
+        var act = JsonTester.Read<@(Model.ClassName)>("JsonRepresentationString");
+        Assert.AreEqual(TestStruct, act);
     }
 
     [Test]
     public void FromJson_Int64Value_AreEqual()
     {
-    var act = JsonTester.Read<@(Model.ClassName)>
-    ((Int64)TestStruct);
-    var exp = TestStruct;
-
-    Assert.AreEqual(exp, act);
+        var act = JsonTester.Read<@(Model.ClassName)>(123456789L);
+        Assert.AreEqual(TestStruct, act);
     }
     [Test]
     public void FromJson_Int64Value_AssertNotSupportedException()


### PR DESCRIPTION
In the JSON serialize/deserialize area, multiple tests used the `TestStruct.ToString(CultureInfo.Invariant)` as input or assert value. It makes test hard to read, and violates the "They shell not use logic in your tests" paradigm.