### PR TITLE
Introdcution of Type.ToCSharpString()

### DIFF
--- a/src/Qowaiv/Reflection/QowaivType.cs
+++ b/src/Qowaiv/Reflection/QowaivType.cs
@@ -143,7 +143,7 @@ namespace Qowaiv.Reflection
                 // special case for nullables.
                 if (arguments.Length == 1 && type.GetGenericTypeDefinition() == typeof(Nullable<>))
                 {
-                    return sb.AppendType(arguments[0], withNamespace).Append("?");
+                    return sb.AppendType(arguments[0], withNamespace).Append('?');
                 }
 
                 sb.AppendNamespace(type, withNamespace)

--- a/src/Qowaiv/Reflection/QowaivType.cs
+++ b/src/Qowaiv/Reflection/QowaivType.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace Qowaiv.Reflection
 {
@@ -89,5 +91,108 @@ namespace Qowaiv.Reflection
             }
             return objectType;
         }
+        /// <summary>Gets a C# formatted <see cref="string"/> representing the <see cref="Type"/>.</summary>
+        /// <param name="type">
+        /// The type to format as C# string.
+        /// </param>
+        public static string ToCSharpString(this Type type) => type.ToCSharpString(false);
+
+        /// <summary>Gets a C# formatted <see cref="string"/> representing the <see cref="Type"/>.</summary>
+        /// <param name="type">
+        /// The type to format as C# string.
+        /// </param>
+        /// <param name="withNamespace">
+        /// Should the namespace be displayed or not.
+        /// </param>
+        public static string ToCSharpString(this Type type, bool withNamespace)
+        {
+            Guard.NotNull(type, nameof(type));
+            return new StringBuilder().AppendType(type, withNamespace).ToString();
+        }
+
+        private static StringBuilder AppendType(this StringBuilder sb, Type type, bool withNamespace)
+        {
+            if (type.IsArray)
+            {
+                return sb.AppendType(type.GetElementType(), withNamespace)
+                    .Append('[')
+                    .Append(',', type.GetArrayRank() - 1)
+                    .Append(']');
+
+            }
+
+            if (primitives.TryGetValue(type, out var primitive))
+            {
+                return sb.Append(primitive);
+            }
+
+            if (type.IsGenericTypeDefinition)
+            {
+                return sb
+                    .AppendNamespace(type, withNamespace)
+                    .Append(type.ToNonGeneric())
+                    .Append('<')
+                    .Append(new string(',', type.GetGenericArguments().Length - 1))
+                    .Append('>');
+            }
+
+            if (type.IsGenericType)
+            {
+                var arguments = type.GetGenericArguments();
+
+                // special case for nullables.
+                if (arguments.Length == 1 && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    return sb.AppendType(arguments[0], withNamespace).Append("?");
+                }
+
+                sb.AppendNamespace(type, withNamespace)
+                   .Append(type.ToNonGeneric())
+                   .Append('<')
+                   .AppendType(arguments[0], withNamespace);
+
+                for (var i = 1; i < arguments.Length; i++)
+                {
+                    sb.Append(", ").AppendType(arguments[i], withNamespace);
+                }
+                return sb.Append('>');
+            }
+
+            return sb.AppendNamespace(type, withNamespace).Append(type.Name);
+        }
+
+        private static StringBuilder AppendNamespace(this StringBuilder sb, Type type, bool withNamespace)
+        {
+            if (type.IsNested)
+            {
+                sb.AppendType(type.DeclaringType, withNamespace).Append('.');
+            }
+            else if (withNamespace && !string.IsNullOrEmpty(type.Namespace))
+            {
+                sb.Append(type.Namespace).Append('.');
+            }
+
+            return sb;
+        }
+
+        private static string ToNonGeneric(this Type type) => type.Name.Substring(0, type.Name.IndexOf('`'));
+
+        private static readonly Dictionary<Type, string> primitives = new Dictionary<Type, string>
+        {
+            { typeof(object), "object" },
+            { typeof(string), "string" },
+            { typeof(bool), "bool" },
+            { typeof(byte), "byte" },
+            { typeof(sbyte), "sbyte" },
+            { typeof(short), "short" },
+            { typeof(ushort), "ushort" },
+            { typeof(int), "int" },
+            { typeof(uint), "uint" },
+            { typeof(long), "long" },
+            { typeof(ulong), "ulong" },
+            { typeof(float), "float" },
+            { typeof(double), "double" },
+            { typeof(decimal), "decimal" },
+        };
     }
 }

