### PR TITLE
Fix minor issue with serializing Amount.Zero

### DIFF
--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -337,7 +337,12 @@ namespace Qowaiv.Financial
         /// <returns>
         /// The serialized JSON number.
         /// </returns>
-        public double ToJson() => (double)m_Value;
+        /// <remarks>
+        /// Some <see cref="decimal.Zero"/> representations will be cast to a
+        /// <see cref="double"/> value that slightly smaller than 0, at least
+        /// enough to have a <see cref="string"/> representation of -0.
+        /// </remarks>
+        public double ToJson() => m_Value == decimal.Zero ? 0 : (double)m_Value;
 
         /// <summary>Returns a <see cref="string"/> that represents the current Amount for debug purposes.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/test/Qowaiv.UnitTests/Financial/AmountTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/AmountTest.cs
@@ -16,7 +16,6 @@ namespace Qowaiv.Financial.UnitTests
         /// <summary>The test instance for most tests.</summary>
         public static readonly Amount TestStruct = (Amount)42.17m;
 
-
         public static NumberFormatInfo GetCustomNumberFormatInfo()
         {
             var info = new NumberFormatInfo
@@ -350,6 +349,19 @@ namespace Qowaiv.Financial.UnitTests
         {
             var act = JsonTester.Write(TestStruct);
             var exp = 42.17m;
+            Assert.AreEqual(exp, act);
+        }
+
+        [Test]
+        public void ToJson_ConstructedZero()
+        {
+            var pls = (Amount)12.456m;
+            var min = (Amount)(-12.456m);
+            var sum = min + pls;
+            
+            var act = sum.ToJson().ToString(CultureInfo.InvariantCulture);
+            var exp = "0";
+
             Assert.AreEqual(exp, act);
         }
 


### PR DESCRIPTION
As reported at #120 there is an edge case where `Amount.Zero` will be serialized as -0.

``` C#
Amount sum = 1234.456m - 1234.456m;
var json = sum.ToJson().ToString(CultureInfo.Invariant); // -0
```
The reason for this was that JSON uses floating points and therefore, ToJson() returns a double, instead of a decimal.
