### PR TITLE
Improvement of code coverage

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.4.0.15306">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.0.16497">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -161,7 +161,9 @@ namespace Qowaiv.Sql
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -228,29 +230,39 @@ namespace Qowaiv.Sql
 namespace Qowaiv.Sql
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Timestamp : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -265,14 +265,19 @@ namespace Qowaiv.Sql
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv.TestTools/SerializationTest.cs
+++ b/src/Qowaiv.TestTools/SerializationTest.cs
@@ -22,17 +22,16 @@ namespace Qowaiv.TestTools
         /// </param>
         public static T SerializeDeserialize<T>(T instance)
         {
-            using (var buffer = new MemoryStream())
-            {
-                var formatter = new BinaryFormatter();
-                formatter.Serialize(buffer, instance);
+            using var buffer = new MemoryStream();
 
-                // reset position.
-                buffer.Position = 0;
+            var formatter = new BinaryFormatter();
+            formatter.Serialize(buffer, instance);
 
-                var result = (T)formatter.Deserialize(buffer);
-                return result;
-            }
+            // reset position.
+            buffer.Position = 0;
+
+            var result = (T)formatter.Deserialize(buffer);
+            return result;
         }
 
         /// <summary>Serializes an instance using an XmlSerializer.</summary>
@@ -44,19 +43,17 @@ namespace Qowaiv.TestTools
         /// </param>
         public static string XmlSerialize<T>(T instance)
         {
-            using (var stream = new MemoryStream())
-            {
-                var writer = new XmlTextWriter(stream, Encoding.UTF8);
-                var serializer = new XmlSerializer(typeof(SerializationWrapper<T>));
-                serializer.Serialize(writer, new SerializationWrapper<T> { Value = instance });
-                stream.Position = 0;
+            using var stream = new MemoryStream();
 
-                using (var reader = new StreamReader(stream))
-                {
-                    var xml = XDocument.Load(reader);
-                    return xml.Element("Wrapper")?.Element("Value")?.Value;
-                }
-            }
+            var writer = new XmlTextWriter(stream, Encoding.UTF8);
+            var serializer = new XmlSerializer(typeof(SerializationWrapper<T>));
+            serializer.Serialize(writer, new SerializationWrapper<T> { Value = instance });
+            stream.Position = 0;
+
+            var reader = new StreamReader(stream);
+
+            var xml = XDocument.Load(reader);
+            return xml.Element("Wrapper")?.Element("Value")?.Value;
         }
 
         /// <summary>Serializes an instance using an XmlSerializer.</summary>
@@ -70,22 +67,20 @@ namespace Qowaiv.TestTools
         {
             var value = new XElement("Value", xml);
             var doc = new XDocument(new XElement("Wrapper", value));
-            
-            using (var stream = new MemoryStream())
-            {
-                doc.Save(stream);
-                stream.Position = 0;
-                var serializer = new XmlSerializer(typeof(SerializationWrapper<T>));
-                try
-                {
-                    var wrapper = (SerializationWrapper<T>)serializer.Deserialize(stream);
-                    return wrapper.Value;
-                }
-                catch (Exception x)
-                {
-                    throw new SerializationException($"'{value.Value}' failed on: {x.Message}", x);
-                }
 
+            using var stream = new MemoryStream();
+
+            doc.Save(stream);
+            stream.Position = 0;
+            var serializer = new XmlSerializer(typeof(SerializationWrapper<T>));
+            try
+            {
+                var wrapper = (SerializationWrapper<T>)serializer.Deserialize(stream);
+                return wrapper.Value;
+            }
+            catch (Exception x)
+            {
+                throw new SerializationException($"'{value.Value}' failed on: {x.Message}", x);
             }
         }
 
@@ -98,14 +93,13 @@ namespace Qowaiv.TestTools
         /// </param>
         public static T XmlSerializeDeserialize<T>(T instance)
         {
-            using (var stream = new MemoryStream())
-            {
-                var writer = new XmlTextWriter(stream, Encoding.UTF8);
-                var serializer = new XmlSerializer(typeof(T));
-                serializer.Serialize(writer, instance);
-                stream.Position = 0;
-                return (T)serializer.Deserialize(stream);
-            }
+            using var stream = new MemoryStream();
+
+            var writer = new XmlTextWriter(stream, Encoding.UTF8);
+            var serializer = new XmlSerializer(typeof(T));
+            serializer.Serialize(writer, instance);
+            stream.Position = 0;
+            return (T)serializer.Deserialize(stream);
         }
 
         /// <summary>Serializes and deserializes an instance using an DataContractSerializer.</summary>
@@ -117,13 +111,12 @@ namespace Qowaiv.TestTools
         /// </param>
         public static T DataContractSerializeDeserialize<T>(T instance)
         {
-            using (var stream = new MemoryStream())
-            {
-                var serializer = new DataContractSerializer(typeof(T));
-                serializer.WriteObject(stream, instance);
-                stream.Position = 0;
-                return (T)serializer.ReadObject(stream);
-            }
+            using var stream = new MemoryStream();
+
+            var serializer = new DataContractSerializer(typeof(T));
+            serializer.WriteObject(stream, instance);
+            stream.Position = 0;
+            return (T)serializer.ReadObject(stream);
         }
 
         /// <summary>Invokes the Deserialize Constructor ( T(SerializationInfo, StreamingContext) ).</summary>

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -391,6 +391,9 @@ namespace Qowaiv
             return m_Value.ToString(f, formatProvider);
         }
 
