### PR TITLE
DebuggerDisplayAssert should also work with nested classes

### DIFF
--- a/Qowaiv.sln
+++ b/Qowaiv.sln
@@ -71,6 +71,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Qowaiv.Text.Json.Serializat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Qowaiv.TestTools", "src\Qowaiv.TestTools\Qowaiv.TestTools.csproj", "{DDB84002-C9A4-4D0C-9B98-19FF02854D11}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Qowaiv.TestTools.UnitTests", "test\Qowaiv.TestTools.UnitTests\Qowaiv.TestTools.UnitTests.csproj", "{A3710D9F-C77B-41F0-AFD8-A999D9F3C17A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,10 @@ Global
 		{DDB84002-C9A4-4D0C-9B98-19FF02854D11}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DDB84002-C9A4-4D0C-9B98-19FF02854D11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DDB84002-C9A4-4D0C-9B98-19FF02854D11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3710D9F-C77B-41F0-AFD8-A999D9F3C17A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3710D9F-C77B-41F0-AFD8-A999D9F3C17A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3710D9F-C77B-41F0-AFD8-A999D9F3C17A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3710D9F-C77B-41F0-AFD8-A999D9F3C17A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -144,6 +150,7 @@ Global
 		{932B4123-594C-494B-9B3E-7017D526E80F} = {A4C3C9FF-4EED-41FE-8849-C896429254B5}
 		{F74D9EF2-39B5-40EB-8C44-1D6015C38D70} = {A4C3C9FF-4EED-41FE-8849-C896429254B5}
 		{CEB12E1E-A171-4D64-B8E1-4E4D2D3C693E} = {225B41F0-0B59-4AB1-96DA-A916E2678AD4}
+		{A3710D9F-C77B-41F0-AFD8-A999D9F3C17A} = {40C1E942-8DB1-4E58-8FB4-71F5EDA66029}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9B55A336-E2D3-4656-9840-D519B3E1159B}

--- a/src/Qowaiv.TestTools/DebuggerDisplayAssert.cs
+++ b/src/Qowaiv.TestTools/DebuggerDisplayAssert.cs
@@ -8,24 +8,32 @@ namespace Qowaiv.TestTools
     public static class DebuggerDisplayAssert
     {
         /// <summary>Verifies that a certain type is decorated with a <see cref="DebuggerDisplayAttribute"/>.</summary>
+        [DebuggerStepThrough]
         public static void HasAttribute(Type type)
         {
             Assert.IsNotNull(type, "The supplied type should not be null.");
 
-            var act = type.GetCustomAttribute<DebuggerDisplayAttribute>(false);
+            var act = type.GetCustomAttribute<DebuggerDisplayAttribute>(true);
             Assert.IsNotNull(act, $"The type '{type}' has no DebuggerDisplay attribute.");
 
             Assert.AreEqual("{DebuggerDisplay}", act.Value, "DebuggerDisplay attribute value is not '{DebuggerDisplay}'.");
         }
 
         /// <summary>Verifies the outcome of the <see cref="DebuggerDisplayAttribute"/> of a certain <see cref="object"/>.</summary>
+        [DebuggerStepThrough]
         public static void HasResult(object expected, object value)
         {
             Assert.IsNotNull(value, "The supplied value should not be null.");
 
             var type = value.GetType();
-
-            var prop = type.GetProperty("DebuggerDisplay", BindingFlags.Instance | BindingFlags.NonPublic);
+            var tp = type;
+            PropertyInfo prop;
+            do
+            {
+                prop = tp.GetProperty("DebuggerDisplay", BindingFlags.Instance | BindingFlags.NonPublic);
+                tp = tp.BaseType;
+            }
+            while (prop is null && !(tp is null));
 
             Assert.IsNotNull(prop, $"The type '{type}' does not contain a non-public property DebuggerDisplay.");
 

--- a/test/Qowaiv.TestTools.UnitTests/DebuggerDisplayAssertTest.cs
+++ b/test/Qowaiv.TestTools.UnitTests/DebuggerDisplayAssertTest.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using System.Diagnostics;
+
+namespace Qowaiv.TestTools.UnitTests
+{
+    public class DebuggerDisplayAssertTest
+    {
+        [Test]
+        public void HasDebuggerDisplay_ViaParent_Successful()
+        {
+            DebuggerDisplayAssert.HasAttribute(typeof(WithDubuggerDisplayChild));
+        }
+
+        [Test]
+        public void HasDebuggerDisplay_Directly_Successful()
+        {
+            DebuggerDisplayAssert.HasAttribute(typeof(WithDebuggerDisplay));
+        }
+
+        [Test]
+        public void HasResult_ViaParent_StringValue()
+        {
+            DebuggerDisplayAssert.HasResult("WithDubuggerDisplayChild", new WithDubuggerDisplayChild());
+        }
+
+        [Test]
+        public void HasResulty_Directly_StringValue()
+        {
+            DebuggerDisplayAssert.HasResult("WithDebuggerDisplay", new WithDebuggerDisplay());
+        }
+    }
+
+    internal class WithDubuggerDisplayChild : WithDebuggerDisplay { }
+
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    internal class WithDebuggerDisplay
+    {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay => GetType().Name;
+    }
+
+}

--- a/test/Qowaiv.TestTools.UnitTests/Qowaiv.TestTools.UnitTests.csproj
+++ b/test/Qowaiv.TestTools.UnitTests/Qowaiv.TestTools.UnitTests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\props\nopackage.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Qowaiv.TestTools\Qowaiv.TestTools.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
`DebuggerDisplayAssert.HasAttribute()` and `DebuggerDisplayAssert.HasResult()` should also detect the `[DebuggerDisplay]` setup also via base classes.