### PR TITLE
Use the private constructor that direct sets the underlying value where possible

### DIFF
--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -105,7 +105,7 @@ namespace Qowaiv
         internal DateSpan Plus() => this;
 
         /// <summary>Negates the date span.</summary>
-        public DateSpan Negate() => new DateSpan { m_Value = AsUInt64(-TotalMonths, -Days) };
+        public DateSpan Negate() => new DateSpan(AsUInt64(-TotalMonths, -Days));
 
         /// <summary>Returns a new date span whose value is the sum of the specified date span and this instance.</summary>
         ///<param name="other">
@@ -174,7 +174,7 @@ namespace Qowaiv
             {
                 throw new OverflowException(QowaivMessages.OverflowException_DateSpan);
             }
-            return new DateSpan { m_Value = AsUInt64(months, days) };
+            return new DateSpan(AsUInt64(months, days));
         }
 
         #endregion
@@ -383,7 +383,7 @@ namespace Qowaiv
 
                 if (!IsOutOfRange(months, d, totalDays))
                 {
-                    result = new DateSpan { m_Value = AsUInt64(months, d) };
+                    result = new DateSpan(AsUInt64(months, d));
                     return true;
                 }
             }

--- a/src/Qowaiv/Financial/Currency.cs
+++ b/src/Qowaiv/Financial/Currency.cs
@@ -317,7 +317,7 @@ namespace Qowaiv.Financial
             ResourceManager
                 .GetString("All")
                 .Split(';')
-                .Select(str => new Currency { m_Value = str })
+                .Select(str => new Currency(str))
                 .ToList());
 
         #endregion