--- a/test/Qowaiv.UnitTests/Reflection/QowaivTypeTest.cs
+++ b/test/Qowaiv.UnitTests/Reflection/QowaivTypeTest.cs
@@ -60,10 +60,23 @@ namespace Qowaiv.UnitTests.Reflection
         [TestCase(typeof(NestedTest), "QowaivTypeTest.NestedTest")]
         public void ToCSharpStringWithoutNamespace(Type type, string expected)
         {
-            var formatted = QowaivType.ToCSharpString(type, false);
+            var formatted = QowaivType.ToCSharpString(type);
             Assert.AreEqual(expected, formatted);
         }
 
+        [Test]
+        public void ToCSharpString_GenericArgument()
+        {
+            var generic = typeof(GenericOf).GetMethod(nameof(GenericOf.Default)).ReturnType;
+            var formatted = QowaivType.ToCSharpString(generic);
+            Assert.AreEqual("QowaivTypeTest.GenericOf.TModel", formatted);
+        }
+
         internal class NestedTest { }
+
+        internal class GenericOf
+        {
+            public TModel Default<TModel>() => default;
+        }
     }
 }

--- a/test/Qowaiv.UnitTests/Reflection/QowaivTypeTest.cs
+++ b/test/Qowaiv.UnitTests/Reflection/QowaivTypeTest.cs
@@ -1,5 +1,7 @@
 ﻿using NUnit.Framework;
 using Qowaiv.Reflection;
+using System;
+using System.Collections.Generic;
 
 namespace Qowaiv.UnitTests.Reflection
 {
@@ -28,5 +30,40 @@ namespace Qowaiv.UnitTests.Reflection
         {
             Assert.IsFalse(QowaivType.IsNullOrDefaultValue(new QowaivTypeTest()));
         }
+
+        [TestCase(typeof(string), "string")]
+        [TestCase(typeof(byte[]), "byte[]")]
+        [TestCase(typeof(Guid), "System.Guid")]
+        [TestCase(typeof(Dictionary<string, Action>), "System.Collections.Generic.Dictionary<string, System.Action>")]
+        [TestCase(typeof(long?), "long?")]
+        [TestCase(typeof(Dictionary<,>), "System.Collections.Generic.Dictionary<,>")]
+        [TestCase(typeof(Nullable<>), "System.Nullable<>")]
+        [TestCase(typeof(Dictionary<object, List<int?>>[]), "System.Collections.Generic.Dictionary<object, System.Collections.Generic.List<int?>>[]")]
+        [TestCase(typeof(NestedTest), "Qowaiv.UnitTests.Reflection.QowaivTypeTest.NestedTest")]
+        public void ToCSharpStringWithNamespace(Type type, string expected)
+        {
+            var formatted = QowaivType.ToCSharpString(type, true);
+            Assert.AreEqual(expected, formatted);
+        }
+
+        [TestCase(typeof(string), "string")]
+        [TestCase(typeof(byte[]), "byte[]")]
+        [TestCase(typeof(int[][]), "int[][]")]
+        [TestCase(typeof(int[,]), "int[,]")]
+        [TestCase(typeof(int[,,]), "int[,,]")]
+        [TestCase(typeof(Guid), "Guid")]
+        [TestCase(typeof(Dictionary<string, Action>), "Dictionary<string, Action>")]
+        [TestCase(typeof(long?), "long?")]
+        [TestCase(typeof(Dictionary<,>), "Dictionary<,>")]
+        [TestCase(typeof(Nullable<>), "Nullable<>")]
+        [TestCase(typeof(Dictionary<object, List<int?>>[]), "Dictionary<object, List<int?>>[]")]
+        [TestCase(typeof(NestedTest), "QowaivTypeTest.NestedTest")]
+        public void ToCSharpStringWithoutNamespace(Type type, string expected)
+        {
+            var formatted = QowaivType.ToCSharpString(type, false);
+            Assert.AreEqual(expected, formatted);
+        }
+
+        internal class NestedTest { }
     }
 }


### PR DESCRIPTION
The `ToString()` of generic types is not that convenient. The CSharp format is.

A requirement for strongly typed-id's (#132 ).