### PR TITLE
Fix of null message for NotSupportedException_ConverterCanNotConvertFromString

### DIFF
--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -457,7 +457,7 @@ namespace Qowaiv {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Converter can not convert from System.String..
         /// </summary>
         public static string NotSupportedException_ConverterCanNotConvertFromString {
             get {

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -161,7 +161,7 @@
     <value>The country '{0} ({1})' is not supported as region info.</value>
   </data>
   <data name="NotSupportedException_ConverterCanNotConvertFromString" xml:space="preserve">
-    <value />
+    <value>Converter can not convert from System.String.</value>
   </data>
   <data name="NotSupportedException_NoGenericType" xml:space="preserve">
     <value>Type must be a none generic type.</value>

--- a/test/Qowaiv.UnitTests/Threading/ThreadDomainTest.cs
+++ b/test/Qowaiv.UnitTests/Threading/ThreadDomainTest.cs
@@ -1,11 +1,9 @@
 ﻿using NUnit.Framework;
 using Qowaiv.Financial;
 using Qowaiv.Globalization;
-using Qowaiv.IO;
 using Qowaiv.TestTools;
 using Qowaiv.Threading;
 using System;
-using System.Configuration;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -41,21 +39,15 @@ namespace Qowaiv.UnitTests.Threading
         [Test]
         public void Get_NullableDecimal_ThrowsNotSupportedException()
         {
-            Assert.Catch<NotSupportedException>(() =>
-            {
-                ThreadDomain.Current.Get<decimal?>();
-            },
-            "Type must be a none generic type.");
+            var x = Assert.Catch<NotSupportedException>(() => ThreadDomain.Current.Get<decimal?>());
+            Assert.AreEqual("Type must be a none generic type.", x.Message);
         }
 
         [Test]
         public void Get_Object_ThrowsNotSupportedException()
         {
-            Assert.Catch<NotSupportedException>(() =>
-            {
-                ThreadDomain.Current.Get<Object>();
-            },
-            "Converter can not convert from System.String.");
+            var x = Assert.Catch<NotSupportedException>(() => ThreadDomain.Current.Get<object>());
+            Assert.AreEqual("Converter can not convert from System.String.", x.Message);
         }
 
         [Test]


### PR DESCRIPTION
As described in #94 .