### PR TITLE
Extend TestTools.SerializationTest with XmlSerialize() and XmlDeserialize<T>()

### DIFF
--- a/test/Qowaiv.Data.SqlClient.UnitTests/Sql/TimestampTest.cs
+++ b/test/Qowaiv.Data.SqlClient.UnitTests/Sql/TimestampTest.cs
@@ -220,13 +220,20 @@ namespace Qowaiv.UnitTests.Sql
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "0x00000000075BCD15";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Timestamp>("0x00000000075BCD15");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/DateTest.cs
+++ b/test/Qowaiv.UnitTests/DateTest.cs
@@ -197,13 +197,21 @@ namespace Qowaiv.UnitTests
             Assert.AreEqual(exp, act);
         }
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "1970-02-14";
             Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Date>("1970-02-14");
+            Assert.AreEqual(TestStruct, act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_DateSerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/EmailAddressCollectionTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressCollectionTest.cs
@@ -91,14 +91,22 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             CollectionAssert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = GetTestInstance();
-            var exp = GetTestInstance();
-            var act = SerializationTest.XmlSerializeDeserialize(input);
-            CollectionAssert.AreEqual(exp, act);
+            var act = SerializationTest.XmlSerialize(GetTestInstance());
+            var exp = "info@qowaiv.org,test@qowaiv.org";
+            Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<EmailAddress>("info@qowaiv.org,test@qowaiv.org");
+            Assert.AreEqual(GetTestInstance(), act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_EmailAddressSerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/EmailAddressCollectionTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressCollectionTest.cs
@@ -69,7 +69,7 @@ namespace Qowaiv.UnitTests
         public void GetObjectData_SerializationInfo_AreEqual()
         {
             ISerializable obj = GetTestInstance();
-            var info = new SerializationInfo(typeof(EmailAddressCollection), new System.Runtime.Serialization.FormatterConverter());
+            var info = new SerializationInfo(typeof(EmailAddressCollection), new FormatterConverter());
             obj.GetObjectData(info, default);
 
             Assert.AreEqual("info@qowaiv.org,test@qowaiv.org", info.GetString("Value"));
@@ -103,7 +103,7 @@ namespace Qowaiv.UnitTests
         [Test]
         public void XmlDeserialize_XmlString_AreEqual()
         {
-            var act = SerializationTest.XmlDeserialize<EmailAddress>("info@qowaiv.org,test@qowaiv.org");
+            var act = SerializationTest.XmlDeserialize<EmailAddressCollection>("info@qowaiv.org,test@qowaiv.org");
             Assert.AreEqual(GetTestInstance(), act);
         }
 

--- a/test/Qowaiv.UnitTests/EmailAddressTest.cs
+++ b/test/Qowaiv.UnitTests/EmailAddressTest.cs
@@ -286,14 +286,22 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = EmailAddressTest.TestStruct;
-            var exp = EmailAddressTest.TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "svo@qowaiv.org";
             Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<EmailAddress>("svo@qowaiv.org");
+            Assert.AreEqual(TestStruct, act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_EmailAddressSerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/Financial/AmountTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/AmountTest.cs
@@ -188,14 +188,22 @@ namespace Qowaiv.Financial.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "42.17";
             Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Amount>("42.17");
+            Assert.AreEqual(TestStruct, act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_AmountSerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/Financial/BusinessIdentifierCodeTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/BusinessIdentifierCodeTest.cs
@@ -249,14 +249,22 @@ namespace Qowaiv.UnitTests.Financial
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "AEGONL2UXXX";
             Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<BusinessIdentifierCode>("AEGONL2UXXX");
+            Assert.AreEqual(TestStruct, act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/Financial/CurrencyTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/CurrencyTest.cs
@@ -324,13 +324,20 @@ namespace Qowaiv.UnitTests.Financial
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = CurrencyTest.TestStruct;
-            var exp = CurrencyTest.TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "EUR";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Currency>("EUR");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/Financial/InternationalBankAccountNumberTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/InternationalBankAccountNumberTest.cs
@@ -188,14 +188,22 @@ namespace Qowaiv.UnitTests.Financial
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = InternationalBankAccountNumberTest.TestStruct;
-            var exp = InternationalBankAccountNumberTest.TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "NL20INGB0001234567";
             Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<InternationalBankAccountNumber>("NL20INGB0001234567");
+            Assert.AreEqual(TestStruct, act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/Financial/MoneyTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/MoneyTest.cs
@@ -181,14 +181,22 @@ namespace Qowaiv.UnitTests.Financial
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "EUR42.17";
             Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Money>("EUR42.17");
+            Assert.AreEqual(TestStruct, act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_MoneySerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/GenderTest.cs
+++ b/test/Qowaiv.UnitTests/GenderTest.cs
@@ -303,13 +303,20 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = GenderTest.TestStruct;
-            var exp = GenderTest.TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "Male";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Gender>("Male");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/Globalization/CountryTest.cs
+++ b/test/Qowaiv.UnitTests/Globalization/CountryTest.cs
@@ -334,14 +334,22 @@ namespace Qowaiv.UnitTests.Globalization
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = CountryTest.TestStruct;
-            var exp = CountryTest.TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "VA";
             Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Country>("VA");
+            Assert.AreEqual(TestStruct, act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_CountrySerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/HouseNumberTest.cs
+++ b/test/Qowaiv.UnitTests/HouseNumberTest.cs
@@ -312,14 +312,22 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "123456789";
             Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<HouseNumber>("123456789");
+            Assert.AreEqual(TestStruct, act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_HouseNumberSerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/IO/StreamSizeTest.cs
+++ b/test/Qowaiv.UnitTests/IO/StreamSizeTest.cs
@@ -228,13 +228,20 @@ namespace Qowaiv.UnitTests.IO
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "123456789 byte";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<StreamSize>("123456789 byte");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/LocalDateTimeTest.cs
+++ b/test/Qowaiv.UnitTests/LocalDateTimeTest.cs
@@ -182,14 +182,22 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = LocalDateTimeTest.TestStructNoMilliseconds;
-            var exp = LocalDateTimeTest.TestStructNoMilliseconds;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "1988-06-13 22:10:05.001";
             Assert.AreEqual(exp, act);
         }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<LocalDateTime>("1988-06-13 22:10:05.001");
+            Assert.AreEqual(TestStruct, act);
+        }
+
 
         [Test]
         public void SerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()

--- a/test/Qowaiv.UnitTests/MonthTest.cs
+++ b/test/Qowaiv.UnitTests/MonthTest.cs
@@ -345,8 +345,15 @@ namespace Qowaiv.UnitTests
         public void XmlSerialize_TestStruct_AreEqual()
         {
             var act = SerializationTest.XmlSerialize(TestStruct);
-            var exp = @"<?xml version=""1.0"" encoding=""utf-8""?><Month>Feb</Month>";
+            var exp = "Feb";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_Feb_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Month>("Feb");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]
@@ -579,10 +586,13 @@ namespace Qowaiv.UnitTests
         [Test]
         public void ToString_CustomFormatter_SupportsCustomFormatting()
         {
-            var act = TestStruct.ToString("Unit Test Format", new UnitTestFormatProvider());
-            var exp = "Unit Test Formatter, value: 'February', format: 'Unit Test Format'";
+            using (CultureInfoScope.NewInvariant())
+            {
+                var act = TestStruct.ToString("Unit Test Format", new UnitTestFormatProvider());
+                var exp = "Unit Test Formatter, value: 'February', format: 'Unit Test Format'";
 
-            Assert.AreEqual(exp, act);
+                Assert.AreEqual(exp, act);
+            }
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/MonthTest.cs
+++ b/test/Qowaiv.UnitTests/MonthTest.cs
@@ -342,21 +342,6 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = SerializationTest.XmlSerialize(TestStruct);
-            var exp = "Feb";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_Feb_AreEqual()
-        {
-            var act = SerializationTest.XmlDeserialize<Month>("Feb");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -372,13 +357,20 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "Feb";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Month>("Feb");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/PercentageTest.cs
+++ b/test/Qowaiv.UnitTests/PercentageTest.cs
@@ -265,13 +265,20 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "17.51%";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Percentage>("17.51%");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/PostalCodeTest.cs
+++ b/test/Qowaiv.UnitTests/PostalCodeTest.cs
@@ -277,13 +277,20 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "H0H0H0";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<PostalCode>("H0H0H0");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/Security/Cryptography/CryptographicSeedTest.cs
+++ b/test/Qowaiv.UnitTests/Security/Cryptography/CryptographicSeedTest.cs
@@ -208,13 +208,20 @@ namespace Qowaiv.Security.Cryptography.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = CryptographicSeedTest.TestStruct;
-            var exp = CryptographicSeedTest.TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "Qowaig==";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<CryptographicSeed>("Qowaig==");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/Statistics/EloTest.cs
+++ b/test/Qowaiv.UnitTests/Statistics/EloTest.cs
@@ -188,13 +188,20 @@ namespace Qowaiv.UnitTests.Statistics
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = EloTest.TestStruct;
-            var exp = EloTest.TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "1732.4";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Elo>("1732.4");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/UuidTest.cs
+++ b/test/Qowaiv.UnitTests/UuidTest.cs
@@ -191,13 +191,20 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "Qowaiv_SVOLibrary_GUIA";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Uuid>("Qowaiv_SVOLibrary_GUIA");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/Web/InternetMediaTypeTest.cs
+++ b/test/Qowaiv.UnitTests/Web/InternetMediaTypeTest.cs
@@ -311,13 +311,20 @@ namespace Qowaiv.UnitTests.Web
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "application/x-chess-pgn";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<InternetMediaType>("application/x-chess-pgn");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/WeekDateTest.cs
+++ b/test/Qowaiv.UnitTests/WeekDateTest.cs
@@ -268,13 +268,20 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "1997-W14-6";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<WeekDate>("1997-W14-6");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/YearTest.cs
+++ b/test/Qowaiv.UnitTests/YearTest.cs
@@ -313,13 +313,20 @@ namespace Qowaiv.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "1979";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Year>("1979");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/YesNoTest.cs
+++ b/test/Qowaiv.UnitTests/YesNoTest.cs
@@ -280,13 +280,20 @@ namespace Qowaiv.Fiancial.UnitTests
             var act = SerializationTest.DataContractSerializeDeserialize(input);
             Assert.AreEqual(exp, act);
         }
+
         [Test]
-        public void XmlSerializeDeserialize_TestStruct_AreEqual()
+        public void XmlSerialize_TestStruct_AreEqual()
         {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializationTest.XmlSerializeDeserialize(input);
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "yes";
             Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<YesNo>("yes");
+            Assert.AreEqual(TestStruct, act);
         }
 
         [Test]

--- a/tooling/Qowaiv.CodeGenerator/Generators/Svo/Templates/SvoStruct_UnitTest.cshtml
+++ b/tooling/Qowaiv.CodeGenerator/Generators/Svo/Templates/SvoStruct_UnitTest.cshtml
@@ -323,14 +323,21 @@ namespace @(Model.Namespace).UnitTests
     var act = SerializationTest.DataContractSerializeDeserialize(input);
     Assert.AreEqual(exp, act);
     }
-    [Test]
-    public void XmlSerializeDeserialize_TestStruct_AreEqual()
-    {
-    var input = TestStruct;
-    var exp = TestStruct;
-    var act = SerializationTest.XmlSerializeDeserialize(input);
-    Assert.AreEqual(exp, act);
-    }
+    
+        [Test]
+        public void XmlSerialize_TestStruct_AreEqual()
+        {
+            var act = SerializationTest.XmlSerialize(TestStruct);
+            var exp = "xmlstring";
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void XmlDeserialize_XmlString_AreEqual()
+        {
+            var act = SerializationTest.XmlDeserialize<Model.ClassNameSerializeObject>("xmlstring");
+            Assert.AreEqual(TestStruct, act);
+        }
 
     [Test]
     public void SerializeDeserialize_@(Model.ClassNameSerializeObject)_AreEqual()

--- a/tooling/Qowaiv.TestTools/SerializationTest.cs
+++ b/tooling/Qowaiv.TestTools/SerializationTest.cs
@@ -68,11 +68,24 @@ namespace Qowaiv.TestTools
         /// </param>
         public static T XmlDeserialize<T>(string xml)
         {
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes($"<Wrapper><Value>{xml}</Value></Wrapper>")))
+            var value = new XElement("Value", xml);
+            var doc = new XDocument(new XElement("Wrapper", value));
+            
+            using (var stream = new MemoryStream())
             {
+                doc.Save(stream);
+                stream.Position = 0;
                 var serializer = new XmlSerializer(typeof(SerializationWrapper<T>));
-                var wrapper = (SerializationWrapper<T>)serializer.Deserialize(stream);
-                return wrapper.Value;
+                try
+                {
+                    var wrapper = (SerializationWrapper<T>)serializer.Deserialize(stream);
+                    return wrapper.Value;
+                }
+                catch (Exception x)
+                {
+                    throw new SerializationException($"'{value.Value}' failed on: {x.Message}", x);
+                }
+
             }
         }
 

--- a/tooling/Qowaiv.TestTools/SerializationTest.cs
+++ b/tooling/Qowaiv.TestTools/SerializationTest.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using System.Xml;
+using System.Xml.Linq;
 using System.Xml.Serialization;
 
 namespace Qowaiv.TestTools
@@ -46,14 +47,32 @@ namespace Qowaiv.TestTools
             using (var stream = new MemoryStream())
             {
                 var writer = new XmlTextWriter(stream, Encoding.UTF8);
-                var serializer = new XmlSerializer(typeof(T));
-                serializer.Serialize(writer, instance);
+                var serializer = new XmlSerializer(typeof(SerializationWrapper<T>));
+                serializer.Serialize(writer, new SerializationWrapper<T> { Value = instance });
                 stream.Position = 0;
 
                 using (var reader = new StreamReader(stream))
                 {
-                    return reader.ReadToEnd();
+                    var xml = XDocument.Load(reader);
+                    return xml.Element("Wrapper")?.Element("Value")?.Value;
                 }
+            }
+        }
+
+        /// <summary>Serializes an instance using an XmlSerializer.</summary>
+        /// <typeparam name="T">
+        /// Type of the instance.
+        /// </typeparam>
+        /// <param name="xml">
+        /// The xml string to (XML) deserialize.
+        /// </param>
+        public static T XmlDeserialize<T>(string xml)
+        {
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes($"<Wrapper><Value>{xml}</Value></Wrapper>")))
+            {
+                var serializer = new XmlSerializer(typeof(SerializationWrapper<T>));
+                var wrapper = (SerializationWrapper<T>)serializer.Deserialize(stream);
+                return wrapper.Value;
             }
         }
 

--- a/tooling/Qowaiv.TestTools/SerializationWrapper.cs
+++ b/tooling/Qowaiv.TestTools/SerializationWrapper.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Xml.Serialization;
+
+namespace Qowaiv.TestTools
+{
+    /// <summary>Wrapper used by <see cref="SerializationTest.XmlSerialize{T}(T)"/>
+    /// and <see cref="SerializationTest.XmlSerializeDeserialize{T}(T)"/>.
+    /// </summary>
+    [Serializable, XmlRoot("Wrapper")]
+    public class SerializationWrapper<T>
+    {
+        public T Value { get; set; }
+    }
+}

--- a/tooling/Qowaiv.TestTools/SerializationWrapper.cs
+++ b/tooling/Qowaiv.TestTools/SerializationWrapper.cs
@@ -9,6 +9,7 @@ namespace Qowaiv.TestTools
     [Serializable, XmlRoot("Wrapper")]
     public class SerializationWrapper<T>
     {
+        /// <summary>The generic part of the wrapper.</summary>
         public T Value { get; set; }
     }
 }


### PR DESCRIPTION
Previously, only an `XmlSerializeDeserialize(object model)` method existed. That lacks a way to check what value is actually used to serialise. To overcome this,  `SerializationTest.XmlSerialize(object model)` and `SerializationTest.XmlDeserialize<T>(string xmlstring)` have been added.

For all existing SVO's, according tests have been added.