### PR TITLE
Introduction of BusinessIdentifierCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Represents a BIC as specified in ISO 13616.
 var bic = BusinessIdentifierCode.Parse("AEGONL2UXXX");
 
 var business = bic.Business; // "AEGO"
-var country = bic.Counrty; // Country.NL
+var country = bic.Country; // Country.NL
 var location = bic.Location; // "2U"
 var branch = bic.Branch; // "XXX"
 var length = bic.Length; // 11

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ A seed, representing random data to encrypt and decrypt data.
 ### Amount
 Represents money without the notion of the actual currency.
 
-### Bank Identifier Code (BIC)
+### Business Identifier Code (BIC)
 Represents a BIC as specified in ISO 13616.
 
 ### Currency
@@ -342,7 +342,7 @@ and if the data type is nullable, all when applicable.
     "format": "amount",
     "nullabe": false
   },
-  "Financial.BankIdentifierCode": {
+  "Financial.BusinessIdentifierCode": {
     "description": "Business Identifier Code, as defined by ISO 9362, for example, DEUTDEFF.",
     "type": "string",
     "format": "bic",

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Represents a BIC as specified in ISO 13616.
 var bic = BusinessIdentifierCode.Parse("AEGONL2UXXX");
 
 var business = bic.Business; // "AEGO"
-var country = bic.County; // Country.NL
+var country = bic.Counrty; // Country.NL
 var location = bic.Location; // "2U"
 var branch = bic.Branch; // "XXX"
 var length = bic.Length; // 11

--- a/README.md
+++ b/README.md
@@ -153,11 +153,10 @@ Represents a BIC as specified in ISO 13616.
 ``` C#
 var bic = BusinessIdentifierCode.Parse("AEGONL2UXXX");
 
-var business = bic.BusinessCode; // "AEGO"
-var code = bic.CountyCode; // "NL"
+var business = bic.Business; // "AEGO"
 var country = bic.County; // Country.NL
-var location = bic.LocationCode; // "2U"
-var branch = bic.BranchCode; // "XXX"
+var location = bic.Location; // "2U"
+var branch = bic.Branch; // "XXX"
 var length = bic.Length; // 11
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ Represents money without the notion of the actual currency.
 ### Business Identifier Code (BIC)
 Represents a BIC as specified in ISO 13616.
 
+``` C#
+var bic = BusinessIdentifierCode.Parse("AEGONL2UXXX");
+
+var business = bic.BusinessCode; // "AEGO"
+var code = bic.CountyCode; // "NL"
+var country = bic.County; // Country.NL
+var location = bic.LocationCode; // "2U"
+var branch = bic.BranchCode; // "XXX"
+var length = bic.Length; // 11
+```
+
 ### Currency
 Represents a currency based on an ISO 4217 code.
 

--- a/src/Qowaiv/Conversion/Fiancial/BusinessIdentifierCodeTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Fiancial/BusinessIdentifierCodeTypeConverter.cs
@@ -1,0 +1,12 @@
+﻿using Qowaiv.Financial;
+using System.Globalization;
+
+namespace Qowaiv.Conversion.Financial
+{
+    /// <summary>Provides a conversion for a BIC.</summary>
+    public class BusinessIdentifierCodeTypeConverter : SvoTypeConverter<BusinessIdentifierCode>
+    {
+        /// <inheritdoc/>
+        protected override BusinessIdentifierCode FromString(string str, CultureInfo culture) => BusinessIdentifierCode.Parse(str, culture);
+    }
+}

--- a/src/Qowaiv/Financial/BankIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BankIdentifierCode.cs
@@ -36,6 +36,7 @@ namespace Qowaiv.Financial
     /// messages between banks. The codes can sometimes be found on account
     /// statements.
     /// </remarks>
+    [Obsolete("Use Qowaiv.Financial.BusinessIdentifierCode instead.")]
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
     [OpenApiDataType(description: "Business Identifier Code, as defined by ISO 9362, for example, DEUTDEFF.", type: "string", format: "bic", nullable: true)]

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -1,0 +1,453 @@
+﻿#pragma warning disable S1210
+// "Equals" and the comparison operators should be overridden when implementing "IComparable"
+// See README.md => Sortable
+
+#pragma warning disable S2328
+// "GetHashCode" should not reference mutable fields
+// See README.md => Hashing
+
+using Qowaiv.Conversion.Financial;
+using Qowaiv.Formatting;
+using Qowaiv.Globalization;
+using Qowaiv.Json;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace Qowaiv.Financial
+{
+    /// <summary>The Business Identifier Code (BIC) is a standard format of Business Identifier Codes
+    /// approved by the International Organization for Standardization (ISO) as ISO 9362.
+    /// It is a unique identification code for both financial and non-financial institutions.
+    /// </summary>
+    /// <remarks>
+    /// When assigned to a non-financial institution, a code may also be known
+    /// as a Business Entity Identifier or BEI.
+    /// 
+    /// These codes are used when transferring money between banks, particularly
+    /// for international wire transfers, and also for the exchange of other
+    /// messages between banks. The codes can sometimes be found on account
+    /// statements.
+    /// </remarks>
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
+    [OpenApiDataType(description: "Business Identifier Code, as defined by ISO 9362, for example, DEUTDEFF.", type: "string", format: "bic", nullable: true)]
+    [TypeConverter(typeof(BusinessIdentifierCodeTypeConverter))]
+    public struct BusinessIdentifierCode : ISerializable, IXmlSerializable, IJsonSerializable, IFormattable, IEquatable<BusinessIdentifierCode>, IComparable, IComparable<BusinessIdentifierCode>
+    {
+        /// <remarks>
+        /// http://www.codeproject.com/KB/recipes/bicRegexValidator.aspx
+        /// </remarks>
+        public static readonly Regex Pattern = new Regex(@"^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>Represents an empty/not set BIC.</summary>
+        public static readonly BusinessIdentifierCode Empty;
+
+        /// <summary>Represents an unknown (but set) BIC.</summary>
+        public static readonly BusinessIdentifierCode Unknown = new BusinessIdentifierCode { m_Value = "ZZZZZZZZZZZ" };
+
+        #region Properties
+
+        /// <summary>The inner value of the BIC.</summary>
+        private string m_Value;
+
+        /// <summary>Gets the number of characters of BIC.</summary>
+        public int Length => IsEmptyOrUnknown() ? 0 : m_Value.Length;
+
+        /// <summary>Gets the institution code or business code.</summary>
+        public string BusinessCode => IsEmptyOrUnknown() ? string.Empty : m_Value.Substring(0, 4);
+
+        /// <summary>Gets the country code.</summary>
+        public string CountryCode => IsEmptyOrUnknown() ? string.Empty : m_Value.Substring(4, 2);
+
+        /// <summary>Gets the country info of the country code.</summary>
+        public Country Country
+        {
+            get
+            {
+                if (IsEmpty())
+                {
+                    return Country.Empty;
+                }
+                if (IsUnknown())
+                {
+                    return Country.Unknown;
+                }
+                return Country.Parse(CountryCode, CultureInfo.InvariantCulture);
+            }
+        }
+
+        /// <summary>Gets the location code.</summary>
+        public string LocationCode => IsEmptyOrUnknown() ? string.Empty : m_Value.Substring(6, 2);
+
+        /// <summary>Gets the branch code.</summary>
+        /// <remarks>
+        /// Is optional, XXX for primary office.
+        /// </remarks>
+        public string BranchCode => Length != 11 ? string.Empty : m_Value.Substring(8);
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>Returns true if the BIC is empty, otherwise false.</summary>
+        public bool IsEmpty() => m_Value == default;
+
+        /// <summary>Returns true if the BIC is unknown, otherwise false.</summary>
+        public bool IsUnknown() => m_Value == Unknown.m_Value;
+
+        /// <summary>Returns true if the BIC is empty or unknown, otherwise false.</summary>
+        public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
+
+        #endregion
+
+        #region (XML) (De)serialization
+
+        /// <summary>Initializes a new instance of BIC based on the serialization info.</summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
+        private BusinessIdentifierCode(SerializationInfo info, StreamingContext context)
+        {
+            Guard.NotNull(info, nameof(info));
+            m_Value = info.GetString("Value");
+        }
+
+        /// <summary>Adds the underlying property of BIC to the serialization info.</summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            Guard.NotNull(info, nameof(info));
+            info.AddValue("Value", m_Value);
+        }
+
+        /// <summary>Gets the <see href="XmlSchema"/> to (de) XML serialize a BIC.</summary>
+        /// <remarks>
+        /// Returns null as no schema is required.
+        /// </remarks>
+        XmlSchema IXmlSerializable.GetSchema() => null;
+
+        /// <summary>Reads the BIC from an <see href="XmlReader"/>.</summary>
+        /// <remarks>
+        /// Uses the string parse function of BIC.
+        /// </remarks>
+        /// <param name="reader">An XML reader.</param>
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            Guard.NotNull(reader, nameof(reader));
+            var s = reader.ReadElementString();
+            var val = Parse(s, CultureInfo.InvariantCulture);
+            m_Value = val.m_Value;
+        }
+
+        /// <summary>Writes the BIC to an <see href="XmlWriter"/>.</summary>
+        /// <remarks>
+        /// Uses the string representation of BIC.
+        /// </remarks>
+        /// <param name="writer">An XML writer.</param>
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            Guard.NotNull(writer, nameof(writer));
+            writer.WriteString(ToString(CultureInfo.InvariantCulture));
+        }
+
+        #endregion
+
+        #region (JSON) (De)serialization
+
+        /// <summary>Generates a BIC from a JSON null object representation.</summary>
+        void IJsonSerializable.FromJson() => m_Value = default;
+
+
+        /// <summary>Generates a BIC from a JSON string representation.</summary>
+        /// <param name="jsonString">
+        /// The JSON string that represents the BIC.
+        /// </param>
+        void IJsonSerializable.FromJson(string jsonString)
+        {
+            m_Value = Parse(jsonString, CultureInfo.InvariantCulture).m_Value;
+        }
+
+        /// <summary>Generates a BIC from a JSON integer representation.</summary>
+        /// <param name="jsonInteger">
+        /// The JSON integer that represents the BIC.
+        /// </param>
+        void IJsonSerializable.FromJson(long jsonInteger) => throw new NotSupportedException(QowaivMessages.JsonSerialization_Int64NotSupported);
+
+        /// <summary>Generates a BIC from a JSON number representation.</summary>
+        /// <param name="jsonNumber">
+        /// The JSON number that represents the BIC.
+        /// </param>
+        void IJsonSerializable.FromJson(double jsonNumber) => throw new NotSupportedException(QowaivMessages.JsonSerialization_DoubleNotSupported);
+
+        /// <summary>Generates a BIC from a JSON date representation.</summary>
+        /// <param name="jsonDate">
+        /// The JSON Date that represents the BIC.
+        /// </param>
+        void IJsonSerializable.FromJson(DateTime jsonDate) => throw new NotSupportedException(QowaivMessages.JsonSerialization_DateTimeNotSupported);
+
+        /// <summary>Converts a BIC into its JSON object representation.</summary>
+        object IJsonSerializable.ToJson()
+        {
+            return m_Value == default ? null : ToString(CultureInfo.InvariantCulture);
+        }
+
+        #endregion
+
+        #region IFormattable / ToString
+
+        /// <summary>Returns a <see cref="string"/> that represents the current BIC for debug purposes.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay
+        {
+            get
+            {
+                if (IsEmpty()) { return "BIC: (empty)"; }
+                if (IsUnknown()) { return "BIC: (unknown)"; }
+                return string.Format(CultureInfo.InvariantCulture, "BIC: {0}", m_Value);
+            }
+        }
+
+        /// <summary>Returns a <see cref="string"/> that represents the current BIC.</summary>
+        public override string ToString() => ToString(CultureInfo.CurrentCulture);
+
+        /// <summary>Returns a formatted <see cref="string"/> that represents the current BIC.</summary>
+        /// <param name="format">
+        /// The format that this describes the formatting.
+        /// </param>
+        public string ToString(string format) => ToString(format, CultureInfo.CurrentCulture);
+
+        /// <summary>Returns a formatted <see cref="string"/> that represents the current BIC.</summary>
+        /// <param name="formatProvider">
+        /// The format provider.
+        /// </param>
+        public string ToString(IFormatProvider formatProvider) => ToString("", formatProvider);
+        /// <summary>Returns a formatted <see cref="string"/> that represents the current BIC.</summary>
+        /// <param name="format">
+        /// The format that this describes the formatting.
+        /// </param>
+        /// <param name="formatProvider">
+        /// The format provider.
+        /// </param>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            if (StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted))
+            {
+                return formatted;
+            }
+            if (IsEmpty()) { return string.Empty; }
+            if (IsUnknown()) { return "?"; }
+            return m_Value;
+        }
+
+        #endregion
+
+        #region IEquatable
+
+        /// <summary>Returns true if this instance and the other object are equal, otherwise false.</summary>
+        /// <param name="obj">An object to compare with.</param>
+        public override bool Equals(object obj) => obj is BusinessIdentifierCode && Equals((BusinessIdentifierCode)obj);
+
+        /// <summary>Returns true if this instance and the other <see cref="BusinessIdentifierCode"/> are equal, otherwise false.</summary>
+        /// <param name="other">The <see cref="BusinessIdentifierCode"/> to compare with.</param>
+        public bool Equals(BusinessIdentifierCode other) => m_Value == other.m_Value;
+
+        /// <summary>Returns the hash code for this BIC.</summary>
+        /// <returns>
+        /// A 32-bit signed integer hash code.
+        /// </returns>
+        public override int GetHashCode() => m_Value == null ? 0 : m_Value.GetHashCode();
+
+        /// <summary>Returns true if the left and right operand are not equal, otherwise false.</summary>
+        /// <param name="left">The left operand.</param>
+        /// <param name="right">The right operand</param>
+        public static bool operator ==(BusinessIdentifierCode left, BusinessIdentifierCode right) => left.Equals(right);
+
+        /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
+        /// <param name="left">The left operand.</param>
+        /// <param name="right">The right operand</param>
+        public static bool operator !=(BusinessIdentifierCode left, BusinessIdentifierCode right) => !(left == right);
+
+        #endregion
+
+        #region IComparable
+
+        /// <summary>Compares this instance with a specified System.Object and indicates whether
+        /// this instance precedes, follows, or appears in the same position in the sort
+        /// order as the specified System.Object.
+        /// </summary>
+        /// <param name="obj">
+        /// An object that evaluates to a BIC.
+        /// </param>
+        /// <returns>
+        /// A 32-bit signed integer that indicates whether this instance precedes, follows,
+        /// or appears in the same position in the sort order as the value parameter.Value
+        /// Condition Less than zero This instance precedes value. Zero This instance
+        /// has the same position in the sort order as value. Greater than zero This
+        /// instance follows value.-or- value is null.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// value is not a BIC.
+        /// </exception>
+        public int CompareTo(object obj)
+        {
+            if (obj is BusinessIdentifierCode)
+            {
+                return CompareTo((BusinessIdentifierCode)obj);
+            }
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, QowaivMessages.ArgumentException_Must, "a BIC"), "obj");
+        }
+
+        /// <summary>Compares this instance with a specified BIC and indicates
+        /// whether this instance precedes, follows, or appears in the same position
+        /// in the sort order as the specified BIC.
+        /// </summary>
+        /// <param name="other">
+        /// The BIC to compare with this instance.
+        /// </param>
+        /// <returns>
+        /// A 32-bit signed integer that indicates whether this instance precedes, follows,
+        /// or appears in the same position in the sort order as the value parameter.
+        /// </returns>
+        public int CompareTo(BusinessIdentifierCode other) { return string.Compare(m_Value, other.m_Value, StringComparison.Ordinal); }
+
+        #endregion
+
+        #region (Explicit) casting
+
+        /// <summary>Casts a BIC to a <see cref="string"/>.</summary>
+        public static explicit operator string(BusinessIdentifierCode val) => val.ToString(CultureInfo.CurrentCulture);
+        /// <summary>Casts a <see cref="string"/> to a BIC.</summary>
+        public static explicit operator BusinessIdentifierCode(string str) => Parse(str, CultureInfo.CurrentCulture);
+
+
+        #endregion
+
+        #region Factory methods
+
+        /// <summary>Converts the string to a BIC.</summary>
+        /// <param name="s">
+        /// A string containing a BIC to convert.
+        /// </param>
+        /// <returns>
+        /// A BIC.
+        /// </returns>
+        /// <exception cref="FormatException">
+        /// s is not in the correct format.
+        /// </exception>
+        public static BusinessIdentifierCode Parse(string s) => Parse(s, CultureInfo.CurrentCulture);
+
+        /// <summary>Converts the string to a BIC.</summary>
+        /// <param name="s">
+        /// A string containing a BIC to convert.
+        /// </param>
+        /// <param name="formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// A BIC.
+        /// </returns>
+        /// <exception cref="FormatException">
+        /// s is not in the correct format.
+        /// </exception>
+        public static BusinessIdentifierCode Parse(string s, IFormatProvider formatProvider)
+        {
+            if (TryParse(s, formatProvider, out BusinessIdentifierCode val))
+            {
+                return val;
+            }
+            throw new FormatException(QowaivMessages.FormatExceptionBusinessIdentifierCode);
+        }
+
+        /// <summary>Converts the string to a BIC.
+        /// A return value indicates whether the conversion succeeded.
+        /// </summary>
+        /// <param name="s">
+        /// A string containing a BIC to convert.
+        /// </param>
+        /// <returns>
+        /// The BIC if the string was converted successfully, otherwise BusinessIdentifierCode.Empty.
+        /// </returns>
+        public static BusinessIdentifierCode TryParse(string s)
+        {
+            if (TryParse(s, out BusinessIdentifierCode val))
+            {
+                return val;
+            }
+            return Empty;
+        }
+
+        /// <summary>Converts the string to a BIC.
+        /// A return value indicates whether the conversion succeeded.
+        /// </summary>
+        /// <param name="s">
+        /// A string containing a BIC to convert.
+        /// </param>
+        /// <param name="result">
+        /// The result of the parsing.
+        /// </param>
+        /// <returns>
+        /// True if the string was converted successfully, otherwise false.
+        /// </returns>
+        public static bool TryParse(string s, out BusinessIdentifierCode result)
+        {
+            return TryParse(s, CultureInfo.CurrentCulture, out result);
+        }
+
+        /// <summary>Converts the string to a BIC.
+        /// A return value indicates whether the conversion succeeded.
+        /// </summary>
+        /// <param name="s">
+        /// A string containing a BIC to convert.
+        /// </param>
+        /// <param name="formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <param name="result">
+        /// The result of the parsing.
+        /// </param>
+        /// <returns>
+        /// True if the string was converted successfully, otherwise false.
+        /// </returns>
+        public static bool TryParse(string s, IFormatProvider formatProvider, out BusinessIdentifierCode result)
+        {
+            result = Empty;
+            if (string.IsNullOrEmpty(s))
+            {
+                return true;
+            }
+            if (Qowaiv.Unknown.IsUnknown(s, formatProvider as CultureInfo))
+            {
+                result = Unknown;
+                return true;
+            }
+            if (IsValid(s, formatProvider))
+            {
+                result = new BusinessIdentifierCode { m_Value = Parsing.ClearSpacingAndMarkupToUpper(s) };
+                return true;
+            }
+            return false;
+        }
+
+        #endregion
+
+        #region Validation
+
+        /// <summary>Returns true if the val represents a valid BIC, otherwise false.</summary>
+        public static bool IsValid(string val) => IsValid(val, CultureInfo.CurrentCulture);
+
+        /// <summary>Returns true if the val represents a valid BIC, otherwise false.</summary>
+        public static bool IsValid(string val, IFormatProvider formatProvider)
+        {
+            var value = val ?? string.Empty;
+            return Pattern.IsMatch(value) && Country.IsValid(value.Substring(4, 2), formatProvider);
+        }
+        #endregion
+    }
+}

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -61,10 +61,7 @@ namespace Qowaiv.Financial
         public int Length => IsEmptyOrUnknown() ? 0 : m_Value.Length;
 
         /// <summary>Gets the institution code or business code.</summary>
-        public string BusinessCode => IsEmptyOrUnknown() ? string.Empty : m_Value.Substring(0, 4);
-
-        /// <summary>Gets the country code.</summary>
-        public string CountryCode => IsEmptyOrUnknown() ? string.Empty : m_Value.Substring(4, 2);
+        public string Business => IsEmptyOrUnknown() ? string.Empty : m_Value.Substring(0, 4);
 
         /// <summary>Gets the country info of the country code.</summary>
         public Country Country
@@ -79,18 +76,18 @@ namespace Qowaiv.Financial
                 {
                     return Country.Unknown;
                 }
-                return Country.Parse(CountryCode, CultureInfo.InvariantCulture);
+                return Country.Parse(m_Value.Substring(4, 2), CultureInfo.InvariantCulture);
             }
         }
 
         /// <summary>Gets the location code.</summary>
-        public string LocationCode => IsEmptyOrUnknown() ? string.Empty : m_Value.Substring(6, 2);
+        public string Location => IsEmptyOrUnknown() ? string.Empty : m_Value.Substring(6, 2);
 
         /// <summary>Gets the branch code.</summary>
         /// <remarks>
         /// Is optional, XXX for primary office.
         /// </remarks>
-        public string BranchCode => Length != 11 ? string.Empty : m_Value.Substring(8);
+        public string Branch => Length != 11 ? string.Empty : m_Value.Substring(8);
 
         #endregion
 

--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -151,6 +151,15 @@ namespace Qowaiv {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Not a valid BIC.
+        /// </summary>
+        public static string FormatExceptionBusinessIdentifierCode {
+            get {
+                return ResourceManager.GetString("FormatExceptionBusinessIdentifierCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not a valid country.
         /// </summary>
         public static string FormatExceptionCountry {

--- a/src/Qowaiv/QowaivMessages.nl.resx
+++ b/src/Qowaiv/QowaivMessages.nl.resx
@@ -120,6 +120,9 @@
   <data name="FormatExceptionBankIdentifierCode" xml:space="preserve">
     <value>Geen geldige BIC</value>
   </data>
+  <data name="FormatExceptionBusinessIdentifierCode" xml:space="preserve">
+    <value>Geen geldige BIC</value>
+  </data>
   <data name="FormatExceptionCountry" xml:space="preserve">
     <value>Geen geldig land</value>
   </data>

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -73,6 +73,9 @@
   <data name="FormatExceptionBankIdentifierCode" xml:space="preserve">
     <value>Not a valid BIC</value>
   </data>
+  <data name="FormatExceptionBusinessIdentifierCode" xml:space="preserve">
+    <value>Not a valid BIC</value>
+  </data>
   <data name="FormatExceptionCountry" xml:space="preserve">
     <value>Not a valid country</value>
   </data>

--- a/test/Qowaiv.UnitTests/AssemblyTest.cs
+++ b/test/Qowaiv.UnitTests/AssemblyTest.cs
@@ -29,6 +29,7 @@ namespace Qowaiv.Tests
                 typeof(YesNo),
                 typeof(Financial.Amount),
                 typeof(Financial.BankIdentifierCode),
+                typeof(Financial.BusinessIdentifierCode),
                 typeof(Financial.Currency),
                 typeof(Financial.InternationalBankAccountNumber),
                 typeof(Financial.Money),

--- a/test/Qowaiv.UnitTests/Financial/BusinessIdentifierCodeTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/BusinessIdentifierCodeTest.cs
@@ -1,0 +1,961 @@
+﻿using NUnit.Framework;
+using Qowaiv.Financial;
+using Qowaiv.Globalization;
+using Qowaiv.TestTools;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Xml.Serialization;
+
+namespace Qowaiv.UnitTests.Financial
+{
+    /// <summary>Tests the BIC SVO.</summary>
+    public class BusinessIdentifierCodeTest
+    {
+        /// <summary>The test instance for most tests.</summary>
+        public static readonly BusinessIdentifierCode TestStruct = BusinessIdentifierCode.Parse("AEGONL2UXXX");
+
+        #region BIC const tests
+
+        /// <summary>BusinessIdentifierCode.Empty should be equal to the default of BIC.</summary>
+        [Test]
+        public void Empty_None_EqualsDefault()
+        {
+            Assert.AreEqual(default(BusinessIdentifierCode), BusinessIdentifierCode.Empty);
+        }
+
+        #endregion
+
+        #region BIC IsEmpty tests
+
+        /// <summary>BusinessIdentifierCode.IsEmpty() should be true for the default of BIC.</summary>
+        [Test]
+        public void IsEmpty_Default_IsTrue()
+        {
+            Assert.IsTrue(default(BusinessIdentifierCode).IsEmpty());
+        }
+        /// <summary>BusinessIdentifierCode.IsEmpty() should be false for BusinessIdentifierCode.Unknown.</summary>
+        [Test]
+        public void IsEmpty_Unknown_IsFalse()
+        {
+            Assert.IsFalse(BusinessIdentifierCode.Unknown.IsEmpty());
+        }
+        /// <summary>BusinessIdentifierCode.IsEmpty() should be false for the TestStruct.</summary>
+        [Test]
+        public void IsEmpty_TestStruct_IsFalse()
+        {
+            Assert.IsFalse(TestStruct.IsEmpty());
+        }
+
+        /// <summary>BusinessIdentifierCode.IsUnknown() should be false for the default of BIC.</summary>
+        [Test]
+        public void IsUnknown_Default_IsFalse()
+        {
+            Assert.IsFalse(default(BusinessIdentifierCode).IsUnknown());
+        }
+        /// <summary>BusinessIdentifierCode.IsUnknown() should be true for BusinessIdentifierCode.Unknown.</summary>
+        [Test]
+        public void IsUnknown_Unknown_IsTrue()
+        {
+            Assert.IsTrue(BusinessIdentifierCode.Unknown.IsUnknown());
+        }
+        /// <summary>BusinessIdentifierCode.IsUnknown() should be false for the TestStruct.</summary>
+        [Test]
+        public void IsUnknown_TestStruct_IsFalse()
+        {
+            Assert.IsFalse(TestStruct.IsUnknown());
+        }
+
+        /// <summary>BusinessIdentifierCode.IsEmptyOrUnknown() should be true for the default of BIC.</summary>
+        [Test]
+        public void IsEmptyOrUnknown_Default_IsFalse()
+        {
+            Assert.IsTrue(default(BusinessIdentifierCode).IsEmptyOrUnknown());
+        }
+        /// <summary>BusinessIdentifierCode.IsEmptyOrUnknown() should be true for BusinessIdentifierCode.Unknown.</summary>
+        [Test]
+        public void IsEmptyOrUnknown_Unknown_IsTrue()
+        {
+            Assert.IsTrue(BusinessIdentifierCode.Unknown.IsEmptyOrUnknown());
+        }
+        /// <summary>BusinessIdentifierCode.IsEmptyOrUnknown() should be false for the TestStruct.</summary>
+        [Test]
+        public void IsEmptyOrUnknown_TestStruct_IsFalse()
+        {
+            Assert.IsFalse(TestStruct.IsEmptyOrUnknown());
+        }
+
+        #endregion
+
+        #region TryParse tests
+
+        /// <summary>TryParse null should be valid.</summary>
+        [Test]
+        public void TyrParse_Null_IsValid()
+        {
+            BusinessIdentifierCode val;
+
+            string str = null;
+
+            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.AreEqual(string.Empty, val.ToString(), "Value");
+        }
+
+        /// <summary>TryParse string.Empty should be valid.</summary>
+        [Test]
+        public void TyrParse_StringEmpty_IsValid()
+        {
+            BusinessIdentifierCode val;
+
+            string str = string.Empty;
+
+            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.AreEqual(string.Empty, val.ToString(), "Value");
+        }
+
+        /// <summary>TryParse "?" should be valid and the result should be BusinessIdentifierCode.Unknown.</summary>
+        [Test]
+        public void TyrParse_Questionmark_IsValid()
+        {
+            BusinessIdentifierCode val;
+
+            string str = "?";
+
+            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.IsTrue(val.IsUnknown(), "Value");
+        }
+
+        /// <summary>TryParse with specified string value should be valid.</summary>
+        [Test]
+        public void TyrParse_StringValue_IsValid()
+        {
+            BusinessIdentifierCode val;
+
+            string str = "AEGONL2UXXX";
+
+            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.AreEqual(str, val.ToString(), "Value");
+        }
+
+        /// <summary>TryParse with specified string value should be invalid.</summary>
+        [Test]
+        public void TyrParse_StringValue_IsNotValid()
+        {
+            BusinessIdentifierCode val;
+
+            string str = "string";
+
+            Assert.IsFalse(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.AreEqual(string.Empty, val.ToString(), "Value");
+        }
+
+        [Test]
+        public void Parse_Unknown_AreEqual()
+        {
+            using (new CultureInfoScope("en-GB"))
+            {
+                var act = BusinessIdentifierCode.Parse("?");
+                var exp = BusinessIdentifierCode.Unknown;
+                Assert.AreEqual(exp, act);
+            }
+        }
+
+        [Test]
+        public void Parse_InvalidInput_ThrowsFormatException()
+        {
+            using (new CultureInfoScope("en-GB"))
+            {
+                Assert.Catch<FormatException>
+                (() =>
+                {
+                    BusinessIdentifierCode.Parse("InvalidInput");
+                },
+                "Not a valid BIC");
+            }
+        }
+
+        [Test]
+        public void TryParse_TestStructInput_AreEqual()
+        {
+            using (new CultureInfoScope("en-GB"))
+            {
+                var exp = TestStruct;
+                var act = BusinessIdentifierCode.TryParse(exp.ToString());
+
+                Assert.AreEqual(exp, act);
+            }
+        }
+
+        [Test]
+        public void TryParse_InvalidInput_DefaultValue()
+        {
+            using (new CultureInfoScope("en-GB"))
+            {
+                var exp = default(BusinessIdentifierCode);
+                var act = BusinessIdentifierCode.TryParse("InvalidInput");
+
+                Assert.AreEqual(exp, act);
+            }
+        }
+
+        #endregion
+
+        #region (XML) (De)serialization tests
+
+        [Test]
+        public void Constructor_SerializationInfoIsNull_ThrowsArgumentNullException()
+        {
+            ExceptionAssert.CatchArgumentNullException
+            (() =>
+            {
+                SerializationTest.DeserializeUsingConstructor<BusinessIdentifierCode>(null, default);
+            },
+            "info");
+        }
+
+        [Test]
+        public void Constructor_InvalidSerializationInfo_ThrowsSerializationException()
+        {
+            Assert.Catch<SerializationException>
+            (() =>
+            {
+                var info = new SerializationInfo(typeof(BusinessIdentifierCode), new System.Runtime.Serialization.FormatterConverter());
+                SerializationTest.DeserializeUsingConstructor<BusinessIdentifierCode>(info, default);
+            });
+        }
+
+        [Test]
+        public void GetObjectData_Null_ThrowsArgumentNullException()
+        {
+            ExceptionAssert.CatchArgumentNullException
+            (() =>
+            {
+                ISerializable obj = TestStruct;
+                obj.GetObjectData(null, default);
+            },
+            "info");
+        }
+
+        [Test]
+        public void GetObjectData_SerializationInfo_AreEqual()
+        {
+            ISerializable obj = TestStruct;
+            var info = new SerializationInfo(typeof(BusinessIdentifierCode), new System.Runtime.Serialization.FormatterConverter());
+            obj.GetObjectData(info, default);
+
+            Assert.AreEqual(TestStruct.ToString(), info.GetString("Value"));
+        }
+
+        [Test]
+        public void SerializeDeserialize_TestStruct_AreEqual()
+        {
+            var input = BusinessIdentifierCodeTest.TestStruct;
+            var exp = BusinessIdentifierCodeTest.TestStruct;
+            var act = SerializationTest.SerializeDeserialize(input);
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+        {
+            var input = BusinessIdentifierCodeTest.TestStruct;
+            var exp = BusinessIdentifierCodeTest.TestStruct;
+            var act = SerializationTest.DataContractSerializeDeserialize(input);
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        {
+            var input = BusinessIdentifierCodeTest.TestStruct;
+            var exp = BusinessIdentifierCodeTest.TestStruct;
+            var act = SerializationTest.XmlSerializeDeserialize(input);
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void SerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
+        {
+            var input = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var exp = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var act = SerializationTest.SerializeDeserialize(input);
+            Assert.AreEqual(exp.Id, act.Id, "Id");
+            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+            Assert.AreEqual(exp.Date, act.Date, "Date");
+        }
+        [Test]
+        public void XmlSerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
+        {
+            var input = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var exp = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var act = SerializationTest.XmlSerializeDeserialize(input);
+            Assert.AreEqual(exp.Id, act.Id, "Id");
+            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+            Assert.AreEqual(exp.Date, act.Date, "Date");
+        }
+        [Test]
+        public void DataContractSerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
+        {
+            var input = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var exp = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var act = SerializationTest.DataContractSerializeDeserialize(input);
+            Assert.AreEqual(exp.Id, act.Id, "Id");
+            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+            Assert.AreEqual(exp.Date, act.Date, "Date");
+        }
+
+        [Test]
+        public void SerializeDeserialize_Empty_AreEqual()
+        {
+            var input = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCode.Empty,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var exp = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCode.Empty,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var act = SerializationTest.SerializeDeserialize(input);
+            Assert.AreEqual(exp.Id, act.Id, "Id");
+            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+            Assert.AreEqual(exp.Date, act.Date, "Date");
+        }
+        [Test]
+        public void XmlSerializeDeserialize_Empty_AreEqual()
+        {
+            var input = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCode.Empty,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var exp = new BusinessIdentifierCodeSerializeObject()
+            {
+                Id = 17,
+                Obj = BusinessIdentifierCode.Empty,
+                Date = new DateTime(1970, 02, 14),
+            };
+            var act = SerializationTest.XmlSerializeDeserialize(input);
+            Assert.AreEqual(exp.Id, act.Id, "Id");
+            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+            Assert.AreEqual(exp.Date, act.Date, "Date");
+        }
+
+        [Test]
+        public void GetSchema_None_IsNull()
+        {
+            IXmlSerializable obj = TestStruct;
+            Assert.IsNull(obj.GetSchema());
+        }
+
+        #endregion
+
+        #region JSON (De)serialization tests
+
+        [Test]
+        public void FromJson_None_EmptyValue()
+        {
+            var act = JsonTester.Read<BusinessIdentifierCode>();
+            var exp = BusinessIdentifierCode.Empty;
+
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void FromJson_InvalidStringValue_AssertFormatException()
+        {
+            Assert.Catch<FormatException>(() =>
+            {
+                JsonTester.Read<BusinessIdentifierCode>("InvalidStringValue");
+            },
+            "Not a valid BIC");
+        }
+        [Test]
+        public void FromJson_StringValue_AreEqual()
+        {
+            var act = JsonTester.Read<BusinessIdentifierCode>("AEGONL2UXXX");
+            var exp = TestStruct;
+
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void FromJson_Int64Value_AssertNotSupportedException()
+        {
+            Assert.Catch<NotSupportedException>(() =>
+            {
+                JsonTester.Read<BusinessIdentifierCode>(123456L);
+            },
+            "JSON deserialization from an integer is not supported.");
+        }
+
+        [Test]
+        public void FromJson_DoubleValue_AssertNotSupportedException()
+        {
+            Assert.Catch<NotSupportedException>(() =>
+            {
+                JsonTester.Read<BusinessIdentifierCode>(1234.56);
+            },
+            "JSON deserialization from a number is not supported.");
+        }
+
+        [Test]
+        public void FromJson_DateTimeValue_AssertNotSupportedException()
+        {
+            Assert.Catch<NotSupportedException>(() =>
+            {
+                JsonTester.Read<BusinessIdentifierCode>(new DateTime(1972, 02, 14));
+            },
+            "JSON deserialization from a date is not supported.");
+        }
+
+        [Test]
+        public void ToJson_DefaultValue_IsNull()
+        {
+            object act = JsonTester.Write(default(BusinessIdentifierCode));
+            Assert.IsNull(act);
+        }
+        [Test]
+        public void ToJson_TestStruct_AreEqual()
+        {
+            var act = JsonTester.Write(TestStruct);
+            var exp = "AEGONL2UXXX";
+            Assert.AreEqual(exp, act);
+        }
+
+        #endregion
+
+        #region IFormattable / ToString tests
+
+        [Test]
+        public void ToString_Empty_StringEmpty()
+        {
+            var act = BusinessIdentifierCode.Empty.ToString();
+            var exp = "";
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void ToString_Unknown_QuestionMark()
+        {
+            var act = BusinessIdentifierCode.Unknown.ToString();
+            var exp = "?";
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void ToString_CustomFormatter_SupportsCustomFormatting()
+        {
+            var act = TestStruct.ToString("Unit Test Format", new UnitTestFormatProvider());
+            var exp = "Unit Test Formatter, value: 'AEGONL2UXXX', format: 'Unit Test Format'";
+
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void ToString_TestStruct_ComplexPattern()
+        {
+            var act = TestStruct.ToString("");
+            var exp = "AEGONL2UXXX";
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void DebuggerDisplay_DebugToString_HasAttribute()
+        {
+            DebuggerDisplayAssert.HasAttribute(typeof(BusinessIdentifierCode));
+        }
+
+        [Test]
+        public void DebuggerDisplay_DefaultValue_String()
+        {
+            DebuggerDisplayAssert.HasResult("BusinessIdentifierCode: (empty)", default(BusinessIdentifierCode));
+        }
+        [Test]
+        public void DebuggerDisplay_Unknown_String()
+        {
+            DebuggerDisplayAssert.HasResult("BusinessIdentifierCode: (unknown)", BusinessIdentifierCode.Unknown);
+        }
+
+        [Test]
+        public void DebuggerDisplay_TestStruct_String()
+        {
+            DebuggerDisplayAssert.HasResult("BusinessIdentifierCode: AEGONL2UXXX", TestStruct);
+        }
+
+        #endregion
+
+        #region IEquatable tests
+
+        /// <summary>GetHash should not fail for BusinessIdentifierCode.Empty.</summary>
+        [Test]
+        public void GetHash_Empty_Hash()
+        {
+            Assert.AreEqual(0, BusinessIdentifierCode.Empty.GetHashCode());
+        }
+
+        /// <summary>GetHash should not fail for the test struct.</summary>
+        [Test]
+        public void GetHash_TestStruct_NotZero()
+        {
+            Assert.NotZero(TestStruct.GetHashCode());
+        }
+
+        [Test]
+        public void Equals_EmptyEmpty_IsTrue()
+        {
+            Assert.IsTrue(BusinessIdentifierCode.Empty.Equals(BusinessIdentifierCode.Empty));
+        }
+
+        [Test]
+        public void Equals_FormattedAndUnformatted_IsTrue()
+        {
+            var l = BusinessIdentifierCode.Parse("AEGONL2UXXX", CultureInfo.InvariantCulture);
+            var r = BusinessIdentifierCode.Parse("AEgonL2Uxxx", CultureInfo.InvariantCulture);
+
+            Assert.IsTrue(l.Equals(r));
+        }
+
+        [Test]
+        public void Equals_TestStructTestStruct_IsTrue()
+        {
+            Assert.IsTrue(BusinessIdentifierCodeTest.TestStruct.Equals(BusinessIdentifierCodeTest.TestStruct));
+        }
+
+        [Test]
+        public void Equals_TestStructEmpty_IsFalse()
+        {
+            Assert.IsFalse(BusinessIdentifierCodeTest.TestStruct.Equals(BusinessIdentifierCode.Empty));
+        }
+
+        [Test]
+        public void Equals_EmptyTestStruct_IsFalse()
+        {
+            Assert.IsFalse(BusinessIdentifierCode.Empty.Equals(BusinessIdentifierCodeTest.TestStruct));
+        }
+
+        [Test]
+        public void Equals_TestStructObjectTestStruct_IsTrue()
+        {
+            Assert.IsTrue(BusinessIdentifierCodeTest.TestStruct.Equals((object)BusinessIdentifierCodeTest.TestStruct));
+        }
+
+        [Test]
+        public void Equals_TestStructNull_IsFalse()
+        {
+            Assert.IsFalse(BusinessIdentifierCodeTest.TestStruct.Equals(null));
+        }
+
+        [Test]
+        public void Equals_TestStructObject_IsFalse()
+        {
+            Assert.IsFalse(BusinessIdentifierCodeTest.TestStruct.Equals(new object()));
+        }
+
+        [Test]
+        public void OperatorIs_TestStructTestStruct_IsTrue()
+        {
+            var l = BusinessIdentifierCodeTest.TestStruct;
+            var r = BusinessIdentifierCodeTest.TestStruct;
+            Assert.IsTrue(l == r);
+        }
+
+        [Test]
+        public void OperatorIsNot_TestStructTestStruct_IsFalse()
+        {
+            var l = BusinessIdentifierCodeTest.TestStruct;
+            var r = BusinessIdentifierCodeTest.TestStruct;
+            Assert.IsFalse(l != r);
+        }
+
+        #endregion
+
+        #region IComparable tests
+
+        /// <summary>Orders a list of BICs ascending.</summary>
+        [Test]
+        public void OrderBy_BusinessIdentifierCode_AreEqual()
+        {
+            var item0 = BusinessIdentifierCode.Parse("AEGONL2UXXX");
+            var item1 = BusinessIdentifierCode.Parse("CEBUNL2U");
+            var item2 = BusinessIdentifierCode.Parse("DSSBNL22");
+            var item3 = BusinessIdentifierCode.Parse("FTSBNL2R");
+
+            var inp = new List<BusinessIdentifierCode>() { BusinessIdentifierCode.Empty, item3, item2, item0, item1, BusinessIdentifierCode.Empty };
+            var exp = new List<BusinessIdentifierCode>() { BusinessIdentifierCode.Empty, BusinessIdentifierCode.Empty, item0, item1, item2, item3 };
+            var act = inp.OrderBy(item => item).ToList();
+
+            CollectionAssert.AreEqual(exp, act);
+        }
+
+        /// <summary>Orders a list of BICs descending.</summary>
+        [Test]
+        public void OrderByDescending_BusinessIdentifierCode_AreEqual()
+        {
+            var item0 = BusinessIdentifierCode.Parse("AEGONL2UXXX");
+            var item1 = BusinessIdentifierCode.Parse("CEBUNL2U");
+            var item2 = BusinessIdentifierCode.Parse("DSSBNL22");
+            var item3 = BusinessIdentifierCode.Parse("FTSBNL2R");
+
+            var inp = new List<BusinessIdentifierCode>() { BusinessIdentifierCode.Empty, item3, item2, item0, item1, BusinessIdentifierCode.Empty };
+            var exp = new List<BusinessIdentifierCode>() { item3, item2, item1, item0, BusinessIdentifierCode.Empty, BusinessIdentifierCode.Empty };
+            var act = inp.OrderByDescending(item => item).ToList();
+
+            CollectionAssert.AreEqual(exp, act);
+        }
+
+        /// <summary>Compare with a to object casted instance should be fine.</summary>
+        [Test]
+        public void CompareTo_ObjectTestStruct_0()
+        {
+            object other = TestStruct;
+
+            var exp = 0;
+            var act = TestStruct.CompareTo(other);
+
+            Assert.AreEqual(exp, act);
+        }
+
+        /// <summary>Compare with null should throw an exception.</summary>
+        [Test]
+        public void CompareTo_null_ThrowsArgumentException()
+        {
+            ExceptionAssert.CatchArgumentException
+            (() =>
+                {
+                    object other = null;
+                    TestStruct.CompareTo(other);
+                },
+                "obj",
+                "Argument must be a BIC"
+            );
+        }
+        /// <summary>Compare with a random object should throw an exception.</summary>
+        [Test]
+        public void CompareTo_newObject_ThrowsArgumentException()
+        {
+            ExceptionAssert.CatchArgumentException
+            (() =>
+                {
+                    object other = new object();
+                    TestStruct.CompareTo(other);
+                },
+                "obj",
+                "Argument must be a BIC"
+            );
+        }
+
+        #endregion
+
+        #region Casting tests
+
+        [Test]
+        public void Explicit_StringToBusinessIdentifierCode_AreEqual()
+        {
+            var exp = TestStruct;
+            var act = (BusinessIdentifierCode)TestStruct.ToString();
+
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void Explicit_BusinessIdentifierCodeToString_AreEqual()
+        {
+            var exp = TestStruct.ToString();
+            var act = (string)TestStruct;
+
+            Assert.AreEqual(exp, act);
+        }
+
+        #endregion
+
+        #region Properties
+
+        [Test]
+        public void Length_DefaultValue_0()
+        {
+            var exp = 0;
+            var act = BusinessIdentifierCode.Empty.Length;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void Length_Unknown_0()
+        {
+            var exp = 0;
+            var act = BusinessIdentifierCode.Unknown.Length;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void Length_TestStruct_IntValue()
+        {
+            var exp = 11;
+            var act = TestStruct.Length;
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void BankCode_DefaultValue_StringEmpty()
+        {
+            var exp = "";
+            var act = BusinessIdentifierCode.Empty.BusinessCode;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void BankCode_Unknown_StringEmpty()
+        {
+            var exp = "";
+            var act = BusinessIdentifierCode.Unknown.BusinessCode;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void BankCode_TestStruct_AEGO()
+        {
+            var exp = "AEGO";
+            var act = TestStruct.BusinessCode;
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void CountryCode_DefaultValue_StringEmpty()
+        {
+            var exp = "";
+            var act = BusinessIdentifierCode.Empty.CountryCode;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void CountryCode_Unknown_StringEmpty()
+        {
+            var exp = "";
+            var act = BusinessIdentifierCode.Unknown.CountryCode;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void CountryCode_TestStruct_NL()
+        {
+            var exp = "NL";
+            var act = TestStruct.CountryCode;
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void Country_DefaultValue_CountryEmpty()
+        {
+            var exp = Country.Empty;
+            var act = BusinessIdentifierCode.Empty.Country;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void Country_Unknown_CountryUnknown()
+        {
+            var exp = Country.Unknown;
+            var act = BusinessIdentifierCode.Unknown.Country;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void Country_TestStruct_NL()
+        {
+            var exp = Country.NL;
+            var act = TestStruct.Country;
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void LocationCode_DefaultValue_StringEmpty()
+        {
+            var exp = "";
+            var act = BusinessIdentifierCode.Empty.LocationCode;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void LocationCode_Unknown_StringEmpty()
+        {
+            var exp = "";
+            var act = BusinessIdentifierCode.Unknown.LocationCode;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void LocationCode_TestStruct_NL()
+        {
+            var exp = "2U";
+            var act = TestStruct.LocationCode;
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void BranchCode_DefaultValue_StringEmpty()
+        {
+            var exp = "";
+            var act = BusinessIdentifierCode.Empty.BranchCode;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void BranchCode_Unknown_StringEmpty()
+        {
+            var exp = "";
+            var act = BusinessIdentifierCode.Unknown.BranchCode;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void BranchCode_TestStruct_NL()
+        {
+            var exp = "XXX";
+            var act = TestStruct.BranchCode;
+            Assert.AreEqual(exp, act);
+        }
+        [Test]
+        public void BranchCode_AEGONL2U_StringEmpty()
+        {
+            var exp = "";
+            var act = BusinessIdentifierCode.Parse("AEGONL2U").BranchCode;
+            Assert.AreEqual(exp, act);
+        }
+
+        #endregion
+
+        #region Type converter tests
+
+        [Test]
+        public void ConverterExists_BusinessIdentifierCode_IsTrue()
+        {
+            TypeConverterAssert.ConverterExists(typeof(BusinessIdentifierCode));
+        }
+
+        [Test]
+        public void CanNotConvertFromInt32_BusinessIdentifierCode_IsTrue()
+        {
+            TypeConverterAssert.CanNotConvertFrom(typeof(BusinessIdentifierCode), typeof(Int32));
+        }
+
+        [Test]
+        public void CanNotConvertToInt32_BusinessIdentifierCode_IsTrue()
+        {
+            TypeConverterAssert.CanNotConvertTo(typeof(BusinessIdentifierCode), typeof(Int32));
+        }
+
+        [Test]
+        public void CanConvertFromString_BusinessIdentifierCode_IsTrue()
+        {
+            TypeConverterAssert.CanConvertFromString(typeof(BusinessIdentifierCode));
+        }
+
+        [Test]
+        public void CanConvertToString_BusinessIdentifierCode_IsTrue()
+        {
+            TypeConverterAssert.CanConvertToString(typeof(BusinessIdentifierCode));
+        }
+
+        [Test]
+        public void ConvertFrom_StringNull_BusinessIdentifierCodeEmpty()
+        {
+            using (new CultureInfoScope("en-GB"))
+            {
+                TypeConverterAssert.ConvertFromEquals(BusinessIdentifierCode.Empty, (string)null);
+            }
+        }
+
+        [Test]
+        public void ConvertFrom_StringEmpty_BusinessIdentifierCodeEmpty()
+        {
+            using (new CultureInfoScope("en-GB"))
+            {
+                TypeConverterAssert.ConvertFromEquals(BusinessIdentifierCode.Empty, string.Empty);
+            }
+        }
+
+        [Test]
+        public void ConvertFromString_StringValue_TestStruct()
+        {
+            using (new CultureInfoScope("en-GB"))
+            {
+                TypeConverterAssert.ConvertFromEquals(BusinessIdentifierCodeTest.TestStruct, BusinessIdentifierCodeTest.TestStruct.ToString());
+            }
+        }
+
+        [Test]
+        public void ConvertFromInstanceDescriptor_BusinessIdentifierCode_Successful()
+        {
+            TypeConverterAssert.ConvertFromInstanceDescriptor(typeof(BusinessIdentifierCode));
+        }
+
+        [Test]
+        public void ConvertToString_TestStruct_StringValue()
+        {
+            using (new CultureInfoScope("en-GB"))
+            {
+                TypeConverterAssert.ConvertToStringEquals(BusinessIdentifierCodeTest.TestStruct.ToString(), BusinessIdentifierCodeTest.TestStruct);
+            }
+        }
+
+        #endregion
+
+        #region IsValid
+
+        [Test]
+        public void IsValid_Data_IsFalse()
+        {
+            Assert.IsFalse(BusinessIdentifierCode.IsValid("1AAANL01"), "1AAANL01, cijfer in eerste vier");
+            Assert.IsFalse(BusinessIdentifierCode.IsValid("AAAANLBB1"), "AAAANLBB1, lengte van 1 voor branch");
+            Assert.IsFalse(BusinessIdentifierCode.IsValid("AAAANLBB12"), "AAAANLBB12, lengte van 2 voor branch");
+            Assert.IsFalse(BusinessIdentifierCode.IsValid("ABCDXX01"), "ABCD1E01, cijfer in landcode");
+            Assert.IsFalse(BusinessIdentifierCode.IsValid("ABCDXX01"), "ABCDXX01, niet bestaand land");
+            Assert.IsFalse(BusinessIdentifierCode.IsValid("AAAANLBË"), "AAAANLBË, diacriet");
+
+            Assert.IsFalse(BusinessIdentifierCode.IsValid((String)null), "(String)null");
+        }
+        [Test]
+        public void IsValid_Data_IsTrue()
+        {
+            Assert.IsTrue(BusinessIdentifierCode.IsValid("PSTBNL21"), "PSTBNL21");
+            Assert.IsTrue(BusinessIdentifierCode.IsValid("ABNANL2A"), "ABNANL2A");
+            Assert.IsTrue(BusinessIdentifierCode.IsValid("BACBBEBB"), "BACBBEBB");
+            Assert.IsTrue(BusinessIdentifierCode.IsValid("GEBABEBB36A"), "GEBABEBB36A");
+            Assert.IsTrue(BusinessIdentifierCode.IsValid("DEUTDEFF"), "DEUTDEFF");
+            Assert.IsTrue(BusinessIdentifierCode.IsValid("NEDSZAJJ"), "NEDSZAJJ");
+            Assert.IsTrue(BusinessIdentifierCode.IsValid("DABADKKK"), "DABADKKK");
+            Assert.IsTrue(BusinessIdentifierCode.IsValid("UNCRIT2B912"), "UNCRIT2B912");
+            Assert.IsTrue(BusinessIdentifierCode.IsValid("DSBACNBXSHA"), "DSBACNBXSHA");
+        }
+
+        #endregion
+    }
+
+    [Serializable]
+    public class BusinessIdentifierCodeSerializeObject
+    {
+        public int Id { get; set; }
+        public BusinessIdentifierCode Obj { get; set; }
+        public DateTime Date { get; set; }
+    }
+}

--- a/test/Qowaiv.UnitTests/Financial/BusinessIdentifierCodeTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/BusinessIdentifierCodeTest.cs
@@ -95,11 +95,8 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void TyrParse_Null_IsValid()
         {
-            BusinessIdentifierCode val;
-
             string str = null;
-
-            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
             Assert.AreEqual(string.Empty, val.ToString(), "Value");
         }
 
@@ -107,11 +104,8 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void TyrParse_StringEmpty_IsValid()
         {
-            BusinessIdentifierCode val;
-
             string str = string.Empty;
-
-            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
             Assert.AreEqual(string.Empty, val.ToString(), "Value");
         }
 
@@ -119,11 +113,8 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void TyrParse_Questionmark_IsValid()
         {
-            BusinessIdentifierCode val;
-
             string str = "?";
-
-            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
             Assert.IsTrue(val.IsUnknown(), "Value");
         }
 
@@ -131,11 +122,8 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void TyrParse_StringValue_IsValid()
         {
-            BusinessIdentifierCode val;
-
             string str = "AEGONL2UXXX";
-
-            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
             Assert.AreEqual(str, val.ToString(), "Value");
         }
 
@@ -143,11 +131,8 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void TyrParse_StringValue_IsNotValid()
         {
-            BusinessIdentifierCode val;
-
             string str = "string";
-
-            Assert.IsFalse(BusinessIdentifierCode.TryParse(str, out val), "Valid");
+            Assert.IsFalse(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
             Assert.AreEqual(string.Empty, val.ToString(), "Value");
         }
 
@@ -251,24 +236,24 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
-            var input = BusinessIdentifierCodeTest.TestStruct;
-            var exp = BusinessIdentifierCodeTest.TestStruct;
+            var input = TestStruct;
+            var exp = TestStruct;
             var act = SerializationTest.SerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void DataContractSerializeDeserialize_TestStruct_AreEqual()
         {
-            var input = BusinessIdentifierCodeTest.TestStruct;
-            var exp = BusinessIdentifierCodeTest.TestStruct;
+            var input = TestStruct;
+            var exp = TestStruct;
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void XmlSerializeDeserialize_TestStruct_AreEqual()
         {
-            var input = BusinessIdentifierCodeTest.TestStruct;
-            var exp = BusinessIdentifierCodeTest.TestStruct;
+            var input = TestStruct;
+            var exp = TestStruct;
             var act = SerializationTest.XmlSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
@@ -279,13 +264,13 @@ namespace Qowaiv.UnitTests.Financial
             var input = new BusinessIdentifierCodeSerializeObject()
             {
                 Id = 17,
-                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var exp = new BusinessIdentifierCodeSerializeObject()
             {
                 Id = 17,
-                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var act = SerializationTest.SerializeDeserialize(input);
@@ -299,13 +284,13 @@ namespace Qowaiv.UnitTests.Financial
             var input = new BusinessIdentifierCodeSerializeObject()
             {
                 Id = 17,
-                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var exp = new BusinessIdentifierCodeSerializeObject()
             {
                 Id = 17,
-                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var act = SerializationTest.XmlSerializeDeserialize(input);
@@ -319,13 +304,13 @@ namespace Qowaiv.UnitTests.Financial
             var input = new BusinessIdentifierCodeSerializeObject()
             {
                 Id = 17,
-                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var exp = new BusinessIdentifierCodeSerializeObject()
             {
                 Id = 17,
-                Obj = BusinessIdentifierCodeTest.TestStruct,
+                Obj = TestStruct,
                 Date = new DateTime(1970, 02, 14),
             };
             var act = SerializationTest.DataContractSerializeDeserialize(input);
@@ -502,18 +487,18 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void DebuggerDisplay_DefaultValue_String()
         {
-            DebuggerDisplayAssert.HasResult("BusinessIdentifierCode: (empty)", default(BusinessIdentifierCode));
+            DebuggerDisplayAssert.HasResult("BIC: (empty)", default(BusinessIdentifierCode));
         }
         [Test]
         public void DebuggerDisplay_Unknown_String()
         {
-            DebuggerDisplayAssert.HasResult("BusinessIdentifierCode: (unknown)", BusinessIdentifierCode.Unknown);
+            DebuggerDisplayAssert.HasResult("BIC: (unknown)", BusinessIdentifierCode.Unknown);
         }
 
         [Test]
         public void DebuggerDisplay_TestStruct_String()
         {
-            DebuggerDisplayAssert.HasResult("BusinessIdentifierCode: AEGONL2UXXX", TestStruct);
+            DebuggerDisplayAssert.HasResult("BIC: AEGONL2UXXX", TestStruct);
         }
 
         #endregion
@@ -552,52 +537,52 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void Equals_TestStructTestStruct_IsTrue()
         {
-            Assert.IsTrue(BusinessIdentifierCodeTest.TestStruct.Equals(BusinessIdentifierCodeTest.TestStruct));
+            Assert.IsTrue(TestStruct.Equals(TestStruct));
         }
 
         [Test]
         public void Equals_TestStructEmpty_IsFalse()
         {
-            Assert.IsFalse(BusinessIdentifierCodeTest.TestStruct.Equals(BusinessIdentifierCode.Empty));
+            Assert.IsFalse(TestStruct.Equals(BusinessIdentifierCode.Empty));
         }
 
         [Test]
         public void Equals_EmptyTestStruct_IsFalse()
         {
-            Assert.IsFalse(BusinessIdentifierCode.Empty.Equals(BusinessIdentifierCodeTest.TestStruct));
+            Assert.IsFalse(BusinessIdentifierCode.Empty.Equals(TestStruct));
         }
 
         [Test]
         public void Equals_TestStructObjectTestStruct_IsTrue()
         {
-            Assert.IsTrue(BusinessIdentifierCodeTest.TestStruct.Equals((object)BusinessIdentifierCodeTest.TestStruct));
+            Assert.IsTrue(TestStruct.Equals((object)TestStruct));
         }
 
         [Test]
         public void Equals_TestStructNull_IsFalse()
         {
-            Assert.IsFalse(BusinessIdentifierCodeTest.TestStruct.Equals(null));
+            Assert.IsFalse(TestStruct.Equals(null));
         }
 
         [Test]
         public void Equals_TestStructObject_IsFalse()
         {
-            Assert.IsFalse(BusinessIdentifierCodeTest.TestStruct.Equals(new object()));
+            Assert.IsFalse(TestStruct.Equals(new object()));
         }
 
         [Test]
         public void OperatorIs_TestStructTestStruct_IsTrue()
         {
-            var l = BusinessIdentifierCodeTest.TestStruct;
-            var r = BusinessIdentifierCodeTest.TestStruct;
+            var l = TestStruct;
+            var r = TestStruct;
             Assert.IsTrue(l == r);
         }
 
         [Test]
         public void OperatorIsNot_TestStructTestStruct_IsFalse()
         {
-            var l = BusinessIdentifierCodeTest.TestStruct;
-            var r = BusinessIdentifierCodeTest.TestStruct;
+            var l = TestStruct;
+            var r = TestStruct;
             Assert.IsFalse(l != r);
         }
 
@@ -726,21 +711,21 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
-        public void BankCode_DefaultValue_StringEmpty()
+        public void BusinessCode_DefaultValue_StringEmpty()
         {
             var exp = "";
             var act = BusinessIdentifierCode.Empty.BusinessCode;
             Assert.AreEqual(exp, act);
         }
         [Test]
-        public void BankCode_Unknown_StringEmpty()
+        public void BusinessCode_Unknown_StringEmpty()
         {
             var exp = "";
             var act = BusinessIdentifierCode.Unknown.BusinessCode;
             Assert.AreEqual(exp, act);
         }
         [Test]
-        public void BankCode_TestStruct_AEGO()
+        public void BusinessCode_TestStruct_AEGO()
         {
             var exp = "AEGO";
             var act = TestStruct.BusinessCode;
@@ -899,7 +884,7 @@ namespace Qowaiv.UnitTests.Financial
         {
             using (new CultureInfoScope("en-GB"))
             {
-                TypeConverterAssert.ConvertFromEquals(BusinessIdentifierCodeTest.TestStruct, BusinessIdentifierCodeTest.TestStruct.ToString());
+                TypeConverterAssert.ConvertFromEquals(TestStruct, TestStruct.ToString());
             }
         }
 
@@ -914,7 +899,7 @@ namespace Qowaiv.UnitTests.Financial
         {
             using (new CultureInfoScope("en-GB"))
             {
-                TypeConverterAssert.ConvertToStringEquals(BusinessIdentifierCodeTest.TestStruct.ToString(), BusinessIdentifierCodeTest.TestStruct);
+                TypeConverterAssert.ConvertToStringEquals(TestStruct.ToString(), TestStruct);
             }
         }
 
@@ -922,21 +907,31 @@ namespace Qowaiv.UnitTests.Financial
 
         #region IsValid
 
-        [Test]
-        public void IsValid_Data_IsFalse()
+        [TestCase("1AAANL01", "Digit in first four characters")]
+        [TestCase("AAAANLBB1", "Branch length of 1")]
+        [TestCase("AAAANLBB12", "Branch length of 2")]
+        [TestCase("ABCDXX01", "Digit in country code")]
+        [TestCase("ABCDXX01", "None existing country")]
+        [TestCase("AAAANLBË", "Diacritic")]
+        [TestCase(null, "(String)null")]
+        [TestCase("", "String.Empty")]
+        public void IsInvalid(string str, string message)
         {
-            Assert.IsFalse(BusinessIdentifierCode.IsValid("1AAANL01"), "1AAANL01, cijfer in eerste vier");
-            Assert.IsFalse(BusinessIdentifierCode.IsValid("AAAANLBB1"), "AAAANLBB1, lengte van 1 voor branch");
-            Assert.IsFalse(BusinessIdentifierCode.IsValid("AAAANLBB12"), "AAAANLBB12, lengte van 2 voor branch");
-            Assert.IsFalse(BusinessIdentifierCode.IsValid("ABCDXX01"), "ABCD1E01, cijfer in landcode");
-            Assert.IsFalse(BusinessIdentifierCode.IsValid("ABCDXX01"), "ABCDXX01, niet bestaand land");
-            Assert.IsFalse(BusinessIdentifierCode.IsValid("AAAANLBË"), "AAAANLBË, diacriet");
-
-            Assert.IsFalse(BusinessIdentifierCode.IsValid((String)null), "(String)null");
+            Assert.IsFalse(BusinessIdentifierCode.IsValid(str), message);
         }
-        [Test]
-        public void IsValid_Data_IsTrue()
+
+        [TestCase("PSTBNL21")]
+        [TestCase("ABNANL2A")]
+        [TestCase("BACBBEBB")]
+        [TestCase("GEBABEBB36A")]
+        [TestCase("DEUTDEFF")]
+        [TestCase("NEDSZAJJ")]
+        [TestCase("DABADKKK")]
+        [TestCase("UNCRIT2B912")]
+        [TestCase("DSBACNBXSHA")]
+        public void IsValid(string str)
         {
+            Assert.IsTrue(BusinessIdentifierCode.IsValid(str));
             Assert.IsTrue(BusinessIdentifierCode.IsValid("PSTBNL21"), "PSTBNL21");
             Assert.IsTrue(BusinessIdentifierCode.IsValid("ABNANL2A"), "ABNANL2A");
             Assert.IsTrue(BusinessIdentifierCode.IsValid("BACBBEBB"), "BACBBEBB");

--- a/test/Qowaiv.UnitTests/Financial/BusinessIdentifierCodeTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/BusinessIdentifierCodeTest.cs
@@ -714,43 +714,21 @@ namespace Qowaiv.UnitTests.Financial
         public void BusinessCode_DefaultValue_StringEmpty()
         {
             var exp = "";
-            var act = BusinessIdentifierCode.Empty.BusinessCode;
+            var act = BusinessIdentifierCode.Empty.Business;
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void BusinessCode_Unknown_StringEmpty()
         {
             var exp = "";
-            var act = BusinessIdentifierCode.Unknown.BusinessCode;
+            var act = BusinessIdentifierCode.Unknown.Business;
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void BusinessCode_TestStruct_AEGO()
         {
             var exp = "AEGO";
-            var act = TestStruct.BusinessCode;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void CountryCode_DefaultValue_StringEmpty()
-        {
-            var exp = "";
-            var act = BusinessIdentifierCode.Empty.CountryCode;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void CountryCode_Unknown_StringEmpty()
-        {
-            var exp = "";
-            var act = BusinessIdentifierCode.Unknown.CountryCode;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void CountryCode_TestStruct_NL()
-        {
-            var exp = "NL";
-            var act = TestStruct.CountryCode;
+            var act = TestStruct.Business;
             Assert.AreEqual(exp, act);
         }
 
@@ -780,21 +758,21 @@ namespace Qowaiv.UnitTests.Financial
         public void LocationCode_DefaultValue_StringEmpty()
         {
             var exp = "";
-            var act = BusinessIdentifierCode.Empty.LocationCode;
+            var act = BusinessIdentifierCode.Empty.Location;
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void LocationCode_Unknown_StringEmpty()
         {
             var exp = "";
-            var act = BusinessIdentifierCode.Unknown.LocationCode;
+            var act = BusinessIdentifierCode.Unknown.Location;
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void LocationCode_TestStruct_NL()
         {
             var exp = "2U";
-            var act = TestStruct.LocationCode;
+            var act = TestStruct.Location;
             Assert.AreEqual(exp, act);
         }
 
@@ -802,28 +780,28 @@ namespace Qowaiv.UnitTests.Financial
         public void BranchCode_DefaultValue_StringEmpty()
         {
             var exp = "";
-            var act = BusinessIdentifierCode.Empty.BranchCode;
+            var act = BusinessIdentifierCode.Empty.Branch;
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void BranchCode_Unknown_StringEmpty()
         {
             var exp = "";
-            var act = BusinessIdentifierCode.Unknown.BranchCode;
+            var act = BusinessIdentifierCode.Unknown.Branch;
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void BranchCode_TestStruct_NL()
         {
             var exp = "XXX";
-            var act = TestStruct.BranchCode;
+            var act = TestStruct.Branch;
             Assert.AreEqual(exp, act);
         }
         [Test]
         public void BranchCode_AEGONL2U_StringEmpty()
         {
             var exp = "";
-            var act = BusinessIdentifierCode.Parse("AEGONL2U").BranchCode;
+            var act = BusinessIdentifierCode.Parse("AEGONL2U").Branch;
             Assert.AreEqual(exp, act);
         }
 


### PR DESCRIPTION
BIC means Business Identifier Code not Bank Identifier Code. So the Single Value Object should be named `BusinessIdentifierCode` not `BankIdentifierCode`. The old SVO has been deprecated, and the new one been introduced.

To consider: remove the LocationCode, BusinessCode, CountryCode, and BranchCode sufix. (not breaking as new type).

See #87