@@ -390,11 +390,12 @@ namespace Qowaiv.Financial
             {
                 if (Parsings.ContainsKey(culture)) { return; }
 
-                Parsings[culture] = new Dictionary<string, string>();
+                Parsings[culture] = new Dictionary<string, string>
+                {
+                    [Unknown.GetDisplayName(culture)] = Unknown.m_Value
+                };
 
-                Parsings[culture][Unknown.GetDisplayName(culture)] = Unknown.m_Value;
-
-                foreach (var country in Currency.AllCurrencies)
+                foreach (var country in AllCurrencies)
                 {
                     Parsings[culture][Parsing.ToUnified(country.GetDisplayName(culture))] = country.m_Value;
                 }

--- a/src/Qowaiv/Financial/CurrencyConstants.cs
+++ b/src/Qowaiv/Financial/CurrencyConstants.cs
@@ -7,705 +7,705 @@ namespace Qowaiv.Financial
     public partial struct Currency
     {
         /// <summary>Describes the currency United Arab Emirates dirham (AED).</summary>
-        public static readonly Currency AED = new Currency { m_Value = "AED" };
+        public static readonly Currency AED = new Currency("AED");
 
         /// <summary>Describes the currency Afghan afghani (AFN).</summary>
-        public static readonly Currency AFN = new Currency { m_Value = "AFN" };
+        public static readonly Currency AFN = new Currency("AFN");
 
         /// <summary>Describes the currency Albanian lek (ALL).</summary>
-        public static readonly Currency ALL = new Currency { m_Value = "ALL" };
+        public static readonly Currency ALL = new Currency("ALL");
 
         /// <summary>Describes the currency Armenian dram (AMD).</summary>
-        public static readonly Currency AMD = new Currency { m_Value = "AMD" };
+        public static readonly Currency AMD = new Currency("AMD");
 
         /// <summary>Describes the currency Netherlands Antillean guilder (ANG).</summary>
-        public static readonly Currency ANG = new Currency { m_Value = "ANG" };
+        public static readonly Currency ANG = new Currency("ANG");
 
         /// <summary>Describes the currency Angolan kwanza (AOA).</summary>
-        public static readonly Currency AOA = new Currency { m_Value = "AOA" };
+        public static readonly Currency AOA = new Currency("AOA");
 
         /// <summary>Describes the currency Argentine peso (ARS).</summary>
-        public static readonly Currency ARS = new Currency { m_Value = "ARS" };
+        public static readonly Currency ARS = new Currency("ARS");
 
         /// <summary>Describes the currency Australian dollar (AUD).</summary>
-        public static readonly Currency AUD = new Currency { m_Value = "AUD" };
+        public static readonly Currency AUD = new Currency("AUD");
 
         /// <summary>Describes the currency Aruban florin (AWG).</summary>
-        public static readonly Currency AWG = new Currency { m_Value = "AWG" };
+        public static readonly Currency AWG = new Currency("AWG");
 
         /// <summary>Describes the currency Azerbaijani manat (AZN).</summary>
-        public static readonly Currency AZN = new Currency { m_Value = "AZN" };
+        public static readonly Currency AZN = new Currency("AZN");
 
         /// <summary>Describes the currency Bosnia and Herzegovina convertible mark (BAM).</summary>
-        public static readonly Currency BAM = new Currency { m_Value = "BAM" };
+        public static readonly Currency BAM = new Currency("BAM");
 
         /// <summary>Describes the currency Barbados dollar (BBD).</summary>
-        public static readonly Currency BBD = new Currency { m_Value = "BBD" };
+        public static readonly Currency BBD = new Currency("BBD");
 
         /// <summary>Describes the currency Bangladeshi taka (BDT).</summary>
-        public static readonly Currency BDT = new Currency { m_Value = "BDT" };
+        public static readonly Currency BDT = new Currency("BDT");
 
         /// <summary>Describes the currency Bulgarian lev (BGN).</summary>
-        public static readonly Currency BGN = new Currency { m_Value = "BGN" };
+        public static readonly Currency BGN = new Currency("BGN");
 
         /// <summary>Describes the currency Bahraini dinar (BHD).</summary>
-        public static readonly Currency BHD = new Currency { m_Value = "BHD" };
+        public static readonly Currency BHD = new Currency("BHD");
 
         /// <summary>Describes the currency Burundian franc (BIF).</summary>
-        public static readonly Currency BIF = new Currency { m_Value = "BIF" };
+        public static readonly Currency BIF = new Currency("BIF");
 
         /// <summary>Describes the currency Bermudian dollar (BMD).</summary>
-        public static readonly Currency BMD = new Currency { m_Value = "BMD" };
+        public static readonly Currency BMD = new Currency("BMD");
 
         /// <summary>Describes the currency Brunei dollar (BND).</summary>
-        public static readonly Currency BND = new Currency { m_Value = "BND" };
+        public static readonly Currency BND = new Currency("BND");
 
         /// <summary>Describes the currency Boliviano (BOB).</summary>
-        public static readonly Currency BOB = new Currency { m_Value = "BOB" };
+        public static readonly Currency BOB = new Currency("BOB");
 
         /// <summary>Describes the currency Bolivian Mvdol (BOV).</summary>
-        public static readonly Currency BOV = new Currency { m_Value = "BOV" };
+        public static readonly Currency BOV = new Currency("BOV");
 
         /// <summary>Describes the currency Brazilian real (BRL).</summary>
-        public static readonly Currency BRL = new Currency { m_Value = "BRL" };
+        public static readonly Currency BRL = new Currency("BRL");
 
         /// <summary>Describes the currency Bahamian dollar (BSD).</summary>
-        public static readonly Currency BSD = new Currency { m_Value = "BSD" };
+        public static readonly Currency BSD = new Currency("BSD");
 
         /// <summary>Describes the currency Bhutanese ngultrum (BTN).</summary>
-        public static readonly Currency BTN = new Currency { m_Value = "BTN" };
+        public static readonly Currency BTN = new Currency("BTN");
 
         /// <summary>Describes the currency Botswana pula (BWP).</summary>
-        public static readonly Currency BWP = new Currency { m_Value = "BWP" };
+        public static readonly Currency BWP = new Currency("BWP");
 
         /// <summary>Describes the currency Belarusian ruble (BYR).</summary>
-        public static readonly Currency BYR = new Currency { m_Value = "BYR" };
+        public static readonly Currency BYR = new Currency("BYR");
 
         /// <summary>Describes the currency Belize dollar (BZD).</summary>
-        public static readonly Currency BZD = new Currency { m_Value = "BZD" };
+        public static readonly Currency BZD = new Currency("BZD");
 
         /// <summary>Describes the currency Canadian dollar (CAD).</summary>
-        public static readonly Currency CAD = new Currency { m_Value = "CAD" };
+        public static readonly Currency CAD = new Currency("CAD");
 
         /// <summary>Describes the currency Congolese franc (CDF).</summary>
-        public static readonly Currency CDF = new Currency { m_Value = "CDF" };
+        public static readonly Currency CDF = new Currency("CDF");
 
         /// <summary>Describes the currency WIR Euro (CHE).</summary>
-        public static readonly Currency CHE = new Currency { m_Value = "CHE" };
+        public static readonly Currency CHE = new Currency("CHE");
 
         /// <summary>Describes the currency Swiss franc (CHF).</summary>
-        public static readonly Currency CHF = new Currency { m_Value = "CHF" };
+        public static readonly Currency CHF = new Currency("CHF");
 
         /// <summary>Describes the currency WIR Franc (CHW).</summary>
-        public static readonly Currency CHW = new Currency { m_Value = "CHW" };
+        public static readonly Currency CHW = new Currency("CHW");
 
         /// <summary>Describes the currency Unidad de Fomento (CLF).</summary>
-        public static readonly Currency CLF = new Currency { m_Value = "CLF" };
+        public static readonly Currency CLF = new Currency("CLF");
 
         /// <summary>Describes the currency Chilean peso (CLP).</summary>
-        public static readonly Currency CLP = new Currency { m_Value = "CLP" };
+        public static readonly Currency CLP = new Currency("CLP");
 
         /// <summary>Describes the currency Chinese yuan when traded in Hong Kong (CNH).</summary>
-        public static readonly Currency CNH = new Currency { m_Value = "CNH" };
+        public static readonly Currency CNH = new Currency("CNH");
 
         /// <summary>Describes the currency Chinese yuan (CNY).</summary>
-        public static readonly Currency CNY = new Currency { m_Value = "CNY" };
+        public static readonly Currency CNY = new Currency("CNY");
 
         /// <summary>Describes the currency Colombian peso (COP).</summary>
-        public static readonly Currency COP = new Currency { m_Value = "COP" };
+        public static readonly Currency COP = new Currency("COP");
 
         /// <summary>Describes the currency Unidad de Valor Real (COU).</summary>
-        public static readonly Currency COU = new Currency { m_Value = "COU" };
+        public static readonly Currency COU = new Currency("COU");
 
         /// <summary>Describes the currency Costa Rican colon (CRC).</summary>
-        public static readonly Currency CRC = new Currency { m_Value = "CRC" };
+        public static readonly Currency CRC = new Currency("CRC");
 
         /// <summary>Describes the currency Cuban convertible peso (CUC).</summary>
-        public static readonly Currency CUC = new Currency { m_Value = "CUC" };
+        public static readonly Currency CUC = new Currency("CUC");
 
         /// <summary>Describes the currency Cuban peso (CUP).</summary>
-        public static readonly Currency CUP = new Currency { m_Value = "CUP" };
+        public static readonly Currency CUP = new Currency("CUP");
 
         /// <summary>Describes the currency Cape Verde escudo (CVE).</summary>
-        public static readonly Currency CVE = new Currency { m_Value = "CVE" };
+        public static readonly Currency CVE = new Currency("CVE");
 
         /// <summary>Describes the currency Czech koruna (CZK).</summary>
-        public static readonly Currency CZK = new Currency { m_Value = "CZK" };
+        public static readonly Currency CZK = new Currency("CZK");
 
         /// <summary>Describes the currency Djiboutian franc (DJF).</summary>
-        public static readonly Currency DJF = new Currency { m_Value = "DJF" };
+        public static readonly Currency DJF = new Currency("DJF");
 
         /// <summary>Describes the currency Danish krone (DKK).</summary>
-        public static readonly Currency DKK = new Currency { m_Value = "DKK" };
+        public static readonly Currency DKK = new Currency("DKK");
 
         /// <summary>Describes the currency Dominican peso (DOP).</summary>
-        public static readonly Currency DOP = new Currency { m_Value = "DOP" };
+        public static readonly Currency DOP = new Currency("DOP");
 
         /// <summary>Describes the currency Algerian dinar (DZD).</summary>
-        public static readonly Currency DZD = new Currency { m_Value = "DZD" };
+        public static readonly Currency DZD = new Currency("DZD");
 
         /// <summary>Describes the currency Egyptian pound (EGP).</summary>
-        public static readonly Currency EGP = new Currency { m_Value = "EGP" };
+        public static readonly Currency EGP = new Currency("EGP");
 
         /// <summary>Describes the currency Eritrean nakfa (ERN).</summary>
-        public static readonly Currency ERN = new Currency { m_Value = "ERN" };
+        public static readonly Currency ERN = new Currency("ERN");
 
         /// <summary>Describes the currency Ethiopian birr (ETB).</summary>
-        public static readonly Currency ETB = new Currency { m_Value = "ETB" };
+        public static readonly Currency ETB = new Currency("ETB");
 
         /// <summary>Describes the currency Euro (EUR).</summary>
-        public static readonly Currency EUR = new Currency { m_Value = "EUR" };
+        public static readonly Currency EUR = new Currency("EUR");
 
         /// <summary>Describes the currency Fiji dollar (FJD).</summary>
-        public static readonly Currency FJD = new Currency { m_Value = "FJD" };
+        public static readonly Currency FJD = new Currency("FJD");
 
         /// <summary>Describes the currency Falkland Islands pound (FKP).</summary>
-        public static readonly Currency FKP = new Currency { m_Value = "FKP" };
+        public static readonly Currency FKP = new Currency("FKP");
 
         /// <summary>Describes the currency Pound sterling (GBP).</summary>
-        public static readonly Currency GBP = new Currency { m_Value = "GBP" };
+        public static readonly Currency GBP = new Currency("GBP");
 
         /// <summary>Describes the currency Georgian lari (GEL).</summary>
-        public static readonly Currency GEL = new Currency { m_Value = "GEL" };
+        public static readonly Currency GEL = new Currency("GEL");
 
         /// <summary>Describes the currency Ghanaian cedi (GHS).</summary>
-        public static readonly Currency GHS = new Currency { m_Value = "GHS" };
+        public static readonly Currency GHS = new Currency("GHS");
 
         /// <summary>Describes the currency Gibraltar pound (GIP).</summary>
-        public static readonly Currency GIP = new Currency { m_Value = "GIP" };
+        public static readonly Currency GIP = new Currency("GIP");
 
         /// <summary>Describes the currency Gambian dalasi (GMD).</summary>
-        public static readonly Currency GMD = new Currency { m_Value = "GMD" };
+        public static readonly Currency GMD = new Currency("GMD");
 
         /// <summary>Describes the currency Guinean franc (GNF).</summary>
-        public static readonly Currency GNF = new Currency { m_Value = "GNF" };
+        public static readonly Currency GNF = new Currency("GNF");
 
         /// <summary>Describes the currency Guatemalan quetzal (GTQ).</summary>
-        public static readonly Currency GTQ = new Currency { m_Value = "GTQ" };
+        public static readonly Currency GTQ = new Currency("GTQ");
 
         /// <summary>Describes the currency Guyanese dollar (GYD).</summary>
-        public static readonly Currency GYD = new Currency { m_Value = "GYD" };
+        public static readonly Currency GYD = new Currency("GYD");
 
         /// <summary>Describes the currency Hong Kong dollar (HKD).</summary>
-        public static readonly Currency HKD = new Currency { m_Value = "HKD" };
+        public static readonly Currency HKD = new Currency("HKD");
 
         /// <summary>Describes the currency Honduran lempira (HNL).</summary>
-        public static readonly Currency HNL = new Currency { m_Value = "HNL" };
+        public static readonly Currency HNL = new Currency("HNL");
 
         /// <summary>Describes the currency Croatian kuna (HRK).</summary>
-        public static readonly Currency HRK = new Currency { m_Value = "HRK" };
+        public static readonly Currency HRK = new Currency("HRK");
 
         /// <summary>Describes the currency Haitian gourde (HTG).</summary>
-        public static readonly Currency HTG = new Currency { m_Value = "HTG" };
+        public static readonly Currency HTG = new Currency("HTG");
 
         /// <summary>Describes the currency Hungarian forint (HUF).</summary>
-        public static readonly Currency HUF = new Currency { m_Value = "HUF" };
+        public static readonly Currency HUF = new Currency("HUF");
 
         /// <summary>Describes the currency Indonesian rupiah (IDR).</summary>
-        public static readonly Currency IDR = new Currency { m_Value = "IDR" };
+        public static readonly Currency IDR = new Currency("IDR");
 
         /// <summary>Describes the currency Israeli new shekel (ILS).</summary>
-        public static readonly Currency ILS = new Currency { m_Value = "ILS" };
+        public static readonly Currency ILS = new Currency("ILS");
 
         /// <summary>Describes the currency Indian rupee (INR).</summary>
-        public static readonly Currency INR = new Currency { m_Value = "INR" };
+        public static readonly Currency INR = new Currency("INR");
 
         /// <summary>Describes the currency Iraqi dinar (IQD).</summary>
-        public static readonly Currency IQD = new Currency { m_Value = "IQD" };
+        public static readonly Currency IQD = new Currency("IQD");
 
         /// <summary>Describes the currency Iranian rial (IRR).</summary>
-        public static readonly Currency IRR = new Currency { m_Value = "IRR" };
+        public static readonly Currency IRR = new Currency("IRR");
 
         /// <summary>Describes the currency Icelandic króna (ISK).</summary>
-        public static readonly Currency ISK = new Currency { m_Value = "ISK" };
+        public static readonly Currency ISK = new Currency("ISK");
 
         /// <summary>Describes the currency Jamaican dollar (JMD).</summary>
-        public static readonly Currency JMD = new Currency { m_Value = "JMD" };
+        public static readonly Currency JMD = new Currency("JMD");
 
         /// <summary>Describes the currency Jordanian dinar (JOD).</summary>
-        public static readonly Currency JOD = new Currency { m_Value = "JOD" };
+        public static readonly Currency JOD = new Currency("JOD");
 
         /// <summary>Describes the currency Japanese yen (JPY).</summary>
-        public static readonly Currency JPY = new Currency { m_Value = "JPY" };
+        public static readonly Currency JPY = new Currency("JPY");
 
         /// <summary>Describes the currency Kenyan shilling (KES).</summary>
-        public static readonly Currency KES = new Currency { m_Value = "KES" };
+        public static readonly Currency KES = new Currency("KES");
 
         /// <summary>Describes the currency Kyrgyzstani som (KGS).</summary>
-        public static readonly Currency KGS = new Currency { m_Value = "KGS" };
+        public static readonly Currency KGS = new Currency("KGS");
 
         /// <summary>Describes the currency Cambodian riel (KHR).</summary>
-        public static readonly Currency KHR = new Currency { m_Value = "KHR" };
+        public static readonly Currency KHR = new Currency("KHR");
 
         /// <summary>Describes the currency Comoro franc (KMF).</summary>
-        public static readonly Currency KMF = new Currency { m_Value = "KMF" };
+        public static readonly Currency KMF = new Currency("KMF");
 
         /// <summary>Describes the currency North Korean won (KPW).</summary>
-        public static readonly Currency KPW = new Currency { m_Value = "KPW" };
+        public static readonly Currency KPW = new Currency("KPW");
 
         /// <summary>Describes the currency South Korean won (KRW).</summary>
-        public static readonly Currency KRW = new Currency { m_Value = "KRW" };
+        public static readonly Currency KRW = new Currency("KRW");
 
         /// <summary>Describes the currency Kuwaiti dinar (KWD).</summary>
-        public static readonly Currency KWD = new Currency { m_Value = "KWD" };
+        public static readonly Currency KWD = new Currency("KWD");
 
         /// <summary>Describes the currency Cayman Islands dollar (KYD).</summary>
-        public static readonly Currency KYD = new Currency { m_Value = "KYD" };
+        public static readonly Currency KYD = new Currency("KYD");
 
         /// <summary>Describes the currency Kazakhstani tenge (KZT).</summary>
-        public static readonly Currency KZT = new Currency { m_Value = "KZT" };
+        public static readonly Currency KZT = new Currency("KZT");
 
         /// <summary>Describes the currency Lao kip (LAK).</summary>
-        public static readonly Currency LAK = new Currency { m_Value = "LAK" };
+        public static readonly Currency LAK = new Currency("LAK");
 
         /// <summary>Describes the currency Lebanese pound (LBP).</summary>
-        public static readonly Currency LBP = new Currency { m_Value = "LBP" };
+        public static readonly Currency LBP = new Currency("LBP");
 
         /// <summary>Describes the currency Sri Lankan rupee (LKR).</summary>
-        public static readonly Currency LKR = new Currency { m_Value = "LKR" };
+        public static readonly Currency LKR = new Currency("LKR");
 
         /// <summary>Describes the currency Liberian dollar (LRD).</summary>
-        public static readonly Currency LRD = new Currency { m_Value = "LRD" };
+        public static readonly Currency LRD = new Currency("LRD");
 
         /// <summary>Describes the currency Lesotho loti (LSL).</summary>
-        public static readonly Currency LSL = new Currency { m_Value = "LSL" };
+        public static readonly Currency LSL = new Currency("LSL");
 
         /// <summary>Describes the currency Libyan dinar (LYD).</summary>
-        public static readonly Currency LYD = new Currency { m_Value = "LYD" };
+        public static readonly Currency LYD = new Currency("LYD");
 
         /// <summary>Describes the currency Moroccan dirham (MAD).</summary>
-        public static readonly Currency MAD = new Currency { m_Value = "MAD" };
+        public static readonly Currency MAD = new Currency("MAD");
 
         /// <summary>Describes the currency Moldovan leu (MDL).</summary>
-        public static readonly Currency MDL = new Currency { m_Value = "MDL" };
+        public static readonly Currency MDL = new Currency("MDL");
 
         /// <summary>Describes the currency Malagasy ariary (MGA).</summary>
-        public static readonly Currency MGA = new Currency { m_Value = "MGA" };
+        public static readonly Currency MGA = new Currency("MGA");
 
         /// <summary>Describes the currency Macedonian denar (MKD).</summary>
-        public static readonly Currency MKD = new Currency { m_Value = "MKD" };
+        public static readonly Currency MKD = new Currency("MKD");
 
         /// <summary>Describes the currency Myanmar kyat (MMK).</summary>
-        public static readonly Currency MMK = new Currency { m_Value = "MMK" };
+        public static readonly Currency MMK = new Currency("MMK");
 
         /// <summary>Describes the currency Mongolian tugrik (MNT).</summary>
-        public static readonly Currency MNT = new Currency { m_Value = "MNT" };
+        public static readonly Currency MNT = new Currency("MNT");
 
         /// <summary>Describes the currency Macanese pataca (MOP).</summary>
-        public static readonly Currency MOP = new Currency { m_Value = "MOP" };
+        public static readonly Currency MOP = new Currency("MOP");
 
         /// <summary>Describes the currency Mauritanian ouguiya (MRO).</summary>
-        public static readonly Currency MRO = new Currency { m_Value = "MRO" };
+        public static readonly Currency MRO = new Currency("MRO");
 
         /// <summary>Describes the currency Mauritian rupee (MUR).</summary>
-        public static readonly Currency MUR = new Currency { m_Value = "MUR" };
+        public static readonly Currency MUR = new Currency("MUR");
 
         /// <summary>Describes the currency Maldivian rufiyaa (MVR).</summary>
-        public static readonly Currency MVR = new Currency { m_Value = "MVR" };
+        public static readonly Currency MVR = new Currency("MVR");
 
         /// <summary>Describes the currency Malawian kwacha (MWK).</summary>
-        public static readonly Currency MWK = new Currency { m_Value = "MWK" };
+        public static readonly Currency MWK = new Currency("MWK");
 
         /// <summary>Describes the currency Mexican peso (MXN).</summary>
-        public static readonly Currency MXN = new Currency { m_Value = "MXN" };
+        public static readonly Currency MXN = new Currency("MXN");
 
         /// <summary>Describes the currency Mexican Unidad de Inversion (UDI) (MXV).</summary>
-        public static readonly Currency MXV = new Currency { m_Value = "MXV" };
+        public static readonly Currency MXV = new Currency("MXV");
 
         /// <summary>Describes the currency Malaysian ringgit (MYR).</summary>
-        public static readonly Currency MYR = new Currency { m_Value = "MYR" };
+        public static readonly Currency MYR = new Currency("MYR");
 
         /// <summary>Describes the currency Mozambican metical (MZN).</summary>
-        public static readonly Currency MZN = new Currency { m_Value = "MZN" };
+        public static readonly Currency MZN = new Currency("MZN");
 
         /// <summary>Describes the currency Namibian dollar (NAD).</summary>
-        public static readonly Currency NAD = new Currency { m_Value = "NAD" };
+        public static readonly Currency NAD = new Currency("NAD");
 
         /// <summary>Describes the currency Nigerian naira (NGN).</summary>
-        public static readonly Currency NGN = new Currency { m_Value = "NGN" };
+        public static readonly Currency NGN = new Currency("NGN");
 
         /// <summary>Describes the currency Nicaraguan córdoba (NIO).</summary>
-        public static readonly Currency NIO = new Currency { m_Value = "NIO" };
+        public static readonly Currency NIO = new Currency("NIO");
 
         /// <summary>Describes the currency Norwegian krone (NOK).</summary>
-        public static readonly Currency NOK = new Currency { m_Value = "NOK" };
+        public static readonly Currency NOK = new Currency("NOK");
 
         /// <summary>Describes the currency Nepalese rupee (NPR).</summary>
-        public static readonly Currency NPR = new Currency { m_Value = "NPR" };
+        public static readonly Currency NPR = new Currency("NPR");
 
         /// <summary>Describes the currency New Zealand dollar (NZD).</summary>
-        public static readonly Currency NZD = new Currency { m_Value = "NZD" };
+        public static readonly Currency NZD = new Currency("NZD");
 
         /// <summary>Describes the currency Omani rial (OMR).</summary>
-        public static readonly Currency OMR = new Currency { m_Value = "OMR" };
+        public static readonly Currency OMR = new Currency("OMR");
 
         /// <summary>Describes the currency Panamanian balboa (PAB).</summary>
-        public static readonly Currency PAB = new Currency { m_Value = "PAB" };
+        public static readonly Currency PAB = new Currency("PAB");
 
         /// <summary>Describes the currency Peruvian nuevo sol (PEN).</summary>
-        public static readonly Currency PEN = new Currency { m_Value = "PEN" };
+        public static readonly Currency PEN = new Currency("PEN");
 
         /// <summary>Describes the currency Papua New Guinean kina (PGK).</summary>
-        public static readonly Currency PGK = new Currency { m_Value = "PGK" };
+        public static readonly Currency PGK = new Currency("PGK");
 
         /// <summary>Describes the currency Philippine peso (PHP).</summary>
-        public static readonly Currency PHP = new Currency { m_Value = "PHP" };
+        public static readonly Currency PHP = new Currency("PHP");
 
         /// <summary>Describes the currency Pakistani rupee (PKR).</summary>
-        public static readonly Currency PKR = new Currency { m_Value = "PKR" };
+        public static readonly Currency PKR = new Currency("PKR");
 
         /// <summary>Describes the currency Polish złoty (PLN).</summary>
-        public static readonly Currency PLN = new Currency { m_Value = "PLN" };
+        public static readonly Currency PLN = new Currency("PLN");
 
         /// <summary>Describes the currency Paraguayan guaraní (PYG).</summary>
-        public static readonly Currency PYG = new Currency { m_Value = "PYG" };
+        public static readonly Currency PYG = new Currency("PYG");
 
         /// <summary>Describes the currency Qatari riyal (QAR).</summary>
-        public static readonly Currency QAR = new Currency { m_Value = "QAR" };
+        public static readonly Currency QAR = new Currency("QAR");
 
         /// <summary>Describes the currency Romanian new leu (RON).</summary>
-        public static readonly Currency RON = new Currency { m_Value = "RON" };
+        public static readonly Currency RON = new Currency("RON");
 
         /// <summary>Describes the currency Serbian dinar (RSD).</summary>
-        public static readonly Currency RSD = new Currency { m_Value = "RSD" };
+        public static readonly Currency RSD = new Currency("RSD");
 
         /// <summary>Describes the currency Russian ruble (RUB).</summary>
-        public static readonly Currency RUB = new Currency { m_Value = "RUB" };
+        public static readonly Currency RUB = new Currency("RUB");
 
         /// <summary>Describes the currency Rwandan franc (RWF).</summary>
-        public static readonly Currency RWF = new Currency { m_Value = "RWF" };
+        public static readonly Currency RWF = new Currency("RWF");
 
         /// <summary>Describes the currency Saudi riyal (SAR).</summary>
-        public static readonly Currency SAR = new Currency { m_Value = "SAR" };
+        public static readonly Currency SAR = new Currency("SAR");
 
         /// <summary>Describes the currency Solomon Islands dollar (SBD).</summary>
-        public static readonly Currency SBD = new Currency { m_Value = "SBD" };
+        public static readonly Currency SBD = new Currency("SBD");
 
         /// <summary>Describes the currency Seychelles rupee (SCR).</summary>
-        public static readonly Currency SCR = new Currency { m_Value = "SCR" };
+        public static readonly Currency SCR = new Currency("SCR");
 
         /// <summary>Describes the currency Sudanese pound (SDG).</summary>
-        public static readonly Currency SDG = new Currency { m_Value = "SDG" };
+        public static readonly Currency SDG = new Currency("SDG");
 
         /// <summary>Describes the currency Swedish krona/kronor (SEK).</summary>
-        public static readonly Currency SEK = new Currency { m_Value = "SEK" };
+        public static readonly Currency SEK = new Currency("SEK");
 
         /// <summary>Describes the currency Singapore dollar (SGD).</summary>
-        public static readonly Currency SGD = new Currency { m_Value = "SGD" };
+        public static readonly Currency SGD = new Currency("SGD");
 
         /// <summary>Describes the currency Saint Helena pound (SHP).</summary>
-        public static readonly Currency SHP = new Currency { m_Value = "SHP" };
+        public static readonly Currency SHP = new Currency("SHP");
 
         /// <summary>Describes the currency Sierra Leonean leone (SLL).</summary>
-        public static readonly Currency SLL = new Currency { m_Value = "SLL" };
+        public static readonly Currency SLL = new Currency("SLL");
 
         /// <summary>Describes the currency Somali shilling (SOS).</summary>
-        public static readonly Currency SOS = new Currency { m_Value = "SOS" };
+        public static readonly Currency SOS = new Currency("SOS");
 
         /// <summary>Describes the currency Surinamese dollar (SRD).</summary>
-        public static readonly Currency SRD = new Currency { m_Value = "SRD" };
+        public static readonly Currency SRD = new Currency("SRD");
 
         /// <summary>Describes the currency South Sudanese pound (SSP).</summary>
-        public static readonly Currency SSP = new Currency { m_Value = "SSP" };
+        public static readonly Currency SSP = new Currency("SSP");
 
         /// <summary>Describes the currency São Tomé and Príncipe dobra (STD).</summary>
-        public static readonly Currency STD = new Currency { m_Value = "STD" };
+        public static readonly Currency STD = new Currency("STD");
 
         /// <summary>Describes the currency Syrian pound (SYP).</summary>
-        public static readonly Currency SYP = new Currency { m_Value = "SYP" };
+        public static readonly Currency SYP = new Currency("SYP");
 
         /// <summary>Describes the currency Swazi lilangeni (SZL).</summary>
-        public static readonly Currency SZL = new Currency { m_Value = "SZL" };
+        public static readonly Currency SZL = new Currency("SZL");
 
         /// <summary>Describes the currency Thai baht (THB).</summary>
-        public static readonly Currency THB = new Currency { m_Value = "THB" };
+        public static readonly Currency THB = new Currency("THB");
 
         /// <summary>Describes the currency Tajikistani somoni (TJS).</summary>
-        public static readonly Currency TJS = new Currency { m_Value = "TJS" };
+        public static readonly Currency TJS = new Currency("TJS");
 
         /// <summary>Describes the currency Turkmenistani manat (TMT).</summary>
-        public static readonly Currency TMT = new Currency { m_Value = "TMT" };
+        public static readonly Currency TMT = new Currency("TMT");
 
         /// <summary>Describes the currency Tunisian dinar (TND).</summary>
-        public static readonly Currency TND = new Currency { m_Value = "TND" };
+        public static readonly Currency TND = new Currency("TND");
 
         /// <summary>Describes the currency Tongan paʻanga (TOP).</summary>
-        public static readonly Currency TOP = new Currency { m_Value = "TOP" };
+        public static readonly Currency TOP = new Currency("TOP");
 
         /// <summary>Describes the currency Turkish lira (TRY).</summary>
-        public static readonly Currency TRY = new Currency { m_Value = "TRY" };
+        public static readonly Currency TRY = new Currency("TRY");
 
         /// <summary>Describes the currency Trinidad and Tobago dollar (TTD).</summary>
-        public static readonly Currency TTD = new Currency { m_Value = "TTD" };
+        public static readonly Currency TTD = new Currency("TTD");
 
         /// <summary>Describes the currency New Taiwan dollar (TWD).</summary>
-        public static readonly Currency TWD = new Currency { m_Value = "TWD" };
+        public static readonly Currency TWD = new Currency("TWD");
 
         /// <summary>Describes the currency Tanzanian shilling (TZS).</summary>
-        public static readonly Currency TZS = new Currency { m_Value = "TZS" };
+        public static readonly Currency TZS = new Currency("TZS");
 
         /// <summary>Describes the currency Ukrainian hryvnia (UAH).</summary>
-        public static readonly Currency UAH = new Currency { m_Value = "UAH" };
+        public static readonly Currency UAH = new Currency("UAH");
 
         /// <summary>Describes the currency Ugandan shilling (UGX).</summary>
-        public static readonly Currency UGX = new Currency { m_Value = "UGX" };
+        public static readonly Currency UGX = new Currency("UGX");
 
         /// <summary>Describes the currency United States dollar (USD).</summary>
-        public static readonly Currency USD = new Currency { m_Value = "USD" };
+        public static readonly Currency USD = new Currency("USD");
 
         /// <summary>Describes the currency United States dollar (next day) (USN).</summary>
-        public static readonly Currency USN = new Currency { m_Value = "USN" };
+        public static readonly Currency USN = new Currency("USN");
 
         /// <summary>Describes the currency United States dollar (same day) (USS).</summary>
-        public static readonly Currency USS = new Currency { m_Value = "USS" };
+        public static readonly Currency USS = new Currency("USS");
 
         /// <summary>Describes the currency Uruguay Peso en Unidades Indexadas (URUIURUI) (UYI).</summary>
-        public static readonly Currency UYI = new Currency { m_Value = "UYI" };
+        public static readonly Currency UYI = new Currency("UYI");
 
         /// <summary>Describes the currency Uruguayan peso (UYU).</summary>
-        public static readonly Currency UYU = new Currency { m_Value = "UYU" };
+        public static readonly Currency UYU = new Currency("UYU");
 
         /// <summary>Describes the currency Uzbekistan som (UZS).</summary>
-        public static readonly Currency UZS = new Currency { m_Value = "UZS" };
+        public static readonly Currency UZS = new Currency("UZS");
 
         /// <summary>Describes the currency Venezuelan bolívar (VEF).</summary>
-        public static readonly Currency VEF = new Currency { m_Value = "VEF" };
+        public static readonly Currency VEF = new Currency("VEF");
 
         /// <summary>Describes the currency Vietnamese dong (VND).</summary>
-        public static readonly Currency VND = new Currency { m_Value = "VND" };
+        public static readonly Currency VND = new Currency("VND");
 
         /// <summary>Describes the currency Vanuatu vatu (VUV).</summary>
-        public static readonly Currency VUV = new Currency { m_Value = "VUV" };
+        public static readonly Currency VUV = new Currency("VUV");
 
         /// <summary>Describes the currency Samoan tala (WST).</summary>
-        public static readonly Currency WST = new Currency { m_Value = "WST" };
+        public static readonly Currency WST = new Currency("WST");
 
         /// <summary>Describes the currency CFA franc BEAC (XAF).</summary>
-        public static readonly Currency XAF = new Currency { m_Value = "XAF" };
+        public static readonly Currency XAF = new Currency("XAF");
 
         /// <summary>Describes the currency Silver (one troy ounce) (XAG).</summary>
-        public static readonly Currency XAG = new Currency { m_Value = "XAG" };
+        public static readonly Currency XAG = new Currency("XAG");
 
         /// <summary>Describes the currency Gold (one troy ounce) (XAU).</summary>
-        public static readonly Currency XAU = new Currency { m_Value = "XAU" };
+        public static readonly Currency XAU = new Currency("XAU");
 
         /// <summary>Describes the currency European Composite Unit (EURCO) (bond market unit) (XBA).</summary>
-        public static readonly Currency XBA = new Currency { m_Value = "XBA" };
+        public static readonly Currency XBA = new Currency("XBA");
 
         /// <summary>Describes the currency European Monetary Unit (E.M.U.-6) (bond market unit) (XBB).</summary>
-        public static readonly Currency XBB = new Currency { m_Value = "XBB" };
+        public static readonly Currency XBB = new Currency("XBB");
 
         /// <summary>Describes the currency European Unit of Account 9 (E.U.A.-9) (bond market unit) (XBC).</summary>
-        public static readonly Currency XBC = new Currency { m_Value = "XBC" };
+        public static readonly Currency XBC = new Currency("XBC");
 
         /// <summary>Describes the currency European Unit of Account 17(E.U.A.-17) (bond market unit) (XBD).</summary>
-        public static readonly Currency XBD = new Currency { m_Value = "XBD" };
+        public static readonly Currency XBD = new Currency("XBD");
 
         /// <summary>Describes the currency East Caribbean dollar (XCD).</summary>
-        public static readonly Currency XCD = new Currency { m_Value = "XCD" };
+        public static readonly Currency XCD = new Currency("XCD");
 
         /// <summary>Describes the currency Special drawing rights (XDR).</summary>
-        public static readonly Currency XDR = new Currency { m_Value = "XDR" };
+        public static readonly Currency XDR = new Currency("XDR");
 
         /// <summary>Describes the currency UIC franc (special settlement currency) (XFU).</summary>
-        public static readonly Currency XFU = new Currency { m_Value = "XFU" };
+        public static readonly Currency XFU = new Currency("XFU");
 
         /// <summary>Describes the currency CFA franc BCEAO (XOF).</summary>
-        public static readonly Currency XOF = new Currency { m_Value = "XOF" };
+        public static readonly Currency XOF = new Currency("XOF");
 
         /// <summary>Describes the currency Palladium (one troy ounce) (XPD).</summary>
-        public static readonly Currency XPD = new Currency { m_Value = "XPD" };
+        public static readonly Currency XPD = new Currency("XPD");
 
         /// <summary>Describes the currency CFP franc (franc Pacifique) (XPF).</summary>
-        public static readonly Currency XPF = new Currency { m_Value = "XPF" };
+        public static readonly Currency XPF = new Currency("XPF");
 
         /// <summary>Describes the currency Platinum (one troy ounce) (XPT).</summary>
-        public static readonly Currency XPT = new Currency { m_Value = "XPT" };
+        public static readonly Currency XPT = new Currency("XPT");
 
         /// <summary>Describes the currency SUCRE (XSU).</summary>
-        public static readonly Currency XSU = new Currency { m_Value = "XSU" };
+        public static readonly Currency XSU = new Currency("XSU");
 
         /// <summary>Describes the currency Code reserved for testing purposes (XTS).</summary>
-        public static readonly Currency XTS = new Currency { m_Value = "XTS" };
+        public static readonly Currency XTS = new Currency("XTS");
 
         /// <summary>Describes the currency ADB Unit of Account (XUA).</summary>
-        public static readonly Currency XUA = new Currency { m_Value = "XUA" };
+        public static readonly Currency XUA = new Currency("XUA");
 
         /// <summary>Describes the currency No currency (XXX).</summary>
-        public static readonly Currency XXX = new Currency { m_Value = "XXX" };
+        public static readonly Currency XXX = new Currency("XXX");
 
         /// <summary>Describes the currency Yemeni rial (YER).</summary>
-        public static readonly Currency YER = new Currency { m_Value = "YER" };
+        public static readonly Currency YER = new Currency("YER");
 
         /// <summary>Describes the currency South African rand (ZAR).</summary>
-        public static readonly Currency ZAR = new Currency { m_Value = "ZAR" };
+        public static readonly Currency ZAR = new Currency("ZAR");
 
         /// <summary>Describes the currency Zambian kwacha (ZMW).</summary>
-        public static readonly Currency ZMW = new Currency { m_Value = "ZMW" };
+        public static readonly Currency ZMW = new Currency("ZMW");
 
         /// <summary>Describes the currency Andorran peseta (ADP).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency ADP = new Currency { m_Value = "ADP" };
+        public static readonly Currency ADP = new Currency("ADP");
 
         /// <summary>Describes the currency Austrian schilling (ATS).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency ATS = new Currency { m_Value = "ATS" };
+        public static readonly Currency ATS = new Currency("ATS");
 
         /// <summary>Describes the currency Belgian franc (BEF).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency BEF = new Currency { m_Value = "BEF" };
+        public static readonly Currency BEF = new Currency("BEF");
 
         /// <summary>Describes the currency Serbian dinar (CSD).</summary>
         /// <remarks>End date is 2005-12-31.</remarks>
-        public static readonly Currency CSD = new Currency { m_Value = "CSD" };
+        public static readonly Currency CSD = new Currency("CSD");
 
         /// <summary>Describes the currency Czechoslovak koruna (CSK).</summary>
         /// <remarks>End date is 1993-02-08.</remarks>
-        public static readonly Currency CSK = new Currency { m_Value = "CSK" };
+        public static readonly Currency CSK = new Currency("CSK");
 
         /// <summary>Describes the currency Cypriot pound (CYP).</summary>
         /// <remarks>End date is 2007-12-31.</remarks>
-        public static readonly Currency CYP = new Currency { m_Value = "CYP" };
+        public static readonly Currency CYP = new Currency("CYP");
 
         /// <summary>Describes the currency East German Mark (DDM).</summary>
         /// <remarks>End date is 1990-06-30.</remarks>
-        public static readonly Currency DDM = new Currency { m_Value = "DDM" };
+        public static readonly Currency DDM = new Currency("DDM");
 
         /// <summary>Describes the currency German mark (DEM).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency DEM = new Currency { m_Value = "DEM" };
+        public static readonly Currency DEM = new Currency("DEM");
 
         /// <summary>Describes the currency Ecuadorian sucre (ECS).</summary>
         /// <remarks>End date is 2000-03-12.</remarks>
-        public static readonly Currency ECS = new Currency { m_Value = "ECS" };
+        public static readonly Currency ECS = new Currency("ECS");
 
         /// <summary>Describes the currency Estonian kroon (EEK).</summary>
         /// <remarks>End date is 2010-12-13.</remarks>
-        public static readonly Currency EEK = new Currency { m_Value = "EEK" };
+        public static readonly Currency EEK = new Currency("EEK");
 
         /// <summary>Describes the currency Spanish peseta (ESP).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency ESP = new Currency { m_Value = "ESP" };
+        public static readonly Currency ESP = new Currency("ESP");
 
         /// <summary>Describes the currency Finnish markka (FIM).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency FIM = new Currency { m_Value = "FIM" };
+        public static readonly Currency FIM = new Currency("FIM");
 
         /// <summary>Describes the currency French franc (FRF).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency FRF = new Currency { m_Value = "FRF" };
+        public static readonly Currency FRF = new Currency("FRF");
 
         /// <summary>Describes the currency Greek drachma (GRD).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency GRD = new Currency { m_Value = "GRD" };
+        public static readonly Currency GRD = new Currency("GRD");
 
         /// <summary>Describes the currency Irish pound (IEP).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency IEP = new Currency { m_Value = "IEP" };
+        public static readonly Currency IEP = new Currency("IEP");
 
         /// <summary>Describes the currency Italian lira (ITL).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency ITL = new Currency { m_Value = "ITL" };
+        public static readonly Currency ITL = new Currency("ITL");
 
         /// <summary>Describes the currency Lithuanian litas (LTL).</summary>
         /// <remarks>End date is 2014-12-31.</remarks>
-        public static readonly Currency LTL = new Currency { m_Value = "LTL" };
+        public static readonly Currency LTL = new Currency("LTL");
 
         /// <summary>Describes the currency Luxembourgish franc (LUF).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency LUF = new Currency { m_Value = "LUF" };
+        public static readonly Currency LUF = new Currency("LUF");
 
         /// <summary>Describes the currency Latvian lats (LVL).</summary>
         /// <remarks>End date is 2014-01-01.</remarks>
-        public static readonly Currency LVL = new Currency { m_Value = "LVL" };
+        public static readonly Currency LVL = new Currency("LVL");
 
         /// <summary>Describes the currency Monégasque franc (MCF).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency MCF = new Currency { m_Value = "MCF" };
+        public static readonly Currency MCF = new Currency("MCF");
 
         /// <summary>Describes the currency Maltese lira (MTL).</summary>
         /// <remarks>End date is 2007-12-31.</remarks>
-        public static readonly Currency MTL = new Currency { m_Value = "MTL" };
+        public static readonly Currency MTL = new Currency("MTL");
 
         /// <summary>Describes the currency Dutch guilder (NLG).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency NLG = new Currency { m_Value = "NLG" };
+        public static readonly Currency NLG = new Currency("NLG");
 
         /// <summary>Describes the currency Portuguese escudo (PTE).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency PTE = new Currency { m_Value = "PTE" };
+        public static readonly Currency PTE = new Currency("PTE");
 
         /// <summary>Describes the currency Slovenian tolar (SIT).</summary>
         /// <remarks>End date is 2007-01-01.</remarks>
-        public static readonly Currency SIT = new Currency { m_Value = "SIT" };
+        public static readonly Currency SIT = new Currency("SIT");
 
         /// <summary>Describes the currency Slovak koruna (SKK).</summary>
         /// <remarks>End date is 2009-01-01.</remarks>
-        public static readonly Currency SKK = new Currency { m_Value = "SKK" };
+        public static readonly Currency SKK = new Currency("SKK");
 
         /// <summary>Describes the currency Sammarinese lira (SML).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency SML = new Currency { m_Value = "SML" };
+        public static readonly Currency SML = new Currency("SML");
 
         /// <summary>Describes the currency Soviet Union ruble (SUR).</summary>
         /// <remarks>End date is 1990-12-31.</remarks>
-        public static readonly Currency SUR = new Currency { m_Value = "SUR" };
+        public static readonly Currency SUR = new Currency("SUR");
 
         /// <summary>Describes the currency Vatican lira (VAL).</summary>
         /// <remarks>End date is 2001-12-31.</remarks>
-        public static readonly Currency VAL = new Currency { m_Value = "VAL" };
+        public static readonly Currency VAL = new Currency("VAL");
 
         /// <summary>Describes the currency Yugoslav dinar (YOU).</summary>
         /// <remarks>End date is 1993-12-31.</remarks>
-        public static readonly Currency YOU = new Currency { m_Value = "YOU" };
+        public static readonly Currency YOU = new Currency("YOU");
 
         /// <summary>Describes the currency Yugoslav dinar (YUD).</summary>
         /// <remarks>End date is 1989-12-31.</remarks>
-        public static readonly Currency YUD = new Currency { m_Value = "YUD" };
+        public static readonly Currency YUD = new Currency("YUD");
 
         /// <summary>Describes the currency Yugoslav dinar (YUG).</summary>
         /// <remarks>End date is 1994-01-23.</remarks>
-        public static readonly Currency YUG = new Currency { m_Value = "YUG" };
+        public static readonly Currency YUG = new Currency("YUG");
 
         /// <summary>Describes the currency Yugoslav dinar (YUM).</summary>
         /// <remarks>End date is 2003-07-02.</remarks>
-        public static readonly Currency YUM = new Currency { m_Value = "YUM" };
+        public static readonly Currency YUM = new Currency("YUM");
 
         /// <summary>Describes the currency Yugoslav dinar (YUN).</summary>
         /// <remarks>End date is 1992-06-30.</remarks>
-        public static readonly Currency YUN = new Currency { m_Value = "YUN" };
+        public static readonly Currency YUN = new Currency("YUN");
 
         /// <summary>Describes the currency Yugoslav dinar (YUR).</summary>
         /// <remarks>End date is 1993-09-30.</remarks>
-        public static readonly Currency YUR = new Currency { m_Value = "YUR" };
+        public static readonly Currency YUR = new Currency("YUR");
 
         /// <summary>Describes the currency Zaïrean new zaïre (ZRN).</summary>
         /// <remarks>End date is 1996-12-31.</remarks>
-        public static readonly Currency ZRN = new Currency { m_Value = "ZRN" };
+        public static readonly Currency ZRN = new Currency("ZRN");
 
         /// <summary>Describes the currency Zaïrean zaïre (ZRZ).</summary>
         /// <remarks>End date is 1992-12-31.</remarks>
-        public static readonly Currency ZRZ = new Currency { m_Value = "ZRZ" };
+        public static readonly Currency ZRZ = new Currency("ZRZ");
 
         /// <summary>Describes the currency Zimbabwe dollar (ZWC).</summary>
         /// <remarks>End date is 1980-04-17.</remarks>
-        public static readonly Currency ZWC = new Currency { m_Value = "ZWC" };
+        public static readonly Currency ZWC = new Currency("ZWC");
 
         /// <summary>Describes the currency Zimbabwe dollar (ZWD).</summary>
         /// <remarks>End date is 2006-07-31.</remarks>
-        public static readonly Currency ZWD = new Currency { m_Value = "ZWD" };
+        public static readonly Currency ZWD = new Currency("ZWD");
 
         /// <summary>Describes the currency Zimbabwe dollar (ZWL).</summary>
         /// <remarks>End date is 2009-04-12.</remarks>
-        public static readonly Currency ZWL = new Currency { m_Value = "ZWL" };
+        public static readonly Currency ZWL = new Currency("ZWL");
 
         /// <summary>Describes the currency Zimbabwe dollar (ZWN).</summary>
         /// <remarks>End date is 2008-07-31.</remarks>
-        public static readonly Currency ZWN = new Currency { m_Value = "ZWN" };
+        public static readonly Currency ZWN = new Currency("ZWN");
 
         /// <summary>Describes the currency Zimbabwe dollar (ZWR).</summary>
         /// <remarks>End date is 2009-02-02.</remarks>
-        public static readonly Currency ZWR = new Currency { m_Value = "ZWR" };
+        public static readonly Currency ZWR = new Currency("ZWR");
 
     }
 }

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -370,7 +370,7 @@ namespace Qowaiv.Financial
         {
             Guard.NotNull(info, nameof(info));
             m_Value = info.GetDecimal("Value");
-            m_Currency = Currency.Parse(info.GetString(nameof(Currency)));
+            m_Currency = Currency.Parse(info.GetString(nameof(Currency)), CultureInfo.InvariantCulture);
         }
 
         /// <summary>Adds the underlying property of Money to the serialization info.</summary>

