### PR TITLE
Add IConvertable to the interfaces suppported by SVO's

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,14 @@ custom format is supplied at the format string - string.Format() the default
 formatting of the object is used, where FormattingArgumentsCollection.Format() 
 uses the default specified at the formatting collection of a type (if available).
 
+### IConvertable
+The `IConvertable` interface has limited value for other types than the .NET
+primitives. However, for some old constructs (like VB.NET's `CStr()`), just
+having an basic implementation helps.
+
+For that reason, all methods required by the interface are only explicitly
+accessable.
+
 ### Threading
 Because there are scenario's where you want to set typical values as a country 
 or a currency for the context of the current thread (like the culture info) 

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -228,6 +228,46 @@ namespace Qowaiv.Sql
 namespace Qowaiv.Sql
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Timestamp : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Sql
+{
+    using System;
     using System.Globalization;
 
     public partial struct Timestamp

--- a/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
+++ b/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
@@ -99,6 +99,13 @@ namespace Qowaiv.Sql
         [CLSCompliant(false)]
         public static implicit operator Timestamp(ulong val) => Create(val);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.UInt64;
+
         /// <summary>Converts the string to a timestamp.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -434,6 +434,13 @@ namespace Qowaiv
 
         #endregion
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.DateTime;
+
         /// <summary>Converts the string to a 
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -161,6 +161,13 @@ namespace Qowaiv
         /// <summary>Gets an XML string representation of the email address.</summary>
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value ?? string.Empty;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.String;
+
         /// <summary>The format token instructions.</summary>
         private static readonly Dictionary<char, Func<EmailAddress, IFormatProvider, string>> FormatTokens = new Dictionary<char, Func<EmailAddress, IFormatProvider, string>>
         {

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -414,6 +414,13 @@ namespace Qowaiv.Financial
         /// <summary>Casts an Amount to a int.</summary>
         public static explicit operator int(Amount val) => (int)val.m_Value;
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Decimal;
+
         /// <summary>Converts the string to an 
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -119,6 +119,14 @@ namespace Qowaiv.Financial
         /// <summary>Casts a <see cref="string"/> to a BIC.</summary>
         public static explicit operator BusinessIdentifierCode(string str) => Parse(str, CultureInfo.CurrentCulture);
 
+
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value ?? string.Empty;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.String;
+
         /// <summary>Converts the string to a BIC.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Financial/Currency.cs
+++ b/src/Qowaiv/Financial/Currency.cs
@@ -230,6 +230,13 @@ namespace Qowaiv.Financial
         /// <summary>Casts a <see cref="string"/> to a currency.</summary>
         public static explicit operator Currency(int val) => AllCurrencies.FirstOrDefault(c => c.IsoNumericCode == val);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value ?? string.Empty;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.String;
+
         /// <summary>Converts the string to a currency.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -172,6 +172,14 @@ namespace Qowaiv.Financial
         public static explicit operator string(InternationalBankAccountNumber val) => val.ToString();
         /// <summary>Casts a <see cref="string"/> to a IBAN.</summary>
         public static explicit operator InternationalBankAccountNumber(string str) => Parse(str, CultureInfo.InvariantCulture);
+
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value ?? string.Empty;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.String;
+
         /// <summary>Converts the string to an IBAN.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -484,6 +484,13 @@ namespace Qowaiv.Financial
 
         #endregion
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Decimal;
+
         /// <summary>Converts the string to 
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Gender.cs
+++ b/src/Qowaiv/Gender.cs
@@ -182,6 +182,13 @@ namespace Qowaiv
         /// <summary>Casts an <see cref="int"/> to a Gender.</summary>
         public static implicit operator Gender(int? val) => Create(val);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => ToInt32();
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Int32;
+
         /// <summary>Converts the string to a Gender.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -229,6 +229,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Date : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct Date

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -226,6 +226,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct EmailAddress : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct EmailAddress

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -228,6 +228,46 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Amount : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Financial
+{
+    using System;
     using System.Globalization;
 
     public partial struct Amount

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -226,6 +226,46 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct BusinessIdentifierCode : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Financial
+{
+    using System;
     using System.Globalization;
 
     public partial struct BusinessIdentifierCode

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -226,6 +226,46 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Currency : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Financial
+{
+    using System;
     using System.Globalization;
 
     public partial struct Currency

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -226,6 +226,46 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct InternationalBankAccountNumber : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Financial
+{
+    using System;
     using System.Globalization;
 
     public partial struct InternationalBankAccountNumber

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -203,6 +203,46 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Money : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Financial
+{
+    using System;
     using System.Globalization;
 
     public partial struct Money

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -225,6 +225,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Gender : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct Gender

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -226,6 +226,46 @@ namespace Qowaiv.Globalization
 namespace Qowaiv.Globalization
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Country : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Globalization
+{
+    using System;
     using System.Globalization;
 
     public partial struct Country

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -225,6 +225,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct HouseNumber : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct HouseNumber

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -207,6 +207,46 @@ namespace Qowaiv.IO
 namespace Qowaiv.IO
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct StreamSize : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.IO
+{
+    using System;
     using System.Globalization;
 
     public partial struct StreamSize

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -229,6 +229,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct LocalDateTime : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct LocalDateTime

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -225,6 +225,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Month : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct Month

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -206,6 +206,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Percentage : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct Percentage

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -226,6 +226,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct PostalCode : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct PostalCode

--- a/src/Qowaiv/Generated/Security/Cryptography/CryptographicSeed.generated.cs
+++ b/src/Qowaiv/Generated/Security/Cryptography/CryptographicSeed.generated.cs
@@ -230,6 +230,46 @@ namespace Qowaiv.Security.Cryptography
 namespace Qowaiv.Security.Cryptography
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct CryptographicSeed : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Security.Cryptography
+{
+    using System;
     using System.Globalization;
 
     public partial struct CryptographicSeed

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -228,6 +228,46 @@ namespace Qowaiv.Statistics
 namespace Qowaiv.Statistics
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Elo : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Statistics
+{
+    using System;
     using System.Globalization;
 
     public partial struct Elo

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -229,6 +229,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Uuid : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct Uuid

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -227,6 +227,46 @@ namespace Qowaiv.Web
 namespace Qowaiv.Web
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct InternetMediaType : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv.Web
+{
+    using System;
     using System.Globalization;
 
     public partial struct InternetMediaType

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -202,6 +202,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct WeekDate : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct WeekDate

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -225,6 +225,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct Year : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct Year

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -226,6 +226,46 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
+    using System.Collections.Generic;
+
+    public partial struct YesNo : IConvertible
+    {
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
+    }
+}
+
+namespace Qowaiv
+{
+    using System;
     using System.Globalization;
 
     public partial struct YesNo

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -231,10 +231,17 @@ namespace Qowaiv.Globalization
         public static explicit operator Country(string str) => Parse(str, CultureInfo.CurrentCulture);
 
         /// <summary>Casts a System.Globalization.RegionInfo to a </summary>
-        public static implicit operator Country(RegionInfo region) { return Create(region); }
+        public static implicit operator Country(RegionInfo region) => Create(region);
 
         /// <summary>Casts a Country to a System.Globalization.RegionInf.</summary>
-        public static explicit operator RegionInfo(Country val) { return val.ToRegionInfo(); }
+        public static explicit operator RegionInfo(Country val) =>val.ToRegionInfo();
+
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value ?? string.Empty;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.String;
 
         /// <summary>Converts the string to a 
         /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -142,6 +142,13 @@ namespace Qowaiv
         /// <summary>Casts a System.Int64 to a house number.</summary>
         public static implicit operator HouseNumber(long val) => Create((int)val);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Int32;
+
         /// <summary>Converts the string to a house number.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -529,6 +529,13 @@ namespace Qowaiv.IO
         /// <summary>Casts a System.DoubleDecimal to a stream size.</summary>
         public static explicit operator StreamSize(decimal val) => new StreamSize((long)val);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Int64;
+
         /// <summary>Converts the string to a stream size.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -544,6 +544,13 @@ namespace Qowaiv
 
         #endregion
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.DateTime;
+
         /// <summary>Converts the string to a local date time.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -183,6 +183,13 @@ namespace Qowaiv
 
         private string ToDefaultString() => IsUnknown() ? "?" : string.Empty;
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Byte;
+
         /// <summary>The format token instructions.</summary>
         private static readonly Dictionary<char, Func<Month, IFormatProvider, string>> FormatTokens = new Dictionary<char, Func<Month, IFormatProvider, string>>
         {

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -677,6 +677,13 @@ namespace Qowaiv
 
         #endregion
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Decimal;
+
         /// <summary>Converts the string to a Percentage.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -110,6 +110,13 @@ namespace Qowaiv
         /// <summary>Casts a <see cref="string"/> to a postal code.</summary>
         public static explicit operator PostalCode(string str) => Parse(str, CultureInfo.CurrentCulture);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value ?? string.Empty;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.String;
+
         /// <summary>Converts the string to a postal code.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -125,6 +125,13 @@ namespace Qowaiv.Security.Cryptography
         /// <summary>Casts a System.byte[] to a cryptographic seed.</summary>
         public static implicit operator CryptographicSeed(byte[] bytes) => Create(bytes);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => ToString(CultureInfo.InvariantCulture);
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.String;
+
         /// <summary>Converts the string to a cryptographic seed.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -186,6 +186,13 @@ namespace Qowaiv.Statistics
         /// <summary>Casts an Elo to an integer.</summary>
         public static explicit operator int(Elo val) => (int)Math.Round(val.m_Value);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Double;
+
         /// <summary>Converts the string to an Elo.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -140,6 +140,13 @@ namespace Qowaiv
         /// <summary>Casts a System.GUID to a Qowaiv.UUID.</summary>
         public static implicit operator Uuid(Guid val) => new Uuid(val);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => ToString(CultureInfo.InvariantCulture);
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.String;
+
         /// <summary>Initializes a new instance of a UUID.</summary>
         public static Uuid NewUuid() => new Uuid(Guid.NewGuid());
 

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -173,6 +173,13 @@ namespace Qowaiv.Web
         /// <summary>Casts a <see cref="string"/> to a Internet media type.</summary>
         public static explicit operator InternetMediaType(string str) { return InternetMediaType.Parse(str); }
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value ?? string.Empty;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.String;
+
         /// <summary>Converts the string to an Internet media type.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -256,6 +256,13 @@ namespace Qowaiv
         /// <summary>Casts a local date time to a week date.</summary>
         public static explicit operator WeekDate(LocalDateTime val) { return Create(val.Date); }
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.DateTime;
+
         /// <summary>Converts the string to a week date.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -121,6 +121,13 @@ namespace Qowaiv
         /// <summary>Casts an System.Int32 to a year.</summary>
         public static implicit operator Year(int val) => Create(val);
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => m_Value;
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Int16;
+
         /// <summary>Converts the string to a year.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -153,6 +153,13 @@ namespace Qowaiv
             return Empty;
         }
 
+        /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IConvertible Convertable => IsYes();
+
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Boolean;
+
         private static readonly bool?[] BooleanValues = new bool?[] { null, false, true, null };
 
         /// <summary>Converts the string to a yes-no.

--- a/test/Qowaiv.UnitTests/ConvertableTest.cs
+++ b/test/Qowaiv.UnitTests/ConvertableTest.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using Qowaiv.Reflection;
 using System;
 using System.Globalization;
 using System.Linq;
@@ -7,16 +8,57 @@ namespace Qowaiv.Tests
 {
     public class ConvertableTest
     {
-        internal static readonly Type[] Convertables = typeof(Date).Assembly
+        internal static readonly Type[] Svos = typeof(Date).Assembly
             .GetTypes()
-            .Where(tp => !tp.IsEnum && tp.GetInterfaces().Any(i => i == typeof(IConvertible)))
-            .OrderBy(tp => tp.FullName)
+            .Where(tp => QowaivType.IsSingleValueObject(tp))
+            .OrderBy(tp => tp.Namespace)
+            .ThenBy(tp => tp.Name)
             .ToArray();
+        
+        internal static readonly Type[] Convertibles = Svos
+            .Except(new[] 
+            { 
+                typeof(DateSpan),
+            })
+            .ToArray();
+
+        /// <summary>This test should prevent us from forgetting to implement IConvertable.</summary>
+        [Test]
+        public void AllSvosImplementIConvertible()
+        {
+            var expected = new[]
+            {
+                typeof(Date),
+                typeof(EmailAddress),
+                typeof(Gender),
+                typeof(HouseNumber),
+                typeof(LocalDateTime),
+                typeof(Month),
+                typeof(Percentage),
+                typeof(PostalCode),
+                typeof(Uuid),
+                typeof(WeekDate),
+                typeof(Year),
+                typeof(YesNo),
+                typeof(Financial.Amount),
+                typeof(Financial.BusinessIdentifierCode),
+                typeof(Financial.Currency),
+                typeof(Financial.InternationalBankAccountNumber),
+                typeof(Financial.Money),
+                typeof(Globalization.Country),
+                typeof(IO.StreamSize),
+                typeof(Security.Cryptography.CryptographicSeed),
+                typeof(Statistics.Elo),
+                typeof(Web.InternetMediaType),
+            };
+            CollectionAssert.AreEqual(expected, Convertibles);
+        }
 
         [TestCase(typeof(Date), TypeCode.DateTime)]
         [TestCase(typeof(EmailAddress), TypeCode.String)]
         [TestCase(typeof(Gender), TypeCode.Int32)]
         [TestCase(typeof(HouseNumber), TypeCode.Int32)]
+        [TestCase(typeof(LocalDateTime), TypeCode.DateTime)]
         [TestCase(typeof(Month), TypeCode.Byte)]
         [TestCase(typeof(Percentage), TypeCode.Decimal)]
         [TestCase(typeof(PostalCode), TypeCode.String)]

--- a/test/Qowaiv.UnitTests/ConvertableTest.cs
+++ b/test/Qowaiv.UnitTests/ConvertableTest.cs
@@ -1,0 +1,81 @@
+﻿using NUnit.Framework;
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace Qowaiv.Tests
+{
+    public class ConvertableTest
+    {
+        internal static readonly Type[] Convertables = typeof(Date).Assembly
+            .GetTypes()
+            .Where(tp => !tp.IsEnum && tp.GetInterfaces().Any(i => i == typeof(IConvertible)))
+            .OrderBy(tp => tp.FullName)
+            .ToArray();
+
+        [TestCase(typeof(Date), TypeCode.DateTime)]
+        [TestCase(typeof(EmailAddress), TypeCode.String)]
+        [TestCase(typeof(Gender), TypeCode.Int32)]
+        [TestCase(typeof(HouseNumber), TypeCode.Int32)]
+        [TestCase(typeof(Month), TypeCode.Byte)]
+        [TestCase(typeof(Percentage), TypeCode.Decimal)]
+        [TestCase(typeof(PostalCode), TypeCode.String)]
+        [TestCase(typeof(Uuid), TypeCode.String)]
+        [TestCase(typeof(WeekDate), TypeCode.DateTime)]
+        [TestCase(typeof(Year), TypeCode.Int16)]
+        [TestCase(typeof(YesNo), TypeCode.Boolean)]
+        [TestCase(typeof(Security.Cryptography.CryptographicSeed), TypeCode.String)]
+        [TestCase(typeof(Statistics.Elo), TypeCode.Double)]
+        [TestCase(typeof(Financial.Amount), TypeCode.Decimal)]
+        [TestCase(typeof(Financial.BusinessIdentifierCode), TypeCode.String)]
+        [TestCase(typeof(Financial.Currency), TypeCode.String)]
+        [TestCase(typeof(Financial.InternationalBankAccountNumber), TypeCode.String)]
+        [TestCase(typeof(Financial.Money), TypeCode.Decimal)]
+        [TestCase(typeof(IO.StreamSize), TypeCode.Int64)]
+        [TestCase(typeof(Globalization.Country), TypeCode.String)]
+        [TestCase(typeof(Web.InternetMediaType), TypeCode.String)]
+        public void HasTypeCode(Type type, TypeCode expected)
+        {
+            var instance = (IConvertible)Activator.CreateInstance(type);
+            var typeCode = instance.GetTypeCode();
+            Assert.AreEqual(expected, typeCode);
+        }
+
+        [TestCase(typeof(Gender), 0.0)]
+        [TestCase(typeof(HouseNumber), 0.0)]
+        [TestCase(typeof(Month), 0.0)]
+        [TestCase(typeof(Percentage), 0.0)]
+        [TestCase(typeof(Year), 0.0)]
+        [TestCase(typeof(YesNo), 0.0)]
+        [TestCase(typeof(Statistics.Elo), 0.0)]
+        [TestCase(typeof(Financial.Amount), 0.0)]
+        [TestCase(typeof(Financial.Money), 0.0)]
+        [TestCase(typeof(IO.StreamSize), 0.0)]
+        public void ToDecimal(Type type, decimal expected)
+        {
+            var instance = (IConvertible)Activator.CreateInstance(type);
+            var converted = instance.ToDecimal(CultureInfo.InvariantCulture);
+            Assert.AreEqual(expected, converted);
+        }
+
+        [TestCase(typeof(Date))]
+        [TestCase(typeof(EmailAddress))]
+        [TestCase(typeof(LocalDateTime))]
+        [TestCase(typeof(PostalCode))]
+        [TestCase(typeof(Uuid))]
+        [TestCase(typeof(WeekDate))]
+        [TestCase(typeof(Security.Cryptography.CryptographicSeed))]
+        [TestCase(typeof(Financial.BusinessIdentifierCode))]
+        [TestCase(typeof(Financial.Currency))]
+        [TestCase(typeof(Financial.InternationalBankAccountNumber))]
+        [TestCase(typeof(Globalization.Country))]
+        [TestCase(typeof(Web.InternetMediaType))]
+        public void ToDecimal_Throws(Type type)
+        {
+            var instance = (IConvertible)Activator.CreateInstance(type);
+            var exeception = Assert.Catch(()=> instance.ToDecimal(CultureInfo.InvariantCulture));
+            var x = exeception.GetType();
+            Assert.IsTrue(x == typeof(FormatException) || x == typeof(InvalidCastException), "Actual: {0}", exeception);
+        }
+    }
+}


### PR DESCRIPTION
The `IConvertable` interface has limited value for other types than the .NET primitives. However, for some old constructs (like VB.NET's `CStr()`), just having an basic implementation helps.

For that reason, all methods required by the interface are only explicitly accessable.