### PR TITLE
Invalid casts should throw cast exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Multiple scenarios are supported:
 * Serialization (JSON, XML, in-memory)
 * Model binding
 * Domain-specific logic
+* Explicit and implicit casting
 
 ## Qowaiv types
 

--- a/src/Qowaiv/Cast.cs
+++ b/src/Qowaiv/Cast.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Globalization;
+
+namespace Qowaiv
+{
+    /// <summary>TryCreate factory method.</summary>
+    internal delegate bool TryCreate<TPrimitive, TSvo>(TPrimitive? value, out TSvo result) where TPrimitive : struct;
+
+    /// <summary>Culture dependent TryParse factory method.</summary>
+    internal delegate bool TryParse<TSvo>(string str, IFormatProvider formatProvider, out TSvo result);
+
+    /// <summary>Culture independent TryParse factory method.</summary>
+    internal delegate bool TryParseInvariant<TSvo>(string str, out TSvo result);
+
+    /// <summary>Helper class to facilitate <see cref="InvalidCastException"/> on SVO casting.</summary>
+    internal static class Cast
+    {
+        /// <summary>Casts from a primitive (not <see cref="string"/>) to a SVO.</summary>
+        public static TSvo Primitive<TPrimitive, TSvo>(TryCreate<TPrimitive, TSvo> tryCreate, TPrimitive? value)
+            where TPrimitive : struct
+        {
+            if (tryCreate(value, out TSvo result))
+            {
+                return result;
+            }
+            throw Exceptions.InvalidCast<TPrimitive, TSvo>();
+        }
+
+        /// <summary>Casts from a <see cref="string"/> to a SVO.</summary>
+        public static TSvo String<TSvo>(TryParse<TSvo> tryParse, string str)
+        {
+            if (tryParse(str, CultureInfo.InvariantCulture, out TSvo result))
+            {
+                return result;
+            }
+            throw Exceptions.InvalidCast<string, TSvo>();
+        }
+
+        /// <summary>Casts from a <see cref="string"/> that is not culture dependent to a SVO.</summary>
+        public static TSvo InvariantString<TSvo>(TryParseInvariant<TSvo> tryParse, string str)
+        {
+            if (tryParse(str, out TSvo result))
+            {
+                return result;
+            }
+            throw Exceptions.InvalidCast<string, TSvo>();
+        }
+
+        /// <summary>Casts a <see cref="double"/> to <see cref="decimal"/> for the SVO.</summary>
+        public static decimal ToDecimal<TSvo>(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value < (double)decimal.MinValue || value > (double)decimal.MaxValue)
+            {
+                throw Exceptions.InvalidCast<double, TSvo>();
+            }
+
+            return (decimal)value;
+        }
+    }
+}