+        /// <summary>Bind XML value.</summary>
+        partial void OnReadXml(Date value) => m_Value = value.m_Value;
+
         /// <summary>Gets an XML string representation of the @FullName.</summary>
         private string ToXmlString() => ToString(SerializableFormat, CultureInfo.InvariantCulture);
 

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -384,7 +384,11 @@ namespace Qowaiv.Financial
         }
 
         /// <remarks>Sets the currency.</remarks>
-        partial void OnReadXml(Money other) => m_Currency = other.m_Currency;
+        partial void OnReadXml(Money value)
+        {
+            m_Value = value.m_Value;
+            m_Currency = value.m_Currency;
+        }
 
         /// <summary>Deserializes the money from a JSON number.</summary>
         /// <param name="json">

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -266,14 +266,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -162,7 +162,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -229,29 +231,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Date : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -162,7 +162,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -159,7 +159,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -226,29 +228,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct EmailAddress : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -263,14 +263,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -265,14 +265,19 @@ namespace Qowaiv.Financial
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -161,7 +161,9 @@ namespace Qowaiv.Financial
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -228,29 +230,39 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Amount : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -263,14 +263,19 @@ namespace Qowaiv.Financial
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -159,7 +159,9 @@ namespace Qowaiv.Financial
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -226,29 +228,39 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct BusinessIdentifierCode : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -263,14 +263,19 @@ namespace Qowaiv.Financial
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -159,7 +159,9 @@ namespace Qowaiv.Financial
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -226,29 +228,39 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Currency : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -263,14 +263,19 @@ namespace Qowaiv.Financial
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -159,7 +159,9 @@ namespace Qowaiv.Financial
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -226,29 +228,39 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct InternationalBankAccountNumber : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -240,14 +240,19 @@ namespace Qowaiv.Financial
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -136,7 +136,9 @@ namespace Qowaiv.Financial
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -203,29 +205,39 @@ namespace Qowaiv.Financial
 namespace Qowaiv.Financial
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Money : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -262,14 +262,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -158,7 +158,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -225,29 +227,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Gender : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -159,7 +159,9 @@ namespace Qowaiv.Globalization
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -226,29 +228,39 @@ namespace Qowaiv.Globalization
 namespace Qowaiv.Globalization
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Country : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -263,14 +263,19 @@ namespace Qowaiv.Globalization
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -262,14 +262,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -158,7 +158,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -225,29 +227,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct HouseNumber : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -244,14 +244,19 @@ namespace Qowaiv.IO
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -162,7 +162,9 @@ namespace Qowaiv.IO
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -207,29 +209,39 @@ namespace Qowaiv.IO
 namespace Qowaiv.IO
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct StreamSize : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -162,7 +162,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -229,29 +231,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct LocalDateTime : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -266,14 +266,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -240,14 +240,19 @@ namespace Qowaiv.Mathematics
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -191,7 +191,7 @@ namespace Qowaiv.Mathematics
         public override string ToString() => ToString(CultureInfo.CurrentCulture);
         /// <summary>Returns a formatted <see cref = "string "/> that represents the fraction.</summary>
         /// <param name = "format">
