### PR TITLE
Month should be serialized using the short name

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ and UTC-based date times.
 ### Month
 Represents a month in the range [1-12].
 
+``` C#
+Month feb = Month.Parse("February");
+Month may = Month.May;
+Month dec = 12;
+
+feb.ToString("f", new CultureInfo("nl-NL")); // februari
+feb.ToString("s"); // Feb
+feb.ToString("M"); // 02
+feb.ToString("m"); // 2
+```
+
 ### Percentage
 Represents a percentage. It supports parsing from per mile and per ten thousand
 too. The basic thought is that `Percentage.Parse("14%")` has the same result

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -83,7 +83,7 @@ namespace Qowaiv
         #region Properties
 
         /// <summary>The inner value of the month.</summary>
-        private Byte m_Value;
+        private byte m_Value;
 
         /// <summary>Gets the full name of the month.</summary>
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods",
@@ -188,7 +188,7 @@ namespace Qowaiv
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             Guard.NotNull(writer, nameof(writer));
-            writer.WriteString(ToString(CultureInfo.InvariantCulture));
+            writer.WriteString(ToString("s", CultureInfo.InvariantCulture));
         }
 
         #endregion
@@ -208,13 +208,13 @@ namespace Qowaiv
         /// <param name="jsonInteger">
         /// The JSON integer that represents the month.
         /// </param>
-        void IJsonSerializable.FromJson(Int64 jsonInteger) => m_Value = Create((Int32)jsonInteger).m_Value;
+        void IJsonSerializable.FromJson(long jsonInteger) => m_Value = Create((int)jsonInteger).m_Value;
 
         /// <summary>Generates a month from a JSON number representation.</summary>
         /// <param name="jsonNumber">
         /// The JSON number that represents the month.
         /// </param>
-        void IJsonSerializable.FromJson(Double jsonNumber) => m_Value = Create((Int32)jsonNumber).m_Value;
+        void IJsonSerializable.FromJson(double jsonNumber) => m_Value = Create((int)jsonNumber).m_Value;
 
         /// <summary>Generates a month from a JSON date representation.</summary>
         /// <param name="jsonDate">
@@ -225,7 +225,7 @@ namespace Qowaiv
         /// <summary>Converts a month into its JSON object representation.</summary>
         object IJsonSerializable.ToJson()
         {
-            return (m_Value == default) ? null : ToString(CultureInfo.InvariantCulture);
+            return (m_Value == default) ? null : ToString("s", CultureInfo.InvariantCulture);
         }
 
         #endregion
@@ -283,7 +283,7 @@ namespace Qowaiv
             // Apply the format.
             return StringFormatter.Apply
             (
-                this, string.IsNullOrEmpty(format) ? "M" : format,
+                this, string.IsNullOrEmpty(format) ? "f" : format,
                 formatProvider ?? CultureInfo.CurrentCulture, FormatTokens
             );
         }
@@ -396,9 +396,9 @@ namespace Qowaiv
 
 
         /// <summary>Casts a month to a System.Int32.</summary>
-        public static explicit operator Int32(Month val) => val.m_Value;
+        public static explicit operator int(Month val) => val.m_Value;
         /// <summary>Casts an System.Int32 to a month.</summary>
-        public static implicit operator Month(Int32 val) => Create(val);
+        public static implicit operator Month(int val) => Create(val);
 
         #endregion
 

--- a/test/Qowaiv.UnitTests/MonthTest.cs
+++ b/test/Qowaiv.UnitTests/MonthTest.cs
@@ -335,33 +335,41 @@ namespace Qowaiv.UnitTests
         public void GetObjectData_SerializationInfo_AreEqual()
         {
             ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(Month), new System.Runtime.Serialization.FormatterConverter());
+            var info = new SerializationInfo(typeof(Month), new FormatterConverter());
             obj.GetObjectData(info, default);
 
-            Assert.AreEqual((Byte)2, info.GetByte("Value"));
+            Assert.AreEqual((byte)2, info.GetByte("Value"));
+        }
+
+        [Test]
+        public void XmlSerialize_TestStruct_AreEqual()
+        {
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = @"<?xml version=""1.0"" encoding=""utf-8""?><Month>Feb</Month>";
+            Assert.AreEqual(exp, act);
         }
 
         [Test]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