--- a/src/Qowaiv/Gender.cs
+++ b/src/Qowaiv/Gender.cs
@@ -203,7 +203,7 @@ namespace Qowaiv
 
             if (Parsings[c].TryGetValue(str, out byte val) || Parsings[CultureInfo.InvariantCulture].TryGetValue(str, out val))
             {
-                result = new Gender { m_Value = val };
+                result = new Gender(val);
                 return true;
             }
             return false;
@@ -263,7 +263,7 @@ namespace Qowaiv
 
             if (!val.HasValue || FromInt32s.TryGetValue(val.Value, out b))
             {
-                result = new Gender { m_Value = b };
+                result = new Gender(b);
                 return true;
             }
             return false;

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -350,7 +350,7 @@ namespace Qowaiv.Globalization
             ResourceManager
                 .GetString("All")
                 .Split(';')
-                .Select(str => new Country { m_Value = str })
+                .Select(str => new Country(str))
                 .ToList());
 
         #endregion
@@ -422,9 +422,10 @@ namespace Qowaiv.Globalization
             {
                 if (Parsings.ContainsKey(culture)) { return; }
 
-                Parsings[culture] = new Dictionary<string, string>();
-
-                Parsings[culture][Unknown.GetDisplayName(culture)] = Unknown.m_Value;
+                Parsings[culture] = new Dictionary<string, string>
+                {
+                    [Unknown.GetDisplayName(culture)] = Unknown.m_Value
+                };
 
                 foreach (var country in All)
                 {
@@ -448,7 +449,7 @@ namespace Qowaiv.Globalization
         };
 
         /// <summary>The locker for adding a culture.</summary>
-        private static volatile object locker = new object();
+        private static readonly object locker = new object();
 
         #endregion
     }