-        /// The format that this describes the formatting.
+        /// The format that describes the formatting.
         /// </param>
         public string ToString(string format) => ToString(format, CultureInfo.CurrentCulture);
         /// <summary>Returns a formatted <see cref = "string "/> that represents the fraction.</summary>
@@ -205,29 +205,39 @@ namespace Qowaiv.Mathematics
 namespace Qowaiv.Mathematics
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Fraction : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -262,14 +262,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -158,7 +158,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -225,29 +227,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Month : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -243,14 +243,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -161,7 +161,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -206,29 +208,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Percentage : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -159,7 +159,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -226,29 +228,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct PostalCode : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -263,14 +263,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Security/Cryptography/CryptographicSeed.generated.cs
+++ b/src/Qowaiv/Generated/Security/Cryptography/CryptographicSeed.generated.cs
@@ -267,14 +267,19 @@ namespace Qowaiv.Security.Cryptography
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Security/Cryptography/CryptographicSeed.generated.cs
+++ b/src/Qowaiv/Generated/Security/Cryptography/CryptographicSeed.generated.cs
@@ -163,7 +163,9 @@ namespace Qowaiv.Security.Cryptography
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -230,29 +232,39 @@ namespace Qowaiv.Security.Cryptography
 namespace Qowaiv.Security.Cryptography
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct CryptographicSeed : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -161,7 +161,9 @@ namespace Qowaiv.Statistics
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -228,29 +230,39 @@ namespace Qowaiv.Statistics
 namespace Qowaiv.Statistics
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Elo : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -265,14 +265,19 @@ namespace Qowaiv.Statistics
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -162,7 +162,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -229,29 +231,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Uuid : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -266,14 +266,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -160,7 +160,9 @@ namespace Qowaiv.Web
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -227,29 +229,39 @@ namespace Qowaiv.Web
 namespace Qowaiv.Web
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct InternetMediaType : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -264,14 +264,19 @@ namespace Qowaiv.Web
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -135,7 +135,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -202,29 +204,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct WeekDate : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -239,14 +239,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -158,7 +158,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -225,29 +227,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct Year : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -262,14 +262,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -159,7 +159,9 @@ namespace Qowaiv
 #else
             var val = Parse(xml);
 #endif
+#if !NotField
             m_Value = val.m_Value;
+#endif
             OnReadXml(val);
         }
 