-            var input = MonthTest.TestStruct;
-            var exp = MonthTest.TestStruct;
+            var input = TestStruct;
+            var exp = TestStruct;
             var act = SerializationTest.SerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void DataContractSerializeDeserialize_TestStruct_AreEqual()
         {
-            var input = MonthTest.TestStruct;
-            var exp = MonthTest.TestStruct;
+            var input = TestStruct;
+            var exp = TestStruct;
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void XmlSerializeDeserialize_TestStruct_AreEqual()
         {
-            var input = MonthTest.TestStruct;
-            var exp = MonthTest.TestStruct;
+            var input = TestStruct;
+            var exp = TestStruct;
             var act = SerializationTest.XmlSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
@@ -372,13 +380,13 @@ namespace Qowaiv.UnitTests
             var input = new MonthSerializeObject()
             {
                 Id = 17,
-                Obj = MonthTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var exp = new MonthSerializeObject()
             {
                 Id = 17,
-                Obj = MonthTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var act = SerializationTest.SerializeDeserialize(input);
@@ -392,13 +400,13 @@ namespace Qowaiv.UnitTests
             var input = new MonthSerializeObject()
             {
                 Id = 17,
-                Obj = MonthTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var exp = new MonthSerializeObject()
             {
                 Id = 17,
-                Obj = MonthTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var act = SerializationTest.XmlSerializeDeserialize(input);
@@ -412,13 +420,13 @@ namespace Qowaiv.UnitTests
             var input = new MonthSerializeObject()
             {
                 Id = 17,
-                Obj = MonthTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var exp = new MonthSerializeObject()
             {
                 Id = 17,
-                Obj = MonthTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var act = SerializationTest.DataContractSerializeDeserialize(input);
@@ -433,13 +441,13 @@ namespace Qowaiv.UnitTests
             var input = new MonthSerializeObject()
             {
                 Id = 17,
-                Obj = default(Month),
+                Obj = default,
                 Date = new DateTime(1970, 02, 14),
             };
             var exp = new MonthSerializeObject()
             {
                 Id = 17,
-                Obj = default(Month),
+                Obj = default,
                 Date = new DateTime(1970, 02, 14),
             };
             var act = SerializationTest.SerializeDeserialize(input);
@@ -509,7 +517,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_Int64Value_AreEqual()
         {
-            var act = JsonTester.Read<Month>((Int64)TestStruct);
+            var act = JsonTester.Read<Month>(2);
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);
@@ -518,7 +526,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void FromJson_DoubleValue_AreEqual()
         {
-            var act = JsonTester.Read<Month>((Double)TestStruct);
+            var act = JsonTester.Read<Month>(2.0);
             var exp = TestStruct;
 
             Assert.AreEqual(exp, act);
@@ -544,7 +552,7 @@ namespace Qowaiv.UnitTests
         public void ToJson_TestStruct_AreEqual()
         {
             var act = JsonTester.Write(TestStruct);
-            var exp = "2";
+            var exp = "Feb";
             Assert.AreEqual(exp, act);
         }
 
@@ -572,7 +580,7 @@ namespace Qowaiv.UnitTests
         public void ToString_CustomFormatter_SupportsCustomFormatting()
         {
             var act = TestStruct.ToString("Unit Test Format", new UnitTestFormatProvider());
-            var exp = "Unit Test Formatter, value: '2', format: 'Unit Test Format'";
+            var exp = "Unit Test Formatter, value: 'February', format: 'Unit Test Format'";
 
             Assert.AreEqual(exp, act);
         }
@@ -683,7 +691,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void GetHash_TestStruct_Hash()
         {
-            Assert.AreEqual(2, MonthTest.TestStruct.GetHashCode());
+            Assert.AreEqual(2, TestStruct.GetHashCode());
         }
 
         [Test]
@@ -704,52 +712,52 @@ namespace Qowaiv.UnitTests
         [Test]
         public void Equals_TestStructTestStruct_IsTrue()
         {
-            Assert.IsTrue(MonthTest.TestStruct.Equals(MonthTest.TestStruct));
+            Assert.IsTrue(TestStruct.Equals(TestStruct));
         }
 
         [Test]
         public void Equals_TestStructEmpty_IsFalse()
         {
-            Assert.IsFalse(MonthTest.TestStruct.Equals(Month.Empty));
+            Assert.IsFalse(TestStruct.Equals(Month.Empty));
         }
 
         [Test]
         public void Equals_EmptyTestStruct_IsFalse()
         {
-            Assert.IsFalse(Month.Empty.Equals(MonthTest.TestStruct));
+            Assert.IsFalse(Month.Empty.Equals(TestStruct));
         }
 
         [Test]
         public void Equals_TestStructObjectTestStruct_IsTrue()
         {
-            Assert.IsTrue(MonthTest.TestStruct.Equals((object)MonthTest.TestStruct));
+            Assert.IsTrue(TestStruct.Equals((object)TestStruct));
         }
 
         [Test]
         public void Equals_TestStructNull_IsFalse()
         {
-            Assert.IsFalse(MonthTest.TestStruct.Equals(null));
+            Assert.IsFalse(TestStruct.Equals(null));
         }
 
         [Test]
         public void Equals_TestStructObject_IsFalse()
         {
-            Assert.IsFalse(MonthTest.TestStruct.Equals(new object()));
+            Assert.IsFalse(TestStruct.Equals(new object()));
         }
 
         [Test]
         public void OperatorIs_TestStructTestStruct_IsTrue()
         {
-            var l = MonthTest.TestStruct;
-            var r = MonthTest.TestStruct;
+            var l = TestStruct;
+            var r = TestStruct;
             Assert.IsTrue(l == r);
         }
 
         [Test]
         public void OperatorIsNot_TestStructTestStruct_IsFalse()
         {
-            var l = MonthTest.TestStruct;
-            var r = MonthTest.TestStruct;
+            var l = TestStruct;
+            var r = TestStruct;
             Assert.IsFalse(l != r);
         }
 
@@ -1093,7 +1101,7 @@ namespace Qowaiv.UnitTests
         {
             using (new CultureInfoScope("en-GB"))
             {
-                TypeConverterAssert.ConvertFromEquals(MonthTest.TestStruct, MonthTest.TestStruct.ToString());
+                TypeConverterAssert.ConvertFromEquals(TestStruct, TestStruct.ToString());
             }
         }
 
@@ -1108,7 +1116,7 @@ namespace Qowaiv.UnitTests
         {
             using (new CultureInfoScope("en-GB"))
             {
-                TypeConverterAssert.ConvertToStringEquals(MonthTest.TestStruct.ToString(), MonthTest.TestStruct);
+                TypeConverterAssert.ConvertToStringEquals(TestStruct.ToString(), TestStruct);
             }
         }
 
@@ -1120,10 +1128,10 @@ namespace Qowaiv.UnitTests
         public void IsValid_Data_IsFalse()
         {
             Assert.IsFalse(Month.IsValid("0"), "0");
-            Assert.IsFalse(Month.IsValid((String)null), "(String)null");
+            Assert.IsFalse(Month.IsValid((string)null), "(String)null");
             Assert.IsFalse(Month.IsValid(string.Empty), "string.Empty");
 
-            Assert.IsFalse(Month.IsValid((System.Byte?)null), "(System.Byte?)null");
+            Assert.IsFalse(Month.IsValid((byte?)null), "(System.Byte?)null");
         }
         [Test]
         public void IsValid_Data_IsTrue()

--- a/tooling/Qowaiv.TestTools/SerializationTest.cs
+++ b/tooling/Qowaiv.TestTools/SerializationTest.cs
@@ -34,6 +34,29 @@ namespace Qowaiv.TestTools
             }
         }
 
+        /// <summary>Serializes an instance using an XmlSerializer.</summary>
+        /// <typeparam name="T">
+        /// Type of the instance.
+        /// </typeparam>
+        /// <param name="instance">
+        /// The instance to (XML) serialize.
+        /// </param>
+        public static string XmlSerialize<T>(T instance)
+        {
+            using (var stream = new MemoryStream())
+            {
+                var writer = new XmlTextWriter(stream, Encoding.UTF8);
+                var serializer = new XmlSerializer(typeof(T));
+                serializer.Serialize(writer, instance);
+                stream.Position = 0;
+
+                using (var reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+
         /// <summary>Serializes and deserializes an instance using an XmlSerializer.</summary>
         /// <typeparam name="T">
         /// Type of the instance.


### PR DESCRIPTION
The default `ToString()` was the numeric value. For serialization this has been changed to the short name, for ToString() the long name.