--- a/src/Qowaiv/Globalization/CountryConstants.cs
+++ b/src/Qowaiv/Globalization/CountryConstants.cs
@@ -7,794 +7,794 @@ namespace Qowaiv.Globalization
     public partial struct Country
     {
         /// <summary>Describes the country Andorra (AD).</summary>
-        public static readonly Country AD = new Country { m_Value = "AD" };
+        public static readonly Country AD = new Country("AD");
 
         /// <summary>Describes the country United Arab Emirates (AE).</summary>
-        public static readonly Country AE = new Country { m_Value = "AE" };
+        public static readonly Country AE = new Country("AE");
 
         /// <summary>Describes the country Afghanistan (AF).</summary>
-        public static readonly Country AF = new Country { m_Value = "AF" };
+        public static readonly Country AF = new Country("AF");
 
         /// <summary>Describes the country Antigua And Barbuda (AG).</summary>
-        public static readonly Country AG = new Country { m_Value = "AG" };
+        public static readonly Country AG = new Country("AG");
 
         /// <summary>Describes the country Anguilla (AI).</summary>
-        public static readonly Country AI = new Country { m_Value = "AI" };
+        public static readonly Country AI = new Country("AI");
 
         /// <summary>Describes the country Albania (AL).</summary>
-        public static readonly Country AL = new Country { m_Value = "AL" };
+        public static readonly Country AL = new Country("AL");
 
         /// <summary>Describes the country Armenia (AM).</summary>
-        public static readonly Country AM = new Country { m_Value = "AM" };
+        public static readonly Country AM = new Country("AM");
 
         /// <summary>Describes the country Angola (AO).</summary>
-        public static readonly Country AO = new Country { m_Value = "AO" };
+        public static readonly Country AO = new Country("AO");
 
         /// <summary>Describes the country Antarctica (AQ).</summary>
-        public static readonly Country AQ = new Country { m_Value = "AQ" };
+        public static readonly Country AQ = new Country("AQ");
 
         /// <summary>Describes the country Argentina (AR).</summary>
-        public static readonly Country AR = new Country { m_Value = "AR" };
+        public static readonly Country AR = new Country("AR");
 
         /// <summary>Describes the country American Samoa (AS).</summary>
-        public static readonly Country AS = new Country { m_Value = "AS" };
+        public static readonly Country AS = new Country("AS");
 
         /// <summary>Describes the country Austria (AT).</summary>
-        public static readonly Country AT = new Country { m_Value = "AT" };
+        public static readonly Country AT = new Country("AT");
 
         /// <summary>Describes the country Australia (AU).</summary>
-        public static readonly Country AU = new Country { m_Value = "AU" };
+        public static readonly Country AU = new Country("AU");
 
         /// <summary>Describes the country Aruba (AW).</summary>
-        public static readonly Country AW = new Country { m_Value = "AW" };
+        public static readonly Country AW = new Country("AW");
 
         /// <summary>Describes the country Åland Islands (AX).</summary>
-        public static readonly Country AX = new Country { m_Value = "AX" };
+        public static readonly Country AX = new Country("AX");
 
         /// <summary>Describes the country Azerbaijan (AZ).</summary>
-        public static readonly Country AZ = new Country { m_Value = "AZ" };
+        public static readonly Country AZ = new Country("AZ");
 
         /// <summary>Describes the country Bosnia And Herzegovina (BA).</summary>
-        public static readonly Country BA = new Country { m_Value = "BA" };
+        public static readonly Country BA = new Country("BA");
 
         /// <summary>Describes the country Barbados (BB).</summary>
-        public static readonly Country BB = new Country { m_Value = "BB" };
+        public static readonly Country BB = new Country("BB");
 
         /// <summary>Describes the country Bangladesh (BD).</summary>
-        public static readonly Country BD = new Country { m_Value = "BD" };
+        public static readonly Country BD = new Country("BD");
 
         /// <summary>Describes the country Belgium (BE).</summary>
-        public static readonly Country BE = new Country { m_Value = "BE" };
+        public static readonly Country BE = new Country("BE");
 
         /// <summary>Describes the country Burkina Faso (BF).</summary>
-        public static readonly Country BF = new Country { m_Value = "BF" };
+        public static readonly Country BF = new Country("BF");
 
         /// <summary>Describes the country Bulgaria (BG).</summary>
-        public static readonly Country BG = new Country { m_Value = "BG" };
+        public static readonly Country BG = new Country("BG");
 
         /// <summary>Describes the country Bahrain (BH).</summary>
-        public static readonly Country BH = new Country { m_Value = "BH" };
+        public static readonly Country BH = new Country("BH");
 
         /// <summary>Describes the country Burundi (BI).</summary>
-        public static readonly Country BI = new Country { m_Value = "BI" };
+        public static readonly Country BI = new Country("BI");
 
         /// <summary>Describes the country Benin (BJ).</summary>
-        public static readonly Country BJ = new Country { m_Value = "BJ" };
+        public static readonly Country BJ = new Country("BJ");
 
         /// <summary>Describes the country Saint Barthélemy (BL).</summary>
-        public static readonly Country BL = new Country { m_Value = "BL" };
+        public static readonly Country BL = new Country("BL");
 
         /// <summary>Describes the country Bermuda (BM).</summary>
-        public static readonly Country BM = new Country { m_Value = "BM" };
+        public static readonly Country BM = new Country("BM");
 
         /// <summary>Describes the country Brunei Darussalam (BN).</summary>
-        public static readonly Country BN = new Country { m_Value = "BN" };
+        public static readonly Country BN = new Country("BN");
 
         /// <summary>Describes the country Bolivia (BO).</summary>
-        public static readonly Country BO = new Country { m_Value = "BO" };
+        public static readonly Country BO = new Country("BO");
 
         /// <summary>Describes the country Bonaire (BQ).</summary>
-        public static readonly Country BQ = new Country { m_Value = "BQ" };
+        public static readonly Country BQ = new Country("BQ");
 
         /// <summary>Describes the country Brazil (BR).</summary>
-        public static readonly Country BR = new Country { m_Value = "BR" };
+        public static readonly Country BR = new Country("BR");
 
         /// <summary>Describes the country Bahamas (BS).</summary>
-        public static readonly Country BS = new Country { m_Value = "BS" };
+        public static readonly Country BS = new Country("BS");
 
         /// <summary>Describes the country Bhutan (BT).</summary>
-        public static readonly Country BT = new Country { m_Value = "BT" };
+        public static readonly Country BT = new Country("BT");
 
         /// <summary>Describes the country Bouvet Island (BV).</summary>
-        public static readonly Country BV = new Country { m_Value = "BV" };
+        public static readonly Country BV = new Country("BV");
 
         /// <summary>Describes the country Botswana (BW).</summary>
-        public static readonly Country BW = new Country { m_Value = "BW" };
+        public static readonly Country BW = new Country("BW");
 
         /// <summary>Describes the country Belarus (BY).</summary>
-        public static readonly Country BY = new Country { m_Value = "BY" };
+        public static readonly Country BY = new Country("BY");
 
         /// <summary>Describes the country Belize (BZ).</summary>
-        public static readonly Country BZ = new Country { m_Value = "BZ" };
+        public static readonly Country BZ = new Country("BZ");
 
         /// <summary>Describes the country Canada (CA).</summary>
-        public static readonly Country CA = new Country { m_Value = "CA" };
+        public static readonly Country CA = new Country("CA");
 
         /// <summary>Describes the country Cocos (CC).</summary>
-        public static readonly Country CC = new Country { m_Value = "CC" };
+        public static readonly Country CC = new Country("CC");
 
         /// <summary>Describes the country Congo (CD).</summary>
-        public static readonly Country CD = new Country { m_Value = "CD" };
+        public static readonly Country CD = new Country("CD");
 
         /// <summary>Describes the country Central African Republic (CF).</summary>
-        public static readonly Country CF = new Country { m_Value = "CF" };
+        public static readonly Country CF = new Country("CF");
 
         /// <summary>Describes the country Congo (CG).</summary>
-        public static readonly Country CG = new Country { m_Value = "CG" };
+        public static readonly Country CG = new Country("CG");
 
         /// <summary>Describes the country Switzerland (CH).</summary>
-        public static readonly Country CH = new Country { m_Value = "CH" };
+        public static readonly Country CH = new Country("CH");
 
         /// <summary>Describes the country Côte D'Ivoire (CI).</summary>
-        public static readonly Country CI = new Country { m_Value = "CI" };
+        public static readonly Country CI = new Country("CI");
 
         /// <summary>Describes the country Cook Islands (CK).</summary>
-        public static readonly Country CK = new Country { m_Value = "CK" };
+        public static readonly Country CK = new Country("CK");
 
         /// <summary>Describes the country Chile (CL).</summary>
-        public static readonly Country CL = new Country { m_Value = "CL" };
+        public static readonly Country CL = new Country("CL");
 
         /// <summary>Describes the country Cameroon (CM).</summary>
-        public static readonly Country CM = new Country { m_Value = "CM" };
+        public static readonly Country CM = new Country("CM");
 
         /// <summary>Describes the country China (CN).</summary>
-        public static readonly Country CN = new Country { m_Value = "CN" };
+        public static readonly Country CN = new Country("CN");
 
         /// <summary>Describes the country Colombia (CO).</summary>
-        public static readonly Country CO = new Country { m_Value = "CO" };
+        public static readonly Country CO = new Country("CO");
 
         /// <summary>Describes the country Costa Rica (CR).</summary>
-        public static readonly Country CR = new Country { m_Value = "CR" };
+        public static readonly Country CR = new Country("CR");
 
         /// <summary>Describes the country Cuba (CU).</summary>
-        public static readonly Country CU = new Country { m_Value = "CU" };
+        public static readonly Country CU = new Country("CU");
 
         /// <summary>Describes the country Cape Verde (CV).</summary>
-        public static readonly Country CV = new Country { m_Value = "CV" };
+        public static readonly Country CV = new Country("CV");
 
         /// <summary>Describes the country Curaçao (CW).</summary>
-        public static readonly Country CW = new Country { m_Value = "CW" };
+        public static readonly Country CW = new Country("CW");
 
         /// <summary>Describes the country Christmas Island (CX).</summary>
-        public static readonly Country CX = new Country { m_Value = "CX" };
+        public static readonly Country CX = new Country("CX");
 
         /// <summary>Describes the country Cyprus (CY).</summary>
-        public static readonly Country CY = new Country { m_Value = "CY" };
+        public static readonly Country CY = new Country("CY");
 
         /// <summary>Describes the country Czech Republic (CZ).</summary>
-        public static readonly Country CZ = new Country { m_Value = "CZ" };
+        public static readonly Country CZ = new Country("CZ");
 
         /// <summary>Describes the country Germany (DE).</summary>
-        public static readonly Country DE = new Country { m_Value = "DE" };
+        public static readonly Country DE = new Country("DE");
 
         /// <summary>Describes the country Djibouti (DJ).</summary>
-        public static readonly Country DJ = new Country { m_Value = "DJ" };
+        public static readonly Country DJ = new Country("DJ");
 
         /// <summary>Describes the country Denmark (DK).</summary>
-        public static readonly Country DK = new Country { m_Value = "DK" };
+        public static readonly Country DK = new Country("DK");
 
         /// <summary>Describes the country Dominica (DM).</summary>
-        public static readonly Country DM = new Country { m_Value = "DM" };
+        public static readonly Country DM = new Country("DM");
 
         /// <summary>Describes the country Dominican Republic (DO).</summary>
-        public static readonly Country DO = new Country { m_Value = "DO" };
+        public static readonly Country DO = new Country("DO");
 
         /// <summary>Describes the country Algeria (DZ).</summary>
-        public static readonly Country DZ = new Country { m_Value = "DZ" };
+        public static readonly Country DZ = new Country("DZ");
 
         /// <summary>Describes the country Ecuador (EC).</summary>
-        public static readonly Country EC = new Country { m_Value = "EC" };
+        public static readonly Country EC = new Country("EC");
 
         /// <summary>Describes the country Estonia (EE).</summary>
-        public static readonly Country EE = new Country { m_Value = "EE" };
+        public static readonly Country EE = new Country("EE");
 
         /// <summary>Describes the country Egypt (EG).</summary>
-        public static readonly Country EG = new Country { m_Value = "EG" };
+        public static readonly Country EG = new Country("EG");
 
         /// <summary>Describes the country Western Sahara (EH).</summary>
-        public static readonly Country EH = new Country { m_Value = "EH" };
+        public static readonly Country EH = new Country("EH");
 
         /// <summary>Describes the country Eritrea (ER).</summary>
-        public static readonly Country ER = new Country { m_Value = "ER" };
+        public static readonly Country ER = new Country("ER");
 
         /// <summary>Describes the country Spain (ES).</summary>
-        public static readonly Country ES = new Country { m_Value = "ES" };
+        public static readonly Country ES = new Country("ES");
 
         /// <summary>Describes the country Ethiopia (ET).</summary>
-        public static readonly Country ET = new Country { m_Value = "ET" };
+        public static readonly Country ET = new Country("ET");
 
         /// <summary>Describes the country Finland (FI).</summary>
-        public static readonly Country FI = new Country { m_Value = "FI" };
+        public static readonly Country FI = new Country("FI");
 
         /// <summary>Describes the country Fiji (FJ).</summary>
-        public static readonly Country FJ = new Country { m_Value = "FJ" };
+        public static readonly Country FJ = new Country("FJ");
 
         /// <summary>Describes the country Falkland Islands (FK).</summary>
-        public static readonly Country FK = new Country { m_Value = "FK" };
+        public static readonly Country FK = new Country("FK");
 
         /// <summary>Describes the country Micronesia (FM).</summary>
-        public static readonly Country FM = new Country { m_Value = "FM" };
+        public static readonly Country FM = new Country("FM");
 
         /// <summary>Describes the country Faroe Islands (FO).</summary>
-        public static readonly Country FO = new Country { m_Value = "FO" };
+        public static readonly Country FO = new Country("FO");
 
         /// <summary>Describes the country France (FR).</summary>
-        public static readonly Country FR = new Country { m_Value = "FR" };
+        public static readonly Country FR = new Country("FR");
 
         /// <summary>Describes the country Gabon (GA).</summary>
-        public static readonly Country GA = new Country { m_Value = "GA" };
+        public static readonly Country GA = new Country("GA");
 
         /// <summary>Describes the country United Kingdom (GB).</summary>
-        public static readonly Country GB = new Country { m_Value = "GB" };
+        public static readonly Country GB = new Country("GB");
 
         /// <summary>Describes the country Grenada (GD).</summary>
-        public static readonly Country GD = new Country { m_Value = "GD" };
+        public static readonly Country GD = new Country("GD");
 
         /// <summary>Describes the country Georgia (GE).</summary>
-        public static readonly Country GE = new Country { m_Value = "GE" };
+        public static readonly Country GE = new Country("GE");
 
         /// <summary>Describes the country French Guiana (GF).</summary>
-        public static readonly Country GF = new Country { m_Value = "GF" };
+        public static readonly Country GF = new Country("GF");
 
         /// <summary>Describes the country Guernsey (GG).</summary>
-        public static readonly Country GG = new Country { m_Value = "GG" };
+        public static readonly Country GG = new Country("GG");
 
         /// <summary>Describes the country Ghana (GH).</summary>
-        public static readonly Country GH = new Country { m_Value = "GH" };
+        public static readonly Country GH = new Country("GH");
 
         /// <summary>Describes the country Gibraltar (GI).</summary>
-        public static readonly Country GI = new Country { m_Value = "GI" };
+        public static readonly Country GI = new Country("GI");
 
         /// <summary>Describes the country Greenland (GL).</summary>
-        public static readonly Country GL = new Country { m_Value = "GL" };
+        public static readonly Country GL = new Country("GL");
 
         /// <summary>Describes the country Gambia (GM).</summary>
-        public static readonly Country GM = new Country { m_Value = "GM" };
+        public static readonly Country GM = new Country("GM");
 
         /// <summary>Describes the country Guinea (GN).</summary>
-        public static readonly Country GN = new Country { m_Value = "GN" };
+        public static readonly Country GN = new Country("GN");
 
         /// <summary>Describes the country Guadeloupe (GP).</summary>
-        public static readonly Country GP = new Country { m_Value = "GP" };
+        public static readonly Country GP = new Country("GP");
 
         /// <summary>Describes the country Equatorial Guinea (GQ).</summary>
-        public static readonly Country GQ = new Country { m_Value = "GQ" };
+        public static readonly Country GQ = new Country("GQ");
 
         /// <summary>Describes the country Greece (GR).</summary>
-        public static readonly Country GR = new Country { m_Value = "GR" };
+        public static readonly Country GR = new Country("GR");
 
         /// <summary>Describes the country South Georgia And The South Sandwich Islands (GS).</summary>
-        public static readonly Country GS = new Country { m_Value = "GS" };
+        public static readonly Country GS = new Country("GS");
 
         /// <summary>Describes the country Guatemala (GT).</summary>
-        public static readonly Country GT = new Country { m_Value = "GT" };
+        public static readonly Country GT = new Country("GT");
 
         /// <summary>Describes the country Guam (GU).</summary>
-        public static readonly Country GU = new Country { m_Value = "GU" };
+        public static readonly Country GU = new Country("GU");
 
         /// <summary>Describes the country Guinea-Bissau (GW).</summary>
-        public static readonly Country GW = new Country { m_Value = "GW" };
+        public static readonly Country GW = new Country("GW");
 
         /// <summary>Describes the country Guyana (GY).</summary>
-        public static readonly Country GY = new Country { m_Value = "GY" };
+        public static readonly Country GY = new Country("GY");
 
         /// <summary>Describes the country Hong Kong (HK).</summary>
-        public static readonly Country HK = new Country { m_Value = "HK" };
+        public static readonly Country HK = new Country("HK");
 
         /// <summary>Describes the country Heard Island And Mcdonald Islands (HM).</summary>
-        public static readonly Country HM = new Country { m_Value = "HM" };
+        public static readonly Country HM = new Country("HM");
 
         /// <summary>Describes the country Honduras (HN).</summary>
-        public static readonly Country HN = new Country { m_Value = "HN" };
+        public static readonly Country HN = new Country("HN");
 
         /// <summary>Describes the country Croatia (HR).</summary>
-        public static readonly Country HR = new Country { m_Value = "HR" };
+        public static readonly Country HR = new Country("HR");
 
         /// <summary>Describes the country Haiti (HT).</summary>
-        public static readonly Country HT = new Country { m_Value = "HT" };
+        public static readonly Country HT = new Country("HT");
 
         /// <summary>Describes the country Hungary (HU).</summary>
-        public static readonly Country HU = new Country { m_Value = "HU" };
+        public static readonly Country HU = new Country("HU");
 
         /// <summary>Describes the country Indonesia (ID).</summary>
-        public static readonly Country ID = new Country { m_Value = "ID" };
+        public static readonly Country ID = new Country("ID");
 
         /// <summary>Describes the country Ireland (IE).</summary>
-        public static readonly Country IE = new Country { m_Value = "IE" };
+        public static readonly Country IE = new Country("IE");
 
         /// <summary>Describes the country Israel (IL).</summary>
-        public static readonly Country IL = new Country { m_Value = "IL" };
+        public static readonly Country IL = new Country("IL");
 
         /// <summary>Describes the country Isle Of Man (IM).</summary>
-        public static readonly Country IM = new Country { m_Value = "IM" };
+        public static readonly Country IM = new Country("IM");
 
         /// <summary>Describes the country India (IN).</summary>
-        public static readonly Country IN = new Country { m_Value = "IN" };
+        public static readonly Country IN = new Country("IN");
 
         /// <summary>Describes the country British Indian Ocean Territory (IO).</summary>
-        public static readonly Country IO = new Country { m_Value = "IO" };
+        public static readonly Country IO = new Country("IO");
 
         /// <summary>Describes the country Iraq (IQ).</summary>
-        public static readonly Country IQ = new Country { m_Value = "IQ" };
+        public static readonly Country IQ = new Country("IQ");
 
         /// <summary>Describes the country Iran (IR).</summary>
-        public static readonly Country IR = new Country { m_Value = "IR" };
+        public static readonly Country IR = new Country("IR");
 
         /// <summary>Describes the country Iceland (IS).</summary>
-        public static readonly Country IS = new Country { m_Value = "IS" };
+        public static readonly Country IS = new Country("IS");
 
         /// <summary>Describes the country Italy (IT).</summary>
-        public static readonly Country IT = new Country { m_Value = "IT" };
+        public static readonly Country IT = new Country("IT");
 
         /// <summary>Describes the country Jersey (JE).</summary>
-        public static readonly Country JE = new Country { m_Value = "JE" };
+        public static readonly Country JE = new Country("JE");
 
         /// <summary>Describes the country Jamaica (JM).</summary>
-        public static readonly Country JM = new Country { m_Value = "JM" };
+        public static readonly Country JM = new Country("JM");
 
         /// <summary>Describes the country Jordan (JO).</summary>
-        public static readonly Country JO = new Country { m_Value = "JO" };
+        public static readonly Country JO = new Country("JO");
 
         /// <summary>Describes the country Japan (JP).</summary>
-        public static readonly Country JP = new Country { m_Value = "JP" };
+        public static readonly Country JP = new Country("JP");
 
         /// <summary>Describes the country Kenya (KE).</summary>
-        public static readonly Country KE = new Country { m_Value = "KE" };
+        public static readonly Country KE = new Country("KE");
 
         /// <summary>Describes the country Kyrgyzstan (KG).</summary>
-        public static readonly Country KG = new Country { m_Value = "KG" };
+        public static readonly Country KG = new Country("KG");
 
         /// <summary>Describes the country Cambodia (KH).</summary>
-        public static readonly Country KH = new Country { m_Value = "KH" };
+        public static readonly Country KH = new Country("KH");
 
         /// <summary>Describes the country Kiribati (KI).</summary>
-        public static readonly Country KI = new Country { m_Value = "KI" };
+        public static readonly Country KI = new Country("KI");
 
         /// <summary>Describes the country Comoros (KM).</summary>
-        public static readonly Country KM = new Country { m_Value = "KM" };
+        public static readonly Country KM = new Country("KM");
 
         /// <summary>Describes the country Saint Kitts And Nevis (KN).</summary>
-        public static readonly Country KN = new Country { m_Value = "KN" };
+        public static readonly Country KN = new Country("KN");
 
         /// <summary>Describes the country Korea (KP).</summary>
-        public static readonly Country KP = new Country { m_Value = "KP" };
+        public static readonly Country KP = new Country("KP");
 
         /// <summary>Describes the country Korea (KR).</summary>
-        public static readonly Country KR = new Country { m_Value = "KR" };
+        public static readonly Country KR = new Country("KR");
 
         /// <summary>Describes the country Kuwait (KW).</summary>
-        public static readonly Country KW = new Country { m_Value = "KW" };
+        public static readonly Country KW = new Country("KW");
 
         /// <summary>Describes the country Cayman Islands (KY).</summary>
-        public static readonly Country KY = new Country { m_Value = "KY" };
+        public static readonly Country KY = new Country("KY");
 
         /// <summary>Describes the country Kazakhstan (KZ).</summary>
-        public static readonly Country KZ = new Country { m_Value = "KZ" };
+        public static readonly Country KZ = new Country("KZ");
 
         /// <summary>Describes the country Lao People'S Democratic Republic (LA).</summary>
-        public static readonly Country LA = new Country { m_Value = "LA" };
+        public static readonly Country LA = new Country("LA");
 
         /// <summary>Describes the country Lebanon (LB).</summary>
-        public static readonly Country LB = new Country { m_Value = "LB" };
+        public static readonly Country LB = new Country("LB");
 
         /// <summary>Describes the country Saint Lucia (LC).</summary>
-        public static readonly Country LC = new Country { m_Value = "LC" };
+        public static readonly Country LC = new Country("LC");
 
         /// <summary>Describes the country Liechtenstein (LI).</summary>
-        public static readonly Country LI = new Country { m_Value = "LI" };
+        public static readonly Country LI = new Country("LI");
 
         /// <summary>Describes the country Sri Lanka (LK).</summary>
-        public static readonly Country LK = new Country { m_Value = "LK" };
+        public static readonly Country LK = new Country("LK");
 
         /// <summary>Describes the country Liberia (LR).</summary>
-        public static readonly Country LR = new Country { m_Value = "LR" };
+        public static readonly Country LR = new Country("LR");
 
         /// <summary>Describes the country Lesotho (LS).</summary>
-        public static readonly Country LS = new Country { m_Value = "LS" };
+        public static readonly Country LS = new Country("LS");
 
         /// <summary>Describes the country Lithuania (LT).</summary>
-        public static readonly Country LT = new Country { m_Value = "LT" };
+        public static readonly Country LT = new Country("LT");
 
         /// <summary>Describes the country Luxembourg (LU).</summary>
-        public static readonly Country LU = new Country { m_Value = "LU" };
+        public static readonly Country LU = new Country("LU");
 
         /// <summary>Describes the country Latvia (LV).</summary>
-        public static readonly Country LV = new Country { m_Value = "LV" };
+        public static readonly Country LV = new Country("LV");
 
         /// <summary>Describes the country Libya (LY).</summary>
-        public static readonly Country LY = new Country { m_Value = "LY" };
+        public static readonly Country LY = new Country("LY");
 
         /// <summary>Describes the country Morocco (MA).</summary>
-        public static readonly Country MA = new Country { m_Value = "MA" };
+        public static readonly Country MA = new Country("MA");
 
         /// <summary>Describes the country Monaco (MC).</summary>
-        public static readonly Country MC = new Country { m_Value = "MC" };
+        public static readonly Country MC = new Country("MC");
 
         /// <summary>Describes the country Moldova (MD).</summary>
-        public static readonly Country MD = new Country { m_Value = "MD" };
+        public static readonly Country MD = new Country("MD");
 
         /// <summary>Describes the country Montenegro (ME).</summary>
-        public static readonly Country ME = new Country { m_Value = "ME" };
+        public static readonly Country ME = new Country("ME");
 
         /// <summary>Describes the country Saint Martin (MF).</summary>
-        public static readonly Country MF = new Country { m_Value = "MF" };
+        public static readonly Country MF = new Country("MF");
 
         /// <summary>Describes the country Madagascar (MG).</summary>
-        public static readonly Country MG = new Country { m_Value = "MG" };
+        public static readonly Country MG = new Country("MG");
 
         /// <summary>Describes the country Marshall Islands (MH).</summary>
-        public static readonly Country MH = new Country { m_Value = "MH" };
+        public static readonly Country MH = new Country("MH");
 
         /// <summary>Describes the country Macedonia (MK).</summary>
-        public static readonly Country MK = new Country { m_Value = "MK" };
+        public static readonly Country MK = new Country("MK");
 
         /// <summary>Describes the country Mali (ML).</summary>
-        public static readonly Country ML = new Country { m_Value = "ML" };
+        public static readonly Country ML = new Country("ML");
 
         /// <summary>Describes the country Myanmar (MM).</summary>
-        public static readonly Country MM = new Country { m_Value = "MM" };
+        public static readonly Country MM = new Country("MM");
 
         /// <summary>Describes the country Mongolia (MN).</summary>
-        public static readonly Country MN = new Country { m_Value = "MN" };
+        public static readonly Country MN = new Country("MN");
 
         /// <summary>Describes the country Macao (MO).</summary>
-        public static readonly Country MO = new Country { m_Value = "MO" };
+        public static readonly Country MO = new Country("MO");
 
         /// <summary>Describes the country Northern Mariana Islands (MP).</summary>
-        public static readonly Country MP = new Country { m_Value = "MP" };
+        public static readonly Country MP = new Country("MP");
 
         /// <summary>Describes the country Martinique (MQ).</summary>
-        public static readonly Country MQ = new Country { m_Value = "MQ" };
+        public static readonly Country MQ = new Country("MQ");
 
         /// <summary>Describes the country Mauritania (MR).</summary>
-        public static readonly Country MR = new Country { m_Value = "MR" };
+        public static readonly Country MR = new Country("MR");
 
         /// <summary>Describes the country Montserrat (MS).</summary>
-        public static readonly Country MS = new Country { m_Value = "MS" };
+        public static readonly Country MS = new Country("MS");
 
         /// <summary>Describes the country Malta (MT).</summary>
-        public static readonly Country MT = new Country { m_Value = "MT" };
+        public static readonly Country MT = new Country("MT");
 
         /// <summary>Describes the country Mauritius (MU).</summary>
-        public static readonly Country MU = new Country { m_Value = "MU" };
+        public static readonly Country MU = new Country("MU");
 
         /// <summary>Describes the country Maldives (MV).</summary>
-        public static readonly Country MV = new Country { m_Value = "MV" };
+        public static readonly Country MV = new Country("MV");
 
         /// <summary>Describes the country Malawi (MW).</summary>
-        public static readonly Country MW = new Country { m_Value = "MW" };
+        public static readonly Country MW = new Country("MW");
 
         /// <summary>Describes the country Mexico (MX).</summary>
-        public static readonly Country MX = new Country { m_Value = "MX" };
+        public static readonly Country MX = new Country("MX");
 
         /// <summary>Describes the country Malaysia (MY).</summary>
-        public static readonly Country MY = new Country { m_Value = "MY" };
+        public static readonly Country MY = new Country("MY");
 
         /// <summary>Describes the country Mozambique (MZ).</summary>
-        public static readonly Country MZ = new Country { m_Value = "MZ" };
+        public static readonly Country MZ = new Country("MZ");
 
         /// <summary>Describes the country Namibia (NA).</summary>
-        public static readonly Country NA = new Country { m_Value = "NA" };
+        public static readonly Country NA = new Country("NA");
 
         /// <summary>Describes the country New Caledonia (NC).</summary>
-        public static readonly Country NC = new Country { m_Value = "NC" };
+        public static readonly Country NC = new Country("NC");
 
         /// <summary>Describes the country Niger (NE).</summary>
-        public static readonly Country NE = new Country { m_Value = "NE" };
+        public static readonly Country NE = new Country("NE");
 
         /// <summary>Describes the country Norfolk Island (NF).</summary>
-        public static readonly Country NF = new Country { m_Value = "NF" };
+        public static readonly Country NF = new Country("NF");
 
         /// <summary>Describes the country Nigeria (NG).</summary>
-        public static readonly Country NG = new Country { m_Value = "NG" };
+        public static readonly Country NG = new Country("NG");
 
         /// <summary>Describes the country Nicaragua (NI).</summary>
-        public static readonly Country NI = new Country { m_Value = "NI" };
+        public static readonly Country NI = new Country("NI");
 
         /// <summary>Describes the country Netherlands (NL).</summary>
-        public static readonly Country NL = new Country { m_Value = "NL" };
+        public static readonly Country NL = new Country("NL");
 
         /// <summary>Describes the country Norway (NO).</summary>
-        public static readonly Country NO = new Country { m_Value = "NO" };
+        public static readonly Country NO = new Country("NO");
 
         /// <summary>Describes the country Nepal (NP).</summary>
-        public static readonly Country NP = new Country { m_Value = "NP" };
+        public static readonly Country NP = new Country("NP");
 
         /// <summary>Describes the country Nauru (NR).</summary>
-        public static readonly Country NR = new Country { m_Value = "NR" };
+        public static readonly Country NR = new Country("NR");
 
         /// <summary>Describes the country Niue (NU).</summary>
-        public static readonly Country NU = new Country { m_Value = "NU" };
+        public static readonly Country NU = new Country("NU");
 
         /// <summary>Describes the country New Zealand (NZ).</summary>
-        public static readonly Country NZ = new Country { m_Value = "NZ" };
+        public static readonly Country NZ = new Country("NZ");
 
         /// <summary>Describes the country Oman (OM).</summary>
-        public static readonly Country OM = new Country { m_Value = "OM" };
+        public static readonly Country OM = new Country("OM");
 
         /// <summary>Describes the country Panama (PA).</summary>
-        public static readonly Country PA = new Country { m_Value = "PA" };
+        public static readonly Country PA = new Country("PA");
 
         /// <summary>Describes the country Peru (PE).</summary>
-        public static readonly Country PE = new Country { m_Value = "PE" };
+        public static readonly Country PE = new Country("PE");
 
         /// <summary>Describes the country French Polynesia (PF).</summary>
-        public static readonly Country PF = new Country { m_Value = "PF" };
+        public static readonly Country PF = new Country("PF");
 
         /// <summary>Describes the country Papua New Guinea (PG).</summary>
-        public static readonly Country PG = new Country { m_Value = "PG" };
+        public static readonly Country PG = new Country("PG");
 
         /// <summary>Describes the country Philippines (PH).</summary>
-        public static readonly Country PH = new Country { m_Value = "PH" };
+        public static readonly Country PH = new Country("PH");
 
         /// <summary>Describes the country Pakistan (PK).</summary>
-        public static readonly Country PK = new Country { m_Value = "PK" };
+        public static readonly Country PK = new Country("PK");
 
         /// <summary>Describes the country Poland (PL).</summary>
-        public static readonly Country PL = new Country { m_Value = "PL" };
+        public static readonly Country PL = new Country("PL");
 
         /// <summary>Describes the country Saint Pierre And Miquelon (PM).</summary>
-        public static readonly Country PM = new Country { m_Value = "PM" };
+        public static readonly Country PM = new Country("PM");
 
         /// <summary>Describes the country Pitcairn (PN).</summary>
-        public static readonly Country PN = new Country { m_Value = "PN" };
+        public static readonly Country PN = new Country("PN");
 
         /// <summary>Describes the country Puerto Rico (PR).</summary>
-        public static readonly Country PR = new Country { m_Value = "PR" };
+        public static readonly Country PR = new Country("PR");
 
         /// <summary>Describes the country Palestinian Territory (PS).</summary>
-        public static readonly Country PS = new Country { m_Value = "PS" };
+        public static readonly Country PS = new Country("PS");
 
         /// <summary>Describes the country Portugal (PT).</summary>
-        public static readonly Country PT = new Country { m_Value = "PT" };
+        public static readonly Country PT = new Country("PT");
 
         /// <summary>Describes the country Palau (PW).</summary>
-        public static readonly Country PW = new Country { m_Value = "PW" };
+        public static readonly Country PW = new Country("PW");
 
         /// <summary>Describes the country Paraguay (PY).</summary>
-        public static readonly Country PY = new Country { m_Value = "PY" };
+        public static readonly Country PY = new Country("PY");
 
         /// <summary>Describes the country Qatar (QA).</summary>
-        public static readonly Country QA = new Country { m_Value = "QA" };
+        public static readonly Country QA = new Country("QA");
 
         /// <summary>Describes the country Réunion (RE).</summary>
-        public static readonly Country RE = new Country { m_Value = "RE" };
+        public static readonly Country RE = new Country("RE");
 
         /// <summary>Describes the country Romania (RO).</summary>
-        public static readonly Country RO = new Country { m_Value = "RO" };
+        public static readonly Country RO = new Country("RO");
 
         /// <summary>Describes the country Serbia (RS).</summary>
-        public static readonly Country RS = new Country { m_Value = "RS" };
+        public static readonly Country RS = new Country("RS");
 
         /// <summary>Describes the country Russian Federation (RU).</summary>
-        public static readonly Country RU = new Country { m_Value = "RU" };
+        public static readonly Country RU = new Country("RU");
 
         /// <summary>Describes the country Rwanda (RW).</summary>
-        public static readonly Country RW = new Country { m_Value = "RW" };
+        public static readonly Country RW = new Country("RW");
 
         /// <summary>Describes the country Saudi Arabia (SA).</summary>
-        public static readonly Country SA = new Country { m_Value = "SA" };
+        public static readonly Country SA = new Country("SA");
 
         /// <summary>Describes the country Solomon Islands (SB).</summary>
-        public static readonly Country SB = new Country { m_Value = "SB" };
+        public static readonly Country SB = new Country("SB");
 
         /// <summary>Describes the country Seychelles (SC).</summary>
-        public static readonly Country SC = new Country { m_Value = "SC" };
+        public static readonly Country SC = new Country("SC");
 
         /// <summary>Describes the country Sudan (SD).</summary>
-        public static readonly Country SD = new Country { m_Value = "SD" };
+        public static readonly Country SD = new Country("SD");
 
         /// <summary>Describes the country Sweden (SE).</summary>
-        public static readonly Country SE = new Country { m_Value = "SE" };
+        public static readonly Country SE = new Country("SE");
 
         /// <summary>Describes the country Singapore (SG).</summary>
-        public static readonly Country SG = new Country { m_Value = "SG" };
+        public static readonly Country SG = new Country("SG");
 
         /// <summary>Describes the country Saint Helena (SH).</summary>
-        public static readonly Country SH = new Country { m_Value = "SH" };
+        public static readonly Country SH = new Country("SH");
 
         /// <summary>Describes the country Slovenia (SI).</summary>
-        public static readonly Country SI = new Country { m_Value = "SI" };
+        public static readonly Country SI = new Country("SI");
 
         /// <summary>Describes the country Svalbard And Jan Mayen (SJ).</summary>
-        public static readonly Country SJ = new Country { m_Value = "SJ" };
+        public static readonly Country SJ = new Country("SJ");
 
         /// <summary>Describes the country Slovakia (SK).</summary>
-        public static readonly Country SK = new Country { m_Value = "SK" };
+        public static readonly Country SK = new Country("SK");
 
         /// <summary>Describes the country Sierra Leone (SL).</summary>
-        public static readonly Country SL = new Country { m_Value = "SL" };
+        public static readonly Country SL = new Country("SL");
 
         /// <summary>Describes the country San Marino (SM).</summary>
-        public static readonly Country SM = new Country { m_Value = "SM" };
+        public static readonly Country SM = new Country("SM");
 
         /// <summary>Describes the country Senegal (SN).</summary>
-        public static readonly Country SN = new Country { m_Value = "SN" };
+        public static readonly Country SN = new Country("SN");
 
         /// <summary>Describes the country Somalia (SO).</summary>
-        public static readonly Country SO = new Country { m_Value = "SO" };
+        public static readonly Country SO = new Country("SO");
 
         /// <summary>Describes the country Suriname (SR).</summary>
-        public static readonly Country SR = new Country { m_Value = "SR" };
+        public static readonly Country SR = new Country("SR");
 
         /// <summary>Describes the country South Sudan (SS).</summary>
-        public static readonly Country SS = new Country { m_Value = "SS" };
+        public static readonly Country SS = new Country("SS");
 
         /// <summary>Describes the country Sao Tome And Principe (ST).</summary>
-        public static readonly Country ST = new Country { m_Value = "ST" };
+        public static readonly Country ST = new Country("ST");
 
         /// <summary>Describes the country El Salvador (SV).</summary>
-        public static readonly Country SV = new Country { m_Value = "SV" };
+        public static readonly Country SV = new Country("SV");
 
         /// <summary>Describes the country Sint Maarten (SX).</summary>
-        public static readonly Country SX = new Country { m_Value = "SX" };
+        public static readonly Country SX = new Country("SX");
 
         /// <summary>Describes the country Syrian Arab Republic (SY).</summary>
-        public static readonly Country SY = new Country { m_Value = "SY" };
+        public static readonly Country SY = new Country("SY");
 
         /// <summary>Describes the country Swaziland (SZ).</summary>
-        public static readonly Country SZ = new Country { m_Value = "SZ" };
+        public static readonly Country SZ = new Country("SZ");
 
         /// <summary>Describes the country Turks And Caicos Islands (TC).</summary>
-        public static readonly Country TC = new Country { m_Value = "TC" };
+        public static readonly Country TC = new Country("TC");
 
         /// <summary>Describes the country Chad (TD).</summary>
-        public static readonly Country TD = new Country { m_Value = "TD" };
+        public static readonly Country TD = new Country("TD");
 
         /// <summary>Describes the country French Southern Territories (TF).</summary>
-        public static readonly Country TF = new Country { m_Value = "TF" };
+        public static readonly Country TF = new Country("TF");
 
         /// <summary>Describes the country Togo (TG).</summary>
-        public static readonly Country TG = new Country { m_Value = "TG" };
+        public static readonly Country TG = new Country("TG");
 
         /// <summary>Describes the country Thailand (TH).</summary>
-        public static readonly Country TH = new Country { m_Value = "TH" };
+        public static readonly Country TH = new Country("TH");
 
         /// <summary>Describes the country Tajikistan (TJ).</summary>
-        public static readonly Country TJ = new Country { m_Value = "TJ" };
+        public static readonly Country TJ = new Country("TJ");
 
         /// <summary>Describes the country Tokelau (TK).</summary>
-        public static readonly Country TK = new Country { m_Value = "TK" };
+        public static readonly Country TK = new Country("TK");
 
         /// <summary>Describes the country Timor-Leste (TL).</summary>
-        public static readonly Country TL = new Country { m_Value = "TL" };
+        public static readonly Country TL = new Country("TL");
 
         /// <summary>Describes the country Turkmenistan (TM).</summary>
-        public static readonly Country TM = new Country { m_Value = "TM" };
+        public static readonly Country TM = new Country("TM");
 
         /// <summary>Describes the country Tunisia (TN).</summary>
-        public static readonly Country TN = new Country { m_Value = "TN" };
+        public static readonly Country TN = new Country("TN");
 
         /// <summary>Describes the country Tonga (TO).</summary>
-        public static readonly Country TO = new Country { m_Value = "TO" };
+        public static readonly Country TO = new Country("TO");
 
         /// <summary>Describes the country Turkey (TR).</summary>
-        public static readonly Country TR = new Country { m_Value = "TR" };
+        public static readonly Country TR = new Country("TR");
 
         /// <summary>Describes the country Trinidad And Tobago (TT).</summary>
-        public static readonly Country TT = new Country { m_Value = "TT" };
+        public static readonly Country TT = new Country("TT");
 
         /// <summary>Describes the country Tuvalu (TV).</summary>
-        public static readonly Country TV = new Country { m_Value = "TV" };
+        public static readonly Country TV = new Country("TV");
 
         /// <summary>Describes the country Taiwan (TW).</summary>
-        public static readonly Country TW = new Country { m_Value = "TW" };
+        public static readonly Country TW = new Country("TW");
 
         /// <summary>Describes the country Tanzania (TZ).</summary>
-        public static readonly Country TZ = new Country { m_Value = "TZ" };
+        public static readonly Country TZ = new Country("TZ");
 
         /// <summary>Describes the country Ukraine (UA).</summary>
-        public static readonly Country UA = new Country { m_Value = "UA" };
+        public static readonly Country UA = new Country("UA");
 
         /// <summary>Describes the country Uganda (UG).</summary>
-        public static readonly Country UG = new Country { m_Value = "UG" };
+        public static readonly Country UG = new Country("UG");
 
         /// <summary>Describes the country United States Minor Outlying Islands (UM).</summary>
-        public static readonly Country UM = new Country { m_Value = "UM" };
+        public static readonly Country UM = new Country("UM");
 
         /// <summary>Describes the country United States (US).</summary>
-        public static readonly Country US = new Country { m_Value = "US" };
+        public static readonly Country US = new Country("US");
 
         /// <summary>Describes the country Uruguay (UY).</summary>
-        public static readonly Country UY = new Country { m_Value = "UY" };
+        public static readonly Country UY = new Country("UY");
 
         /// <summary>Describes the country Uzbekistan (UZ).</summary>
-        public static readonly Country UZ = new Country { m_Value = "UZ" };
+        public static readonly Country UZ = new Country("UZ");
 
         /// <summary>Describes the country Holy See (VA).</summary>
-        public static readonly Country VA = new Country { m_Value = "VA" };
+        public static readonly Country VA = new Country("VA");
 
         /// <summary>Describes the country Saint Vincent And The Grenadines (VC).</summary>
-        public static readonly Country VC = new Country { m_Value = "VC" };
+        public static readonly Country VC = new Country("VC");
 
         /// <summary>Describes the country Venezuela (VE).</summary>
-        public static readonly Country VE = new Country { m_Value = "VE" };
+        public static readonly Country VE = new Country("VE");
 
         /// <summary>Describes the country Virgin Islands (VG).</summary>
-        public static readonly Country VG = new Country { m_Value = "VG" };
+        public static readonly Country VG = new Country("VG");
 
         /// <summary>Describes the country Virgin Islands (VI).</summary>
-        public static readonly Country VI = new Country { m_Value = "VI" };
+        public static readonly Country VI = new Country("VI");
 
         /// <summary>Describes the country Viet Nam (VN).</summary>
-        public static readonly Country VN = new Country { m_Value = "VN" };
+        public static readonly Country VN = new Country("VN");
 
         /// <summary>Describes the country Vanuatu (VU).</summary>
-        public static readonly Country VU = new Country { m_Value = "VU" };
+        public static readonly Country VU = new Country("VU");
 
         /// <summary>Describes the country Wallis And Futuna (WF).</summary>
-        public static readonly Country WF = new Country { m_Value = "WF" };
+        public static readonly Country WF = new Country("WF");
 
         /// <summary>Describes the country Samoa (WS).</summary>
-        public static readonly Country WS = new Country { m_Value = "WS" };
+        public static readonly Country WS = new Country("WS");
 
         /// <summary>Describes the country Yemen (YE).</summary>
-        public static readonly Country YE = new Country { m_Value = "YE" };
+        public static readonly Country YE = new Country("YE");
 
         /// <summary>Describes the country Mayotte (YT).</summary>
-        public static readonly Country YT = new Country { m_Value = "YT" };
+        public static readonly Country YT = new Country("YT");
 
         /// <summary>Describes the country South Africa (ZA).</summary>
-        public static readonly Country ZA = new Country { m_Value = "ZA" };
+        public static readonly Country ZA = new Country("ZA");
 
         /// <summary>Describes the country Zambia (ZM).</summary>
-        public static readonly Country ZM = new Country { m_Value = "ZM" };
+        public static readonly Country ZM = new Country("ZM");
 
         /// <summary>Describes the country Zimbabwe (ZW).</summary>
-        public static readonly Country ZW = new Country { m_Value = "ZW" };
+        public static readonly Country ZW = new Country("ZW");
 
         /// <summary>Describes the country Netherlands Antilles (ANHH).</summary>
         /// <remarks>End date is 2010-10-10.</remarks>
-        public static readonly Country ANHH = new Country { m_Value = "ANHH" };
+        public static readonly Country ANHH = new Country("ANHH");
 
         /// <summary>Describes the country British Antarctic Territory (BQAQ).</summary>
         /// <remarks>End date is 1979-12-31.</remarks>
-        public static readonly Country BQAQ = new Country { m_Value = "BQAQ" };
+        public static readonly Country BQAQ = new Country("BQAQ");
 
         /// <summary>Describes the country Burma (BUMM).</summary>
         /// <remarks>End date is 1988-12-31.</remarks>
-        public static readonly Country BUMM = new Country { m_Value = "BUMM" };
+        public static readonly Country BUMM = new Country("BUMM");
 
         /// <summary>Describes the country Czechoslovakia (CSHH).</summary>
         /// <remarks>End date is 1992-12-31.</remarks>
-        public static readonly Country CSHH = new Country { m_Value = "CSHH" };
+        public static readonly Country CSHH = new Country("CSHH");
 
         /// <summary>Describes the country Serbia And Montenegro (CSXX).</summary>
         /// <remarks>End date is 2006-12-31.</remarks>
-        public static readonly Country CSXX = new Country { m_Value = "CSXX" };
+        public static readonly Country CSXX = new Country("CSXX");
 
         /// <summary>Describes the country German Democratic Republic (DDDE).</summary>
         /// <remarks>End date is 1990-10-03.</remarks>
-        public static readonly Country DDDE = new Country { m_Value = "DDDE" };
+        public static readonly Country DDDE = new Country("DDDE");
 
         /// <summary>Describes the country Upper Volta (HVBF).</summary>
         /// <remarks>End date is 1984-08-03.</remarks>
-        public static readonly Country HVBF = new Country { m_Value = "HVBF" };
+        public static readonly Country HVBF = new Country("HVBF");
 
         /// <summary>Describes the country Soviet Union (SUHH).</summary>
         /// <remarks>End date is 1991-12-31.</remarks>
-        public static readonly Country SUHH = new Country { m_Value = "SUHH" };
+        public static readonly Country SUHH = new Country("SUHH");
 
         /// <summary>Describes the country Yugoslavia (YUCS).</summary>
         /// <remarks>End date is 2002-12-31.</remarks>
-        public static readonly Country YUCS = new Country { m_Value = "YUCS" };
+        public static readonly Country YUCS = new Country("YUCS");
 
         /// <summary>Describes the country Zaire (ZRCD).</summary>
         /// <remarks>End date is 1996-05-17.</remarks>
-        public static readonly Country ZRCD = new Country { m_Value = "ZRCD" };
+        public static readonly Country ZRCD = new Country("ZRCD");
 
         /// <summary>Describes the country Kosovo (XK).</summary>
-        public static readonly Country XK = new Country { m_Value = "XK" };
+        public static readonly Country XK = new Country("XK");
 
     }
 }

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -241,7 +241,7 @@ namespace Qowaiv
             }
             if (IsValid(val.Value))
             {
-                result = new HouseNumber { m_Value = val.Value };
+                result = new HouseNumber(val.Value);
                 return true;
             }
             return false;

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -238,7 +238,7 @@ namespace Qowaiv
             }
             if (Pattern.IsMatch(s))
             {
-                result = new Month { m_Value = byte.Parse(s, formatProvider) };
+                result = new Month(byte.Parse(s, formatProvider));
                 return true;
             }
             else