@@ -226,29 +228,39 @@ namespace Qowaiv
 namespace Qowaiv
 {
     using System;
-    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     public partial struct YesNo : IConvertible
     {
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -263,14 +263,19 @@ namespace Qowaiv
         [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -443,6 +443,9 @@ namespace Qowaiv.IO
         /// <summary>Gets an XML string representation of the stream size.</summary>
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
+        /// <summary>Bind XML value.</summary>
+        partial void OnReadXml(StreamSize value) => m_Value = value.m_Value;
+
         private string ToFormattedString(IFormatProvider formatProvider, Match match)
         {
             var format = match.Groups["format"].Value;

--- a/src/Qowaiv/Identifiers/Id.IConvertible.cs
+++ b/src/Qowaiv/Identifiers/Id.IConvertible.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Qowaiv.Identifiers
@@ -35,34 +36,49 @@ namespace Qowaiv.Identifiers
         }
 
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         object IConvertible.ToType(Type conversionType, IFormatProvider provider) => Convertable.ToType(conversionType, provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         bool IConvertible.ToBoolean(IFormatProvider provider) => Convertable.ToBoolean(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         byte IConvertible.ToByte(IFormatProvider provider) => Convertable.ToByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         char IConvertible.ToChar(IFormatProvider provider) => Convertable.ToChar(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convertable.ToDateTime(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         decimal IConvertible.ToDecimal(IFormatProvider provider) => Convertable.ToDecimal(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         double IConvertible.ToDouble(IFormatProvider provider) => Convertable.ToDouble(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         short IConvertible.ToInt16(IFormatProvider provider) => Convertable.ToInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         int IConvertible.ToInt32(IFormatProvider provider) => Convertable.ToInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         long IConvertible.ToInt64(IFormatProvider provider) => Convertable.ToInt64(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         sbyte IConvertible.ToSByte(IFormatProvider provider) => Convertable.ToSByte(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         float IConvertible.ToSingle(IFormatProvider provider) => Convertable.ToSingle(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ushort IConvertible.ToUInt16(IFormatProvider provider) => Convertable.ToUInt16(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         uint IConvertible.ToUInt32(IFormatProvider provider) => Convertable.ToUInt32(provider);
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         ulong IConvertible.ToUInt64(IFormatProvider provider) => Convertable.ToUInt64(provider);
     }
 }

--- a/src/Qowaiv/Json/OpenApiDataTypeAttribute.cs
+++ b/src/Qowaiv/Json/OpenApiDataTypeAttribute.cs
@@ -29,7 +29,7 @@ namespace Qowaiv.Json
             Format = format;
             Nullable = nullable;
             Pattern = pattern;
-            Enum = @enum is null ? null : @enum.Split(',');
+            Enum = @enum?.Split(',');
         }
 
         /// <summary>Gets the bound .NET type of the OpenAPI Data Type.</summary>

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -505,6 +505,9 @@ namespace Qowaiv
         /// <summary>Gets an XML string representation of the @FullName.</summary>
         private string ToXmlString() => ToString(SerializableFormat, CultureInfo.InvariantCulture);
 
+        /// <summary>Bind XML value.</summary>
+        partial void OnReadXml(LocalDateTime value) => m_Value = value.m_Value;
+
         #region (Explicit) casting
 
         /// <summary>Casts a local date time to a <see cref="string"/>.</summary>

--- a/src/Qowaiv/UuidComparer.cs
+++ b/src/Qowaiv/UuidComparer.cs
@@ -52,7 +52,7 @@ namespace Qowaiv
                     return Compare(a, b);
                 }
             }
-            throw new ArgumentException($"Both arguments must be GUID/UUID.");
+            throw new NotSupportedException("Both arguments must be GUID/UUID.");
         }
     }
 }

--- a/src/Qowaiv/UuidComparer.cs
+++ b/src/Qowaiv/UuidComparer.cs
@@ -43,7 +43,7 @@ namespace Qowaiv
             {
                 if (y is null)
                 {
-                    return -1;
+                    return +1;
                 }
                 if (y is Guid || y is Uuid)
                 {

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -241,6 +241,9 @@ namespace Qowaiv
         /// <summary>Gets an XML string representation of the week date.</summary>
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
+        /// <summary>Bind XML value.</summary>
+        partial void OnReadXml(WeekDate value) => m_Value = value.m_Value;
+
         /// <summary>Casts a week date to a <see cref="string"/>.</summary>
         public static explicit operator string(WeekDate val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a week date to a date time.</summary>

--- a/test/Qowaiv.UnitTests/DateSpanOperationTest.cs
+++ b/test/Qowaiv.UnitTests/DateSpanOperationTest.cs
@@ -5,6 +5,14 @@ namespace Qowaiv.UnitTests
 {
     public class DateSpanOperationTest
     {
+        [Test]
+        public void Add_DateSpan_ShouldAddDaysSecond()
+        {
+            var date = new DateTime(1999, 01, 30);
+            var span = DateSpan.FromMonths(1);
+            Assert.AreEqual(new DateTime(1999,02,28), date.Add(span));
+        }
+
         [TestCase("1999-01-30", "1999-02-28", 1, +0, false)]
         [TestCase("2000-01-30", "2000-02-29", 1, +0, false)]
         [TestCase("1999-01-30", "1999-02-27", 1, -1, false)]

--- a/test/Qowaiv.UnitTests/DateSpanTest.cs
+++ b/test/Qowaiv.UnitTests/DateSpanTest.cs
@@ -15,6 +15,8 @@ namespace Qowaiv.UnitTests
     {
         /// <summary>The test instance for most tests.</summary>
         public static readonly DateSpan TestStruct = new DateSpan(10, 3, -5);
+        public static readonly DateSpan Smaller = new DateSpan(10, 3, -5);
+        public static readonly DateSpan Bigger = new DateSpan(10, 3, +02);
 
         #region date span const tests
 
@@ -547,8 +549,47 @@ namespace Qowaiv.UnitTests
             "Argument must be DateSpan."
             );
         }
+
+        [Test]
+        public void Smaller_LessThan_Bigger_IsTrue()
+        {
+            Assert.IsTrue(Smaller < Bigger);
+        }
+        [Test]
+        public void Bigger_GreaterThan_Smaller_IsTrue()
+        {
+            Assert.IsTrue(Bigger > Smaller);
+        }
+
+        [Test]
+        public void Smaller_LessThanOrEqual_Bigger_IsTrue()
+        {
+            Assert.IsTrue(Smaller <= Bigger);
+        }
+        [Test]
+        public void Bigger_GreaterThanOrEqual_Smaller_IsTrue()
+        {
+            Assert.IsTrue(Bigger >= Smaller);
+        }
+
+        [Test]
+        public void Smaller_LessThanOrEqual_Smaller_IsTrue()
+        {
+            var left = Smaller;
+            var right = Smaller;
+            Assert.IsTrue(left <= right);
+        }
+
+        [Test]
+        public void Smaller_GreaterThanOrEqual_Smaller_IsTrue()
+        {
+            var left = Smaller;
+            var right = Smaller;
+            Assert.IsTrue(left >= right);
+        }
+
         #endregion
-    
+
         #region Properties
 
         [TestCase(1, 2, +3)]
@@ -598,6 +639,19 @@ namespace Qowaiv.UnitTests
         #endregion
 
         #region Operations
+
+        [Test]
+        public void Negate_TestStruct_Negated()
+        {
+            var negated = -TestStruct;
+            Assert.AreEqual(new DateSpan(-10, -3, +5), negated);
+        }
+        [Test]
+        public void Pluse_TestStruct_Unchanged()
+        {
+            var negated = +TestStruct;
+            Assert.AreEqual(TestStruct, negated);
+        }
 
         [Test]
         public void Mutate_Overflows()

--- a/test/Qowaiv.UnitTests/IO/StreamSizeTest.cs
+++ b/test/Qowaiv.UnitTests/IO/StreamSizeTest.cs
@@ -1328,31 +1328,29 @@ namespace Qowaiv.UnitTests.IO
         [Test]
         public void GetStreamSize_Stream_17Byte()
         {
-            using (var stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 }))
-            {
-                StreamSize act = stream.GetStreamSize();
-                StreamSize exp = 17;
+            using var stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 });
 
-                Assert.AreEqual(exp, act);
-            }
+            StreamSize act = stream.GetStreamSize();
+            StreamSize exp = 17;
+
+            Assert.AreEqual(exp, act);
         }
 
         [Test]
         public void GetStreamSize_FileInfo_9Byte()
         {
-            using (var dir = new TemporaryDirectory())
+            using var dir = new TemporaryDirectory();
+
+            FileInfo file = dir.CreateFile("GetStreamSize_FileInfo_9.test");
+            using (var writer = new StreamWriter(file.FullName, false))
             {
-                FileInfo file = dir.CreateFile("GetStreamSize_FileInfo_9.test");
-                using (var writer = new StreamWriter(file.FullName, false))
-                {
-                    writer.Write("Unit Test");
-                }
-
-                StreamSize act = file.GetStreamSize();
-                StreamSize exp = 9;
-
-                Assert.AreEqual(exp, act);
+                writer.Write("Unit Test");
             }
+
+            StreamSize act = file.GetStreamSize();
+            StreamSize exp = 9;
+
+            Assert.AreEqual(exp, act);
         }
 
         [Test]

--- a/test/Qowaiv.UnitTests/Identifiers/IdForGuidTest.cs
+++ b/test/Qowaiv.UnitTests/Identifiers/IdForGuidTest.cs
@@ -139,6 +139,19 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        public void TryCreate_Int_NotSuccessful()
+        {
+            Assert.IsFalse(Id<ForGuid>.TryCreate(17L, out _));
+        }
+
+        [Test]
+        public void TryCreate_Guid_Successful()
+        {
+            Assert.IsTrue(Id<ForGuid>.TryCreate(Guid.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), out var id));
+            Assert.AreEqual(Id<ForGuid>.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), id);
+        }
+
+        [Test]
         public void Constructor_SerializationInfoIsNull_Throws()
         {
             Assert.Catch<ArgumentNullException>(() => SerializationTest.DeserializeUsingConstructor<Id<ForGuid>>(null, default));
@@ -344,6 +357,13 @@ namespace Qowaiv.UnitTests.Identifiers
         {
             var actual = JsonTester.Read<Id<ForGuid>>(json);
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ToJson_TestStruct_StringValue()
+        {
+            var json = TestStruct.ToJson();
+            Assert.AreEqual("0f5ab5ab-12cb-4629-878d-b18b88b9a504", json);
         }
 
         [Test]
@@ -597,6 +617,13 @@ namespace Qowaiv.UnitTests.Identifiers
         public void IsValid_String(string str)
         {
             Assert.IsTrue(Id<ForGuid>.IsValid(str));
+        }
+    
+        [Test]
+        public void GetCodeType_String()
+        {
+            var convertable = (IConvertible)TestStruct;
+            Assert.AreEqual(TypeCode.String, convertable.GetTypeCode());
         }
     }
 

--- a/test/Qowaiv.UnitTests/Identifiers/IdForInt32Test.cs
+++ b/test/Qowaiv.UnitTests/Identifiers/IdForInt32Test.cs
@@ -140,6 +140,13 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        public void TryCreate_Int_Successful()
+        {
+            Assert.IsTrue(Id<ForInt32>.TryCreate(13, out var id));
+            Assert.AreEqual(Id<ForInt32>.Parse("13"), id);
+        }
+
+        [Test]
         public void Constructor_SerializationInfoIsNull_Throws()
         {
             Assert.Catch<ArgumentNullException>(() => SerializationTest.DeserializeUsingConstructor<Id<ForInt32>>(null, default));
@@ -347,6 +354,13 @@ namespace Qowaiv.UnitTests.Identifiers
         {
             var actual = JsonTester.Read<Id<ForInt32>>(json);
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ToJson_TestStruct_LongValue()
+        {
+            var json = TestStruct.ToJson();
+            Assert.AreEqual(123456789L, json);
         }
 
         [Test]
@@ -601,6 +615,13 @@ namespace Qowaiv.UnitTests.Identifiers
         public void IsValid_String(string str)
         {
             Assert.IsTrue(Id<ForInt32>.IsValid(str));
+        }
+
+        [Test]
+        public void GetCodeType_String()
+        {
+            var convertable = (IConvertible)TestStruct;
+            Assert.AreEqual(TypeCode.Int32, convertable.GetTypeCode());
         }
     }
 

--- a/test/Qowaiv.UnitTests/Identifiers/IdForInt64Test.cs
+++ b/test/Qowaiv.UnitTests/Identifiers/IdForInt64Test.cs
@@ -104,6 +104,13 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        public void TryCreate_Int_Successful()
+        {
+            Assert.IsTrue(Id<ForInt64>.TryCreate(13L, out var id));
+            Assert.AreEqual(Id<ForInt64>.Parse("13"), id);
+        }
+
+        [Test]
         public void Parse_InvalidInput_ThrowsFormatException()
         {
             using (new CultureInfoScope("en-GB"))
@@ -347,6 +354,13 @@ namespace Qowaiv.UnitTests.Identifiers
         {
             var actual = JsonTester.Read<Id<ForInt64>>(json);
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ToJson_TestStruct_LongValue()
+        {
+            var json = TestStruct.ToJson();
+            Assert.AreEqual(123456789L, json);
         }
 
         [Test]
@@ -602,6 +616,14 @@ namespace Qowaiv.UnitTests.Identifiers
         {
             Assert.IsTrue(Id<ForInt64>.IsValid(str));
         }
+
+        [Test]
+        public void GetCodeType_String()
+        {
+            var convertable = (IConvertible)TestStruct;
+            Assert.AreEqual(TypeCode.Int64, convertable.GetTypeCode());
+        }
+
     }
 
     [Serializable]

--- a/test/Qowaiv.UnitTests/Identifiers/IdForStringTest.cs
+++ b/test/Qowaiv.UnitTests/Identifiers/IdForStringTest.cs
@@ -550,6 +550,13 @@ namespace Qowaiv.UnitTests.Identifiers
         {
             Assert.IsTrue(Id<ForString>.IsValid(str));
         }
+
+        [Test]
+        public void GetCodeType_String()
+        {
+            var convertable = (IConvertible)TestStruct;
+            Assert.AreEqual(TypeCode.String, convertable.GetTypeCode());
+        }
     }
 
     [Serializable]

--- a/test/Qowaiv.UnitTests/UuidComparerTest.cs
+++ b/test/Qowaiv.UnitTests/UuidComparerTest.cs
@@ -99,5 +99,11 @@ namespace Qowaiv.UnitTests
         {
             Assert.AreEqual(+1, UuidComparer.Default.Compare((object)uuid, (object)guid));
         }
+
+        [Test]
+        public void Compare_UuidObject_Throws()
+        {
+            Assert.Throws<NotSupportedException>(() => UuidComparer.Default.Compare((object)uuid, new object()));
+        }
     }
 }

--- a/test/Qowaiv.UnitTests/UuidComparerTest.cs
+++ b/test/Qowaiv.UnitTests/UuidComparerTest.cs
@@ -6,6 +6,9 @@ namespace Qowaiv.UnitTests
 {
     public class UuidComparerTest
     {
+        private readonly Guid guid = Guid.Parse("40E56044-F781-43BD-A4AE-AA08882B4E28");
+        private readonly Uuid uuid = Uuid.Parse("BD411BB9-D8C9-4A4F-B739-57F2312E0BC5");
+
         /// <summary>Proves that the<paramref name="index0"/> has an higher priority than the paired
         /// <paramref name="index1"/>.
         /// </summary>
@@ -41,7 +44,6 @@ namespace Qowaiv.UnitTests
             return new Guid(bytes);
         }
 
-
         [Test]
         public void Compare_Default_IsOrderComarerGuidDefault()
         {
@@ -54,6 +56,48 @@ namespace Qowaiv.UnitTests
             uuids.Sort(UuidComparer.Default);
 
             CollectionAssert.IsOrdered(uuids, Comparer<Guid>.Default);
+        }
+    
+        [Test]
+        public void Compare_NullNull_Zero()
+        {
+            Assert.AreEqual(0, UuidComparer.Default.Compare(null, null));
+        }
+
+        [Test]
+        public void Compare_NullGuid_Minus1()
+        {
+            Assert.AreEqual(-1, UuidComparer.Default.Compare(null, Guid.NewGuid()));
+        }
+
+        [Test]
+        public void Compare_NullUuid_Minus1()
+        {
+            Assert.AreEqual(-1, UuidComparer.Default.Compare(null, Uuid.NewUuid()));
+        }
+
+        [Test]
+        public void Compare_GuidNull_Plus1()
+        {
+            Assert.AreEqual(+1, UuidComparer.Default.Compare(Guid.NewGuid(), null));
+        }
+
+        [Test]
+        public void Compare_UuidNull_Plus1()
+        {
+            Assert.AreEqual(+1, UuidComparer.Default.Compare(Uuid.NewUuid(), null));
+        }
+
+        [Test]
+        public void Compare_GuidUuid_Minus1()
+        {
+            Assert.AreEqual(-1, UuidComparer.Default.Compare((object)guid, (object)uuid));
+        }
+
+        [Test]
+        public void Compare_UuidGuid_Plus1()
+        {
+            Assert.AreEqual(+1, UuidComparer.Default.Compare((object)uuid, (object)guid));
         }
     }
 }


### PR DESCRIPTION
Due to a bug in VS2019 (in combination with .NET Core 3.1) this was broken. It let to some new features missing some coverage.