### PR TITLE
JSON Deserialize does not work with Newtonsoft JSON Date node

### DIFF
--- a/example/Qowaiv.Json.Newtonsoft.UnitTests/QowaivJsonConverterTest.cs
+++ b/example/Qowaiv.Json.Newtonsoft.UnitTests/QowaivJsonConverterTest.cs
@@ -85,9 +85,30 @@ namespace Qowaiv.Json.UnitTests
             Assert.AreEqual("JSON deserialization from a number is not supported.", exception.Message);
         }
 
+
+        [Test]
+        public void DeserializeObject_WithQowaivJsonConverter_SupportsJsonDateNode()
+        {
+            QowaivJsonConverter.Register();
+
+            var json = "{ Id: 3, Date: \"2012-04-23T10:25:43.015-05:00\", Val: \"Hello World!\" }";
+            var act = JsonConvert.DeserializeObject<JsonDateObject>(json);
+
+            Assert.AreEqual(3, act.Id);
+            Assert.AreEqual(new Date(2012, 04, 23), act.Date);
+            Assert.AreEqual("Hello World!", act.Val);
+        }
+
         internal class ReadModel
         {
             public Gender Gender { get; set; }
+        }
+
+        internal class JsonDateObject
+        {
+            public int Id { get; set; }
+            public Date? Date { get; set; }
+            public string Val { get; set; }
         }
 
     }

--- a/example/Qowaiv.Json.Newtonsoft/QowaivJsonConverter.cs
+++ b/example/Qowaiv.Json.Newtonsoft/QowaivJsonConverter.cs
@@ -69,6 +69,11 @@ namespace Qowaiv.Json
                         result.FromJson();
                         break;
 
+                    // A string.
+                    case JsonToken.String:
+                        result.FromJson((string)reader.Value);
+                        break;
+
                     // A number without digits.
                     case JsonToken.Integer:
                         result.FromJson((long)reader.Value);
@@ -79,10 +84,11 @@ namespace Qowaiv.Json
                         result.FromJson((double)reader.Value);
                         break;
 
-                    // A string.
-                    case JsonToken.String:
-                        result.FromJson((string)reader.Value);
+                    // A date.
+                    case JsonToken.Date:
+                        result.FromJson((DateTime)reader.Value);
                         break;
+
                     // Other scenario's are not supported.    
                     default:
                         throw new JsonSerializationException(string.Format(CultureInfo.CurrentCulture, QowaivMessages.JsonSerialization_TokenNotSupported, objectType.FullName, reader.TokenType));

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -42,20 +42,7 @@ namespace Qowaiv
         public static Date Tomorrow => Clock.Tomorrow();
 
         #region Constructors
-
-        /// <summary>Initializes a new instance of the date structure based on a System.DateTime.
-        /// </summary>
-        /// <param name="dt">
-        /// A date and time.
-        /// </param>
-        /// <remarks>
-        /// The date of the date time is taken.
-        /// </remarks>
-        private Date(DateTime dt)
-        {
-            m_Value = dt.Date;
-        }
-
+           
         /// <summary>Initializes a new instance of the date structure to a specified number of ticks.</summary>
         /// <param name="ticks">
         /// A date expressed in 100-nanosecond units.
@@ -84,6 +71,20 @@ namespace Qowaiv
         /// more than date.MaxValue.
         /// </exception>
         public Date(int year, int month, int day) : this(new DateTime(year, month, day)) { }
+
+        /// <summary>Initializes a new instance of the date structure based on a System.DateTime.
+        /// </summary>
+        /// <param name="dt">
+        /// A date and time.
+        /// </param>
+        /// <remarks>
+        /// The date of the date time is taken.
+        /// </remarks>
+        private Date(DateTime dt)
+        {
+            m_Value = dt.Date;
+        }
+
 
         #endregion
 
@@ -678,7 +679,7 @@ namespace Qowaiv
         public static bool IsValid(string val) => IsValid(val, CultureInfo.CurrentCulture);
 
         /// <summary>Returns true if the val represents a valid Date, otherwise false.</summary>
-        public static bool IsValid(string val, IFormatProvider formatProvider) => TryParse(val, formatProvider, out Date d);
+        public static bool IsValid(string val, IFormatProvider formatProvider) => TryParse(val, formatProvider, out _);
 
         #endregion
     }

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -85,7 +85,6 @@ namespace Qowaiv
             m_Value = dt.Date;
         }
 
-
         #endregion
 
         #region Properties
@@ -374,7 +373,7 @@ namespace Qowaiv
         /// <param name="jsonDate">
         /// The JSON Date that represents the 
         /// </param>
-        void IJsonSerializable.FromJson(DateTime jsonDate) => m_Value = jsonDate;
+        void IJsonSerializable.FromJson(DateTime jsonDate) => m_Value = jsonDate.Date;
 
         /// <summary>Converts a Date into its JSON object representation.</summary>
         object IJsonSerializable.ToJson() => ToString(SerializableFormat, CultureInfo.InvariantCulture);

--- a/test/Qowaiv.UnitTests/DateTest.cs
+++ b/test/Qowaiv.UnitTests/DateTest.cs
@@ -386,6 +386,15 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        public void FromJson_DateTimeValueWithSeconds_AreEqual()
+        {
+            var act = JsonTester.Read<Date>(new DateTime(1970, 02, 14, 17, 44, 09));
+            var exp = TestStruct;
+
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
         public void ToJson_DefaultValue_AreEqual()
         {
             object act = JsonTester.Write(default(Date));

--- a/test/Qowaiv.UnitTests/DateTest.cs
+++ b/test/Qowaiv.UnitTests/DateTest.cs
@@ -345,11 +345,14 @@ namespace Qowaiv.UnitTests
             },
             "Not a valid date");
         }
-        [Test]
-        public void FromJson_StringValue_AreEqual()
+
+        [TestCase("2012-04-23")]
+        [TestCase("2012-04-23T18:25:43.511Z")]
+        [TestCase("2012-04-23T10:25:43-05:00")]
+        public void FromJson_StringValue_AreEqual(string str)
         {
-            var act = JsonTester.Read<Date>("1970-02-14");
-            var exp = TestStruct;
+            var act = JsonTester.Read<Date>(str);
+            var exp = new Date(2012, 04, 23);
 
             Assert.AreEqual(exp, act);
         }


### PR DESCRIPTION
Deserialzing a JSON Date node (a `string` that is regonized as such by Newtonsoft JSON Serializer) is not picked up correctly:
* The default example implementation does not route Date-nodes
* The `Date.FromJson(DateTime)` does not strip the time information from the date