@@ -249,7 +249,7 @@ namespace Qowaiv
                 if (Parsings[culture].TryGetValue(str, out byte m) ||
                     Parsings[CultureInfo.InvariantCulture].TryGetValue(str, out m))
                 {
-                    result = new Month { m_Value = m };
+                    result = new Month(m);
                     return true;
                 }
             }

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -722,7 +722,7 @@ namespace Qowaiv
         /// <param name="val" >
         /// A decimal describing a Percentage.
         /// </param >
-        public static Percentage Create(decimal val) => new Percentage { m_Value = val };
+        public static Percentage Create(decimal val) => new Percentage(val);
 
         /// <summary>Creates a Percentage from a Double.</summary >
         /// <param name="val" >

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -173,7 +173,7 @@ namespace Qowaiv.Security.Cryptography
             var bytes = new byte[val.Length];
             Array.Copy(val, bytes, val.Length);
 
-            return new CryptographicSeed { m_Value = bytes };
+            return new CryptographicSeed(bytes);
         }
 
         /// <summary>Creates a cryptographic seed from a GUID.</summary >

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -217,7 +217,7 @@ namespace Qowaiv.Statistics
 
                 if (double.TryParse(str, NumberStyles.Number, formatProvider, out var d) && !double.IsNaN(d) && !double.IsInfinity(d))
                 {
-                    result = new Elo { m_Value = d };
+                    result = new Elo(d);
                     return true;
                 }
             }

