### PR TITLE
NaN is not a valid value for Elo

### DIFF
--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -106,6 +106,15 @@ namespace Qowaiv {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The number can not represent an Elo..
+        /// </summary>
+        public static string ArgumentOutOfRange_Elo {
+            get {
+                return ResourceManager.GetString("ArgumentOutOfRange_Elo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Percentages can only round to between -26 and 26 digits of precision..
         /// </summary>
         public static string ArgumentOutOfRange_PercentageRound {
@@ -120,15 +129,6 @@ namespace Qowaiv {
         public static string ArgumentOutOfRangeException_DateSpan {
             get {
                 return ResourceManager.GetString("ArgumentOutOfRangeException_DateSpan", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The double.NaN value can not represent an Elo..
-        /// </summary>
-        public static string ArgumentOutOfRangeException_EloNotFromNaN {
-            get {
-                return ResourceManager.GetString("ArgumentOutOfRangeException_EloNotFromNaN", resourceCulture);
             }
         }
         

--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -124,6 +124,15 @@ namespace Qowaiv {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The double.NaN value can not represent an Elo..
+        /// </summary>
+        public static string ArgumentOutOfRangeException_EloNotFromNaN {
+            get {
+                return ResourceManager.GetString("ArgumentOutOfRangeException_EloNotFromNaN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} operation could not be applied. There is a mismatch between {1} and {2}..
         /// </summary>
         public static string CurrencyMismatchException {

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -79,8 +79,8 @@
   <data name="ArgumentOutOfRangeException_DateSpan" xml:space="preserve">
     <value>The specified years, months and days results in an un-representable DateSpan.</value>
   </data>
-  <data name="ArgumentOutOfRangeException_EloNotFromNaN" xml:space="preserve">
-    <value>The double.NaN value can not represent an Elo.</value>
+  <data name="ArgumentOutOfRange_Elo" xml:space="preserve">
+    <value>The number can not represent an Elo.</value>
   </data>
   <data name="CurrencyMismatchException" xml:space="preserve">
     <value>The {0} operation could not be applied. There is a mismatch between {1} and {2}.</value>

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -79,6 +79,9 @@
   <data name="ArgumentOutOfRangeException_DateSpan" xml:space="preserve">
     <value>The specified years, months and days results in an un-representable DateSpan.</value>
   </data>
+  <data name="ArgumentOutOfRangeException_EloNotFromNaN" xml:space="preserve">
+    <value>The double.NaN value can not represent an Elo.</value>
+  </data>
   <data name="CurrencyMismatchException" xml:space="preserve">
     <value>The {0} operation could not be applied. There is a mismatch between {1} and {2}.</value>
   </data>

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -146,7 +146,7 @@ namespace Qowaiv.Statistics
 
         /// <summary>Returns a <see cref="string"/> that represents the current Elo for debug purposes.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private double DebuggerDisplay=> m_Value;
+        private double DebuggerDisplay => m_Value;
 
         /// <summary>Returns a formatted <see cref="string"/> that represents the current Elo.</summary>
         /// <param name="format">
@@ -170,10 +170,10 @@ namespace Qowaiv.Statistics
         /// <summary>Casts an Elo to a <see cref="string"/>.</summary>
         public static explicit operator string(Elo val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a Elo.</summary>
-        public static explicit operator Elo(string str) =>Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Elo(string str) => Parse(str, CultureInfo.CurrentCulture);
 
         /// <summary>Casts a decimal to an Elo.</summary>
-        public static implicit operator Elo(decimal val)=>new Elo((double)val);
+        public static implicit operator Elo(decimal val) => new Elo((double)val);
         /// <summary>Casts a decimal to an Elo.</summary>
         public static implicit operator Elo(double val) => new Elo(val);
         /// <summary>Casts an integer to an Elo.</summary>
@@ -184,7 +184,7 @@ namespace Qowaiv.Statistics
         /// <summary>Casts an Elo to a double.</summary>
         public static explicit operator double(Elo val) => val.m_Value;
         /// <summary>Casts an Elo to an integer.</summary>
-        public static explicit operator int(Elo val) =>(int)Math.Round(val.m_Value);
+        public static explicit operator int(Elo val) => (int)Math.Round(val.m_Value);
 
         /// <summary>Converts the string to an Elo.
         /// A return value indicates whether the conversion succeeded.
@@ -207,7 +207,8 @@ namespace Qowaiv.Statistics
             if (!string.IsNullOrEmpty(s))
             {
                 var str = s.EndsWith("*", StringComparison.InvariantCultureIgnoreCase) ? s.Substring(0, s.Length - 1) : s;
-                if (double.TryParse(str, NumberStyles.Number, formatProvider, out double d))
+
+                if (double.TryParse(str, NumberStyles.Number, formatProvider, out var d) && !double.IsNaN(d))
                 {
                     result = new Elo { m_Value = d };
                     return true;
@@ -216,13 +217,20 @@ namespace Qowaiv.Statistics
             return false;
         }
 
-        /// <summary >Creates an Elo from a Double. </summary >
-        /// <param name="val" >
-        /// A decimal describing an Elo.
-        /// </param >
-        /// <exception cref="FormatException" >
-        /// val is not a valid Elo.
-        /// </exception >
-        public static Elo Create(double val) => new Elo(val);
+        /// <summary>Creates an <see cref="Elo"/> from a <see cref="double"/>.</summary>
+        /// <param name="val">
+        /// A decimal describing an <see cref="Elo"/>.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// val is not a valid <see cref="Elo"/>.
+        /// </exception>
+        public static Elo Create(double val)
+        {
+            if (double.IsNaN(val))
+            {
+                throw new ArgumentOutOfRangeException(nameof(val), QowaivMessages.ArgumentOutOfRangeException_EloNotFromNaN);
+            }
+            return new Elo(val);
+        }
     }
 }

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -208,7 +208,7 @@ namespace Qowaiv.Statistics
             {
                 var str = s.EndsWith("*", StringComparison.InvariantCultureIgnoreCase) ? s.Substring(0, s.Length - 1) : s;
 
-                if (double.TryParse(str, NumberStyles.Number, formatProvider, out var d) && !double.IsNaN(d))
+                if (double.TryParse(str, NumberStyles.Number, formatProvider, out var d) && !double.IsNaN(d) && !double.IsInfinity(d))
                 {
                     result = new Elo { m_Value = d };
                     return true;
@@ -226,9 +226,9 @@ namespace Qowaiv.Statistics
         /// </exception>
         public static Elo Create(double val)
         {
-            if (double.IsNaN(val))
+            if (double.IsNaN(val) || double.IsInfinity(val))
             {
-                throw new ArgumentOutOfRangeException(nameof(val), QowaivMessages.ArgumentOutOfRangeException_EloNotFromNaN);
+                throw new ArgumentOutOfRangeException(nameof(val), QowaivMessages.ArgumentOutOfRange_Elo);
             }
             return new Elo(val);
         }

--- a/test/Qowaiv.UnitTests/Statistics/EloTest.cs
+++ b/test/Qowaiv.UnitTests/Statistics/EloTest.cs
@@ -38,19 +38,23 @@ namespace Qowaiv.UnitTests.Statistics
 
         #endregion
 
-        #region NaN
+        #region NaN and +oo and -oo
 
-        [Test]
-        public void Create_NaN_Throws()
+        [TestCase(double.NaN)]
+        [TestCase(double.PositiveInfinity)]
+        [TestCase(double.NegativeInfinity)]
+        public void Create_Throws(double dbl)
         {
-            var x = Assert.Catch<ArgumentOutOfRangeException>(() => Elo.Create(double.NaN));
-            StringAssert.StartsWith("The double.NaN value can not represent an Elo. ", x.Message);
+            var x = Assert.Catch<ArgumentOutOfRangeException>(() => Elo.Create(dbl));
+            StringAssert.StartsWith("The number can not represent an Elo. ", x.Message);
         }
 
-        [Test]
-        public void Parse_NaN_Throws()
+        [TestCase(double.NaN)]
+        [TestCase(double.PositiveInfinity)]
+        [TestCase(double.NegativeInfinity)]
+        public void Parse_Throws(double dbl)
         {
-            Assert.Throws<FormatException>(() => Elo.Parse(double.NaN.ToString(CultureInfo.InvariantCulture)));
+            Assert.Throws<FormatException>(() => Elo.Parse(dbl.ToString(CultureInfo.InvariantCulture)));
         }
 
         #endregion

--- a/test/Qowaiv.UnitTests/Statistics/EloTest.cs
+++ b/test/Qowaiv.UnitTests/Statistics/EloTest.cs
@@ -38,6 +38,23 @@ namespace Qowaiv.UnitTests.Statistics
 
         #endregion
 
+        #region NaN
+
+        [Test]
+        public void Create_NaN_Throws()
+        {
+            var x = Assert.Catch<ArgumentOutOfRangeException>(() => Elo.Create(double.NaN));
+            StringAssert.StartsWith("The double.NaN value can not represent an Elo. ", x.Message);
+        }
+
+        [Test]
+        public void Parse_NaN_Throws()
+        {
+            Assert.Throws<FormatException>(() => Elo.Parse(double.NaN.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        #endregion
+
         #region Methods
 
         [Test]


### PR DESCRIPTION
As mentioned in #114 , There is no reason to have an Elo.NaN, so the double value NaN should not be allowed as underlying value.