--- a/src/Qowaiv/Cast.cs
+++ b/src/Qowaiv/Cast.cs
@@ -29,7 +29,7 @@ namespace Qowaiv
         /// <summary>Casts from a <see cref="string"/> to a SVO.</summary>
         public static TSvo String<TSvo>(TryParse<TSvo> tryParse, string str)
         {
-            if (tryParse(str, CultureInfo.InvariantCulture, out TSvo result))
+            if (tryParse(str, CultureInfo.CurrentCulture, out TSvo result))
             {
                 return result;
             }

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -39,7 +39,7 @@ namespace Qowaiv
         public static Date Tomorrow => Clock.Tomorrow();
 
         #region Constructors
-           
+
         /// <summary>Initializes a new instance of the date structure to a specified number of ticks.</summary>
         /// <param name="ticks">
         /// A date expressed in 100-nanosecond units.
@@ -404,14 +404,14 @@ namespace Qowaiv
         public static implicit operator DateTime(Date val) => val.m_Value;
 
         /// <summary>Casts a <see cref="string"/> to a date.</summary>
-        public static explicit operator Date(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Date(string str) => Cast.String<Date>(TryParse, str);
         /// <summary>Casts a date time to a date.</summary>
-        public static explicit operator Date(DateTime val) { return new Date(val); }
+        public static explicit operator Date(DateTime val) => new Date(val);
 
         /// <summary>Casts a local date time to a date.</summary>
-        public static explicit operator Date(LocalDateTime val) { return val.Date; }
+        public static explicit operator Date(LocalDateTime val) => val.Date;
         /// <summary>Casts a week date to a date.</summary>
-        public static implicit operator Date(WeekDate val) { return val.Date; }
+        public static implicit operator Date(WeekDate val) => val.Date;
 
         #endregion
 

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -182,7 +182,7 @@ namespace Qowaiv
         /// <summary>Casts an email address to a <see cref="string"/>.</summary>
         public static explicit operator string(EmailAddress val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a email address.</summary>
-        public static explicit operator EmailAddress(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator EmailAddress(string str) => Cast.String<EmailAddress>(TryParse, str);
 
         /// <summary>Converts the string to an email address.
         /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Exceptions.cs
+++ b/src/Qowaiv/Exceptions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Globalization;
+
+namespace Qowaiv
+{
+    /// <summary>Helper for creating <see cref="Exception"/>'s.</summary>
+    internal static class Exceptions
+    {
+
+        /// <summary>Creates an <see cref="InvalidCastException"/>.</summary>
+        public static InvalidCastException InvalidCast<TFrom, TTo>() => InvalidCast(typeof(TFrom), typeof(TTo));
+
+        /// <summary>Creates an <see cref="InvalidCastException"/>.</summary>
+        public static InvalidCastException InvalidCast(Type from, Type to)
+        {
+            return new InvalidCastException(string.Format(
+                CultureInfo.CurrentCulture,
+                QowaivMessages.InvalidCastException_FromTo,
+                from,
+                to));
+        }
+    }
+}

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -379,7 +379,7 @@ namespace Qowaiv.Financial
         /// <returns>
         /// The deserialized amount.
         /// </returns>
-        public static Amount FromJson(double json) => new Amount((decimal)json);
+        public static Amount FromJson(double json) => new Amount(Cast.ToDecimal<Amount>(json));
 
         /// <summary>Deserializes the amountfrom a JSON number.</summary>
         /// <param name="json">
@@ -394,7 +394,7 @@ namespace Qowaiv.Financial
         /// <summary>Casts an Amount to a <see cref="string"/>.</summary>
         public static explicit operator string(Amount val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a </summary>
-        public static explicit operator Amount(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Amount(string str) => Cast.String<Amount>(TryParse, str);
 
         /// <summary>Casts a decimal an </summary>
         public static explicit operator Amount(decimal val) => Create(val);
@@ -457,6 +457,6 @@ namespace Qowaiv.Financial
         /// <param name="val" >
         /// A decimal describing an Amount.
         /// </param >
-        public static Amount Create(double val) => Create((decimal)val);
+        public static Amount Create(double val) => Create(Cast.ToDecimal<Amount>(val));
     }
 }

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -117,7 +117,7 @@ namespace Qowaiv.Financial
         /// <summary>Casts a BIC to a <see cref="string"/>.</summary>
         public static explicit operator string(BusinessIdentifierCode val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a BIC.</summary>
-        public static explicit operator BusinessIdentifierCode(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator BusinessIdentifierCode(string str) => Cast.String<BusinessIdentifierCode>(TryParse, str);
 
 
         /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>

--- a/src/Qowaiv/Financial/Currency.cs
+++ b/src/Qowaiv/Financial/Currency.cs
@@ -222,10 +222,10 @@ namespace Qowaiv.Financial
         /// <summary>Casts a currency to a <see cref="string"/>.</summary>
         public static explicit operator string(Currency val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a currency.</summary>
-        public static explicit operator Currency(string str) =>Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Currency(string str) => Cast.String<Currency>(TryParse, str);
 
         /// <summary>Casts a currency to a <see cref="string"/>.</summary>
-        public static explicit operator int(Currency val) { return val.IsoNumericCode; }
+        public static explicit operator int(Currency val) => val.IsoNumericCode;
 
         /// <summary>Casts a <see cref="string"/> to a currency.</summary>
         public static explicit operator Currency(int val) => AllCurrencies.FirstOrDefault(c => c.IsoNumericCode == val);
@@ -271,7 +271,7 @@ namespace Qowaiv.Financial
 
             if (Parsings[culture].TryGetValue(str, out string val) || Parsings[CultureInfo.InvariantCulture].TryGetValue(str, out val))
             {
-                result = new Currency( val );
+                result = new Currency(val);
                 return true;
             }
             foreach (var currency in AllCurrencies.Where(c => !string.IsNullOrEmpty(c.Symbol)))
@@ -430,7 +430,7 @@ namespace Qowaiv.Financial
         /// <summary>Creates money based on the amount and the currency.</summary>
         public static Money operator +(decimal val, Currency currency) => Money.Create(val, currency);
         /// <summary>Creates money based on the amount and the currency.</summary>
-        public static Money operator +(double val, Currency currency) => Money.Create((decimal)val, currency);
+        public static Money operator +(double val, Currency currency) => Money.Create(Cast.ToDecimal<Money>(val), currency);
         /// <summary>Creates money based on the amount and the currency.</summary>
         public static Money operator +(int val, Currency currency) => Money.Create(val, currency);
 

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -169,9 +169,9 @@ namespace Qowaiv.Financial
         private string ToXmlString() => ToUnformattedString();
 
         /// <summary>Casts an IBAN to a <see cref="string"/>.</summary>
-        public static explicit operator string(InternationalBankAccountNumber val) => val.ToString();
+        public static explicit operator string(InternationalBankAccountNumber val) => val.ToString(CultureInfo.InvariantCulture);
         /// <summary>Casts a <see cref="string"/> to a IBAN.</summary>
-        public static explicit operator InternationalBankAccountNumber(string str) => Parse(str, CultureInfo.InvariantCulture);
+        public static explicit operator InternationalBankAccountNumber(string str) => Cast.String<InternationalBankAccountNumber>(TryParse, str);
 
         /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -473,7 +473,7 @@ namespace Qowaiv.Financial
         /// <summary>Casts Money to a <see cref="string"/>.</summary>
         public static explicit operator string(Money val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a </summary>
-        public static explicit operator Money(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Money(string str) => Cast.String<Money>(TryParse, str);
 
         /// <summary>Casts Money to a decimal.</summary>
         public static explicit operator Amount(Money val) => (Amount)val.m_Value;

--- a/src/Qowaiv/Gender.cs
+++ b/src/Qowaiv/Gender.cs
@@ -152,19 +152,19 @@ namespace Qowaiv
         /// <summary>Casts a Gender to a <see cref="string"/>.</summary>
         public static explicit operator string(Gender val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a Gender.</summary>
-        public static explicit operator Gender(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Gender(string str) => Cast.String<Gender>(TryParse, str);
 
         /// <summary>Casts a Gender to a <see cref="byte"/>.</summary>
         public static explicit operator byte(Gender val) => (byte)val.ToInt32();
         /// <summary>Casts a Gender to a <see cref="int"/>.</summary>
         public static explicit operator int(Gender val) => val.ToInt32();
         /// <summary>Casts an <see cref="int"/> to a Gender.</summary>
-        public static implicit operator Gender(int val) => Create(val);
+        public static implicit operator Gender(int val) => Cast.Primitive<int, Gender>(TryCreate, val);
 
         /// <summary>Casts a Gender to a <see cref="int"/>.</summary>
         public static explicit operator int?(Gender val) => val.ToNullableInt32();
         /// <summary>Casts an <see cref="int"/> to a Gender.</summary>
-        public static implicit operator Gender(int? val) => Create(val);
+        public static implicit operator Gender(int? val) => Cast.Primitive<int, Gender>(TryCreate, val);
 
         /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -257,7 +257,7 @@ namespace Qowaiv
         /// </returns>
         public static bool TryCreate(int? val, out Gender result)
         {
-            result = Gender.Empty;
+            result = Empty;
 
             byte b = 0;
 

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -41,7 +41,7 @@ namespace Qowaiv.Globalization
         public static readonly Country Unknown = new Country("ZZ");
 
         /// <summary>Gets a country based on the current thread.</summary>
-        public static Country Current=>Thread.CurrentThread.GetValue<Country>();
+        public static Country Current => Thread.CurrentThread.GetValue<Country>();
 
         /// <summary>Gets the name of the country.</summary>
         /// <remarks>
@@ -64,31 +64,31 @@ namespace Qowaiv.Globalization
         /// <returns>
         /// The two-letter code defined in ISO 3166-1 for the country.
         /// </returns>
-        public string IsoAlpha2Code=> GetResourceString("ISO2", CultureInfo.InvariantCulture); 
+        public string IsoAlpha2Code => GetResourceString("ISO2", CultureInfo.InvariantCulture);
 
         ///<summary>Gets the three-letter code defined in ISO 3166-1 for the country.</summary>
         /// <returns>
         /// The three-letter code defined in ISO 3166-1 for the country.
         /// </returns>
-        public string IsoAlpha3Code=>GetResourceString("ISO3", CultureInfo.InvariantCulture); 
+        public string IsoAlpha3Code => GetResourceString("ISO3", CultureInfo.InvariantCulture);
 
         ///<summary>Gets the numeric code defined in ISO 3166-1 for the country/region.</summary>
         /// <returns>
         /// The numeric code defined in ISO 3166-1 for the country/region.
         /// </returns>
-        public int IsoNumericCode => m_Value == default ? 0 : XmlConvert.ToInt32(GetResourceString("ISO", CultureInfo.InvariantCulture)); 
+        public int IsoNumericCode => m_Value == default ? 0 : XmlConvert.ToInt32(GetResourceString("ISO", CultureInfo.InvariantCulture));
 
         /// <summary>Gets the country calling code as defined by ITU-T.</summary>
         /// <remarks>
         /// Recommendations E.123 and E.164, also called IDD (International Direct Dialing) or ISD (International Subscriber Dialling) codes.
         /// </remarks>
-        public string CallingCode => GetResourceString("CallingCode", CultureInfo.InvariantCulture); 
+        public string CallingCode => GetResourceString("CallingCode", CultureInfo.InvariantCulture);
 
         ///<summary>Gets true if the RegionInfo equivalent of this country exists, otherwise false.</summary>
         public bool RegionInfoExists => !string.IsNullOrEmpty(GetResourceString("RegionInfoExists", CultureInfo.InvariantCulture));
 
         /// <summary>Gets the start date from witch the country exists.</summary>
-        public Date StartDate=> m_Value == default ? Date.MinValue : (Date)XmlConvert.ToDateTime(GetResourceString("StartDate", CultureInfo.InvariantCulture), "yyyy-MM-dd");
+        public Date StartDate => m_Value == default ? Date.MinValue : (Date)XmlConvert.ToDateTime(GetResourceString("StartDate", CultureInfo.InvariantCulture), "yyyy-MM-dd");
 
         /// <summary>If the country does not exist anymore, the end date is given, otherwise null.</summary>
         public Date? EndDate
@@ -228,13 +228,13 @@ namespace Qowaiv.Globalization
         /// <summary>Casts a Country to a <see cref="string"/>.</summary>
         public static explicit operator string(Country val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a </summary>
-        public static explicit operator Country(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Country(string str) => Cast.String<Country>(TryParse, str);
 
         /// <summary>Casts a System.Globalization.RegionInfo to a </summary>
         public static implicit operator Country(RegionInfo region) => Create(region);
 
         /// <summary>Casts a Country to a System.Globalization.RegionInf.</summary>
-        public static explicit operator RegionInfo(Country val) =>val.ToRegionInfo();
+        public static explicit operator RegionInfo(Country val) => val.ToRegionInfo();
 
         /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -280,7 +280,7 @@ namespace Qowaiv.Globalization
 
             if (Parsings[culture].TryGetValue(str, out string val) || Parsings[CultureInfo.InvariantCulture].TryGetValue(str, out val))
             {
-                result = new Country( val );
+                result = new Country(val);
                 return true;
             }
             return false;

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -130,17 +130,17 @@ namespace Qowaiv
         /// <summary>Casts a house number to a <see cref="string"/>.</summary>
         public static explicit operator string(HouseNumber val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a house number.</summary>
-        public static explicit operator HouseNumber(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator HouseNumber(string str) => Cast.String<HouseNumber>(TryParse, str);
 
         /// <summary>Casts a house number to a System.Int32.</summary>
         public static explicit operator int(HouseNumber val) => val.m_Value;
         /// <summary>Casts an System.Int32 to a house number.</summary>
-        public static implicit operator HouseNumber(int val) => Create(val);
+        public static implicit operator HouseNumber(int val) => Cast.Primitive<int, HouseNumber>(TryCreate, val);
 
         /// <summary>Casts a house number to a System.Int64.</summary>
         public static explicit operator long(HouseNumber val) => val.m_Value;
         /// <summary>Casts a System.Int64 to a house number.</summary>
-        public static implicit operator HouseNumber(long val) => Create((int)val);
+        public static implicit operator HouseNumber(long val) => Cast.Primitive<int, HouseNumber>(TryCreate, (int)val);
 
         /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -506,8 +506,7 @@ namespace Qowaiv.IO
         /// <summary>Casts a stream size to a <see cref="string"/>.</summary>
         public static explicit operator string(StreamSize val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a stream size.</summary>
-        public static explicit operator StreamSize(string str) => Parse(str, CultureInfo.CurrentCulture);
-
+        public static explicit operator StreamSize(string str) => Cast.String<StreamSize>(TryParse, str);
 
         /// <summary>Casts a stream size to a System.Int32.</summary>
         public static explicit operator int(StreamSize val) => (int)val.m_Value;

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -514,14 +514,14 @@ namespace Qowaiv
 
 
         /// <summary>Casts a <see cref="string"/> to a local date time.</summary>
-        public static explicit operator LocalDateTime(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator LocalDateTime(string str) => Cast.String<LocalDateTime>(TryParse, str);
         /// <summary>Casts a date time to a local date time.</summary>
-        public static implicit operator LocalDateTime(DateTime val) { return new LocalDateTime(val); }
+        public static implicit operator LocalDateTime(DateTime val) => new LocalDateTime(val);
 
         /// <summary>Casts a date to a local date time.</summary>
-        public static explicit operator LocalDateTime(Date val) { return new LocalDateTime(val); }
+        public static explicit operator LocalDateTime(Date val) => new LocalDateTime(val);
         /// <summary>Casts a week date to a week date.</summary>
-        public static implicit operator LocalDateTime(WeekDate val) { return (LocalDateTime)val.Date; }
+        public static implicit operator LocalDateTime(WeekDate val) => (LocalDateTime)val.Date;
 
         #endregion
 

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -200,13 +200,13 @@ namespace Qowaiv
         /// <summary>Casts a month to a <see cref="string"/>.</summary>
         public static explicit operator string(Month val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a month.</summary>
-        public static explicit operator Month(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Month(string str) => Cast.String<Month>(TryParse, str);
 
 
         /// <summary>Casts a month to a System.Int32.</summary>
         public static explicit operator int(Month val) => val.m_Value;
         /// <summary>Casts an System.Int32 to a month.</summary>
-        public static implicit operator Month(int val) => Create(val);
+        public static implicit operator Month(int val) => Cast.Primitive<int, Month>(TryCreate, val);
 
         /// <summary>Converts the string to a month.
         /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -558,7 +558,7 @@ namespace Qowaiv
         /// <returns>
         /// The deserialized percentage.
         /// </returns>
-        public static Percentage FromJson(double json) => new Percentage((decimal)json);
+        public static Percentage FromJson(double json) => new Percentage(Cast.ToDecimal<Percentage>(json));
 
         /// <summary>Serializes the percentage to a JSON node.</summary>
         /// <returns>
@@ -662,8 +662,7 @@ namespace Qowaiv
         /// <summary>Casts a Percentage to a <see cref="string"/>.</summary>
         public static explicit operator string(Percentage val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a Percentage.</summary>
-        public static explicit operator Percentage(string str) => Parse(str, CultureInfo.CurrentCulture);
-
+        public static explicit operator Percentage(string str) => Cast.String<Percentage>(TryParse, str);
 
         /// <summary>Casts a decimal a Percentage.</summary>
         public static implicit operator Percentage(decimal val) => Create(val);
@@ -722,13 +721,13 @@ namespace Qowaiv
         /// <param name="val" >
         /// A decimal describing a Percentage.
         /// </param >
-        public static Percentage Create(decimal val) => new Percentage { m_Value = val };
+        public static Percentage Create(decimal val) => new Percentage(val);
 
         /// <summary>Creates a Percentage from a Double.</summary >
         /// <param name="val" >
         /// A decimal describing a Percentage.
         /// </param >
-        public static Percentage Create(double val) => Create((decimal)val);
+        public static Percentage Create(double val) => Create(Cast.ToDecimal<Percentage>(val));
 
         #region Parsing Helpers
 

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -108,7 +108,7 @@ namespace Qowaiv
         /// <summary>Casts a postal code to a <see cref="string"/>.</summary>
         public static explicit operator string(PostalCode val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a postal code.</summary>
-        public static explicit operator PostalCode(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator PostalCode(string str) => Cast.String<PostalCode>(TryParse, str);
 
         /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -116,9 +116,9 @@ namespace Qowaiv.Security.Cryptography
         }
 
         /// <summary>Casts a cryptographic seed to a <see cref="string"/>.</summary>
-        public static explicit operator string(CryptographicSeed val) => val.ToString();
+        public static explicit operator string(CryptographicSeed val) => val.ToString(CultureInfo.InvariantCulture);
         /// <summary>Casts a <see cref="string"/> to a cryptographic seed.</summary>
-        public static explicit operator CryptographicSeed(string str) => Parse(str);
+        public static explicit operator CryptographicSeed(string str) => Cast.InvariantString<CryptographicSeed>(TryParse, str);
 
         /// <summary>Casts a cryptographic seed to a System.byte[].</summary>
         public static explicit operator byte[](CryptographicSeed val) => val.ToByteArray();
@@ -173,7 +173,7 @@ namespace Qowaiv.Security.Cryptography
             var bytes = new byte[val.Length];
             Array.Copy(val, bytes, val.Length);
 
-            return new CryptographicSeed { m_Value = bytes };
+            return new CryptographicSeed(bytes);
         }
 
         /// <summary>Creates a cryptographic seed from a GUID.</summary >

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -170,12 +170,12 @@ namespace Qowaiv.Statistics
         /// <summary>Casts an Elo to a <see cref="string"/>.</summary>
         public static explicit operator string(Elo val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a Elo.</summary>
-        public static explicit operator Elo(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Elo(string str) => Cast.String<Elo>(TryParse, str);
 
         /// <summary>Casts a decimal to an Elo.</summary>
         public static implicit operator Elo(decimal val) => new Elo((double)val);
         /// <summary>Casts a decimal to an Elo.</summary>
-        public static implicit operator Elo(double val) => new Elo(val);
+        public static implicit operator Elo(double val) => Create(val);
         /// <summary>Casts an integer to an Elo.</summary>
         public static implicit operator Elo(int val) => new Elo(val);
 

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -133,7 +133,7 @@ namespace Qowaiv
         /// <summary>Casts a UUID to a <see cref="string"/>.</summary>
         public static explicit operator string(Uuid val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a UUID.</summary>
-        public static explicit operator Uuid(string str) => Parse(str);
+        public static explicit operator Uuid(string str) => Cast.InvariantString<Uuid>(TryParse, str);
 
         /// <summary>Casts a Qowaiv.UUID to a System.GUID.</summary>
         public static implicit operator Guid(Uuid val) => val.m_Value;
@@ -240,9 +240,9 @@ namespace Qowaiv
         public static Uuid GenerateWithMD5(byte[] data)
         {
             Guard.NotNull(data, nameof(data));
-            
+
             using var md5 = MD5.Create();
-            
+
             var hash = md5.ComputeHash(data);
             UuidExtensions.SetVersion(hash, UuidVersion.MD5);
             return new Guid(hash);
@@ -252,9 +252,9 @@ namespace Qowaiv
         public static Uuid GenerateWithSHA1(byte[] data)
         {
             Guard.NotNull(data, nameof(data));
-            
+
             using var sha1 = SHA1.Create();
-            
+
             var bytes = sha1.ComputeHash(data);
             var hash = new byte[ArraySize];
             Array.Copy(bytes, hash, ArraySize);

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -171,7 +171,7 @@ namespace Qowaiv.Web
         /// <summary>Casts an Internet media type to a <see cref="string"/>.</summary>
         public static explicit operator string(InternetMediaType val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a Internet media type.</summary>
-        public static explicit operator InternetMediaType(string str) { return InternetMediaType.Parse(str); }
+        public static explicit operator InternetMediaType(string str) => Cast.InvariantString<InternetMediaType>(TryParse, str);
 
         /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -247,14 +247,14 @@ namespace Qowaiv
         public static implicit operator DateTime(WeekDate val) => val.m_Value;
 
         /// <summary>Casts a <see cref="string"/> to a week date.</summary>
-        public static explicit operator WeekDate(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator WeekDate(string str) => Cast.String<WeekDate>(TryParse, str);
         /// <summary>Casts a date time to a week date.</summary>
-        public static explicit operator WeekDate(DateTime val) { return Create((Date)val); }
+        public static explicit operator WeekDate(DateTime val) => Create((Date)val);
 
         /// <summary>Casts a date to a week date.</summary>
         public static implicit operator WeekDate(Date val) => Create(val);
         /// <summary>Casts a local date time to a week date.</summary>
-        public static explicit operator WeekDate(LocalDateTime val) { return Create(val.Date); }
+        public static explicit operator WeekDate(LocalDateTime val) => Create(val.Date);
 
         /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -114,12 +114,13 @@ namespace Qowaiv
         /// <summary>Casts a year to a <see cref="string"/>.</summary>
         public static explicit operator string(Year val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a year.</summary>
-        public static explicit operator Year(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator Year(string str) => Cast.String<Year>(TryParse, str);
 
         /// <summary>Casts a year to a System.Int32.</summary>
         public static explicit operator int(Year val) => val.m_Value;
+
         /// <summary>Casts an System.Int32 to a year.</summary>
-        public static implicit operator Year(int val) => Create(val);
+        public static implicit operator Year(int val) => Cast.Primitive<int, Year>(TryCreate, val);
 
         /// <summary>Represents the underlying value as <see cref="IConvertible"/>.</summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -138,7 +138,7 @@ namespace Qowaiv
         /// <summary>Casts a yes-no to a <see cref="string"/>.</summary>
         public static explicit operator string(YesNo val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a <see cref="string"/> to a yes-no.</summary>
-        public static explicit operator YesNo(string str) => Parse(str, CultureInfo.CurrentCulture);
+        public static explicit operator YesNo(string str) => Cast.String<YesNo>(TryParse, str);
 
         /// <summary>Casts a yes-no to a nullable <see cref="bool"/>.</summary>
         public static explicit operator bool?(YesNo val) => BooleanValues[val.m_Value];
@@ -196,7 +196,7 @@ namespace Qowaiv
             if (Parsings[culture].TryGetValue(str, out byte val) ||
                 Parsings[CultureInfo.InvariantCulture].TryGetValue(str, out val))
             {
-                result = new YesNo { m_Value = val };
+                result = new YesNo(val);
                 return true;
             }
             return false;

--- a/test/Qowaiv.UnitTests/CastTest.cs
+++ b/test/Qowaiv.UnitTests/CastTest.cs
@@ -1,0 +1,87 @@
+﻿using NUnit.Framework;
+using Qowaiv.Financial;
+using System;
+using System.Diagnostics;
+
+namespace Qowaiv.UnitTests
+{
+    public class CastTest
+    {
+        private static readonly string InvalidString = "$%$!@$%$D!@@!!!!!";
+        private static readonly int InvalidInt = int.MinValue + 17;
+
+        [Test]
+        public void InvalidCast_DoubleMaxValueToPercentage() => AssertInvalidCast(() => (Percentage)double.MaxValue);
+        
+        [Test]
+        public void InvalidCast_DoubleMinValueToPercentage() => AssertInvalidCast(() => (Percentage)double.MinValue);
+
+        [Test]
+        public void InvalidCast_DoubleNaNToPercentage() => AssertInvalidCast(() => (Percentage)double.NaN);
+
+        [Test]
+        public void InvalidCast_DoubleNegativeInfinityToPercentage() => AssertInvalidCast(() => (Percentage)double.NegativeInfinity);
+
+        [Test]
+        public void InvalidCast_DoublePositiveInfinityToPercentage() => AssertInvalidCast(() => (Percentage)double.PositiveInfinity);
+
+        [Test]
+        public void InvalidCast_DoubleToAmount() => AssertInvalidCast(() => (Amount)double.MaxValue);
+
+        [Test]
+        public void InvalidCast_IntToHouseNumber() => AssertInvalidCast(() => (HouseNumber)InvalidInt);
+
+        [Test]
+        public void InvalidCast_IntToGender() => AssertInvalidCast(() => (Gender)InvalidInt);
+
+        [Test]
+        public void InvalidCast_IntToMonth() => AssertInvalidCast(() => (Month)InvalidInt);
+
+        [Test]
+        public void InvalidCast_IntToYear() => AssertInvalidCast(() => (Year)InvalidInt);
+
+        [Test]
+        public void InvalidCast_StringToDate() => AssertInvalidCast(() => (Date)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToEmail() => AssertInvalidCast(() => (EmailAddress)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToGender() => AssertInvalidCast(() => (Gender)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToHouseNumber() => AssertInvalidCast(() => (HouseNumber)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToLocalDateTime() => AssertInvalidCast(() => (LocalDateTime)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToMonth() => AssertInvalidCast(() => (Month)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToPercentage() => AssertInvalidCast(() => (Percentage)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToPostalCode() => AssertInvalidCast(() => (PostalCode)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToUuid() => AssertInvalidCast(() => (Uuid)InvalidString);
+        
+        [Test]
+        public void InvalidCast_StringToWeekDate() => AssertInvalidCast(() => (WeekDate)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToYear() => AssertInvalidCast(() => (Year)InvalidString);
+
+        [Test]
+        public void InvalidCast_StringToYesNo() => AssertInvalidCast(() => (YesNo)InvalidString);
+
+        /// <remarks>A cast can not be applied unless you assign it, therefore a <see cref="Func{TResult}"/>.</remarks>
+        [DebuggerStepThrough]
+        private static void AssertInvalidCast<TSvo>(Func<TSvo> cast)
+        {
+            var x = Assert.Catch<InvalidCastException>(() => cast());
+            StringAssert.IsMatch($"Cast from .+ to {typeof(TSvo)} is not valid.", x.Message);
+        }
+    }
+}

--- a/test/Qowaiv.UnitTests/DateTest.cs
+++ b/test/Qowaiv.UnitTests/DateTest.cs
@@ -644,10 +644,13 @@ namespace Qowaiv.UnitTests
         [Test]
         public void Explicit_StringToDate_AreEqual()
         {
-            var exp = TestStruct;
-            var act = (Date)TestStruct.ToString();
+            using (new CultureInfoScope("es-EQ"))
+            {
+                var exp = TestStruct;
+                var act = (Date)TestStruct.ToString(CultureInfo.CurrentCulture);
 
-            Assert.AreEqual(exp, act);
+                Assert.AreEqual(exp, act);
+            }
         }
         [Test]
         public void Explicit_DateToString_AreEqual()

--- a/test/Qowaiv.UnitTests/Financial/MoneyTest.cs
+++ b/test/Qowaiv.UnitTests/Financial/MoneyTest.cs
@@ -657,10 +657,13 @@ namespace Qowaiv.UnitTests.Financial
         [Test]
         public void Explicit_StringToMoney_AreEqual()
         {
-            var exp = TestStruct;
-            var act = (Money)TestStruct.ToString();
+            using (new CultureInfoScope("fr-FR"))
+            {
+                var exp = TestStruct;
+                var act = (Money)TestStruct.ToString(CultureInfo.CurrentCulture);
 
-            Assert.AreEqual(exp, act);
+                Assert.AreEqual(exp, act);
+            }
         }
         [Test]
         public void Explicit_MoneyToString_AreEqual()

--- a/test/Qowaiv.UnitTests/LocalDateTimeTest.cs
+++ b/test/Qowaiv.UnitTests/LocalDateTimeTest.cs
@@ -527,10 +527,13 @@ namespace Qowaiv.UnitTests
         [Test]
         public void Explicit_StringToLocalDateTime_AreEqual()
         {
-            var exp = TestStructNoMilliseconds;
-            var act = (LocalDateTime)TestStructNoMilliseconds.ToString();
+            using (new CultureInfoScope("en-GB"))
+            {
+                var exp = TestStructNoMilliseconds;
+                var act = (LocalDateTime)TestStructNoMilliseconds.ToString(CultureInfo.CurrentCulture);
 
-            Assert.AreEqual(exp, act);
+                Assert.AreEqual(exp, act);
+            }
         }
         [Test]
         public void Explicit_LocalDateTimeToString_AreEqual()

--- a/test/Qowaiv.UnitTests/PercentageTest.cs
+++ b/test/Qowaiv.UnitTests/PercentageTest.cs
@@ -1570,11 +1570,15 @@ namespace Qowaiv.UnitTests
         [Test]
         public void Explicit_StringToPercentage_AreEqual()
         {
-            var exp = TestStruct;
-            var act = (Percentage)TestStruct.ToString();
+            using (new CultureInfoScope("nl-NL"))
+            {
+                var exp = TestStruct;
+                var act = (Percentage)TestStruct.ToString();
 
-            Assert.AreEqual(exp, act);
+                Assert.AreEqual(exp, act);
+            }
         }
+
         [Test]
         public void Explicit_PercentageToString_AreEqual()
         {

--- a/test/Qowaiv.UnitTests/Statistics/EloTest.cs
+++ b/test/Qowaiv.UnitTests/Statistics/EloTest.cs
@@ -616,10 +616,13 @@ namespace Qowaiv.UnitTests.Statistics
         [Test]
         public void Explicit_StringToElo_AreEqual()
         {
-            var exp = TestStruct;
-            var act = (Elo)TestStruct.ToString();
+            using (new CultureInfoScope("en-GB"))
+            {
+                var exp = TestStruct;
+                var act = (Elo)TestStruct.ToString(CultureInfo.CurrentCulture);
 
-            Assert.AreEqual(exp, act);
+                Assert.AreEqual(exp, act);
+            }
         }
         [Test]
         public void Explicit_EloToString_AreEqual()


### PR DESCRIPTION
Most SVO's have multiple implicit and explicit casts that they support. As mentioned in #135 due to the implementation of the cast operators, `FormatException`'s and `ArgumentException`'s where thrown.

With the introduction of an internal `Cast` helper class, this has been solved/fixed.

The casts can now be typed like this:

``` C#
/// <summary>Casts a <see cref="string"/> to a house number.</summary>
public static explicit operator HouseNumber(string str) => Cast.String<HouseNumber>(TryParse, str);
/// <summary>Casts an System.Int32 to a house number.</summary>
public static implicit operator HouseNumber(int val) => Cast.Primitive<int, HouseNumber>(TryCreate, val);
```

With the helper class look like this:
``` C#
/// <summary>Helper class to facilitate <see cref="InvalidCastException"/> on SVO casting.</summary>
internal static class Cast
{
    /// <summary>Casts from a primitive (not <see cref="string"/>) to a SVO.</summary>
    public static TSvo Primitive<TPrimitive, TSvo>(TryCreate<TPrimitive, TSvo> tryCreate, TPrimitive? value)
        where TPrimitive : struct
    {
        if (tryCreate(value, out TSvo result))
        {
            return result;
        }
        throw Exceptions.InvalidCast<TPrimitive, TSvo>();
    }

    /// <summary>Casts from a <see cref="string"/> to a SVO.</summary>
    public static TSvo String<TSvo>(TryParse<TSvo> tryParse, string str)
    {
        if (tryParse(str, CultureInfo.CurrentCulture, out TSvo result))
        {
            return result;
        }
        throw Exceptions.InvalidCast<string, TSvo>();
    }
}
```