--- a/src/Qowaiv/Unknown.cs
+++ b/src/Qowaiv/Unknown.cs
@@ -79,6 +79,10 @@ namespace Qowaiv
         /// </remarks>
         public static object Value(Type type)
         {
+            if(type is null)
+            {
+                return null;
+            }
             if (UnknownValues.TryGetValue(type, out object unknown))
             {
                 return unknown;

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -70,7 +70,7 @@ namespace Qowaiv.Web
         public static readonly InternetMediaType Empty;
 
         /// <summary>Represents an unknown (but set) Internet media type.</summary>
-        public static readonly InternetMediaType Unknown = new InternetMediaType { m_Value = "application/octet-stream" };
+        public static readonly InternetMediaType Unknown = new InternetMediaType("application/octet-stream");
 
         /// <summary>Gets the number of characters of the Internet media type.</summary>
         public int Length => IsEmpty() ? 0 : m_Value.Length;

--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -196,7 +196,7 @@ namespace Qowaiv
             if (Parsings[culture].TryGetValue(str, out byte val) ||
                 Parsings[CultureInfo.InvariantCulture].TryGetValue(str, out val))
             {
-                result = new YesNo { m_Value = val };
+                result = new YesNo(val);
                 return true;
             }
             return false;


### PR DESCRIPTION
Since introducing the .generated files (almost) all SVO's have a private constructor. A lot of older code however did not use that one to create a new instance but used ``new SVO { m_Value = value }` instead. That has been changed. See #136 