### PR TITLE
Introduction of the CultureInfo.Scoped() extension method

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ var rounded = money.Round(0); // EUR 125.00
 ### Country
 Represents a country based on an ISO 3166-1 code (or 3166-3 if the country does not longer exists).
 
+### CultureInfoScope
+A CultureInfoScope is a class that allows to specify the current (UI) for the
+duration/lifetime of specified scope.
+
+``` C#
+using(new CultureInfoScope("es-ES"))
+{
+    Console.WriteLine(234.12.ToString()); // 234,12
+}
+// or with an extension
+using(new CultureInfo("en-ES").Scoped())
+{
+    // ...
+}
+```
+
 ## Qowaiv mathimatical types
 
 ### Fraction

--- a/src/Qowaiv/Globalization/CultureInfoExtensions.cs
+++ b/src/Qowaiv/Globalization/CultureInfoExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System.Globalization;
+
+namespace Qowaiv.Globalization
+{
+    /// <summary>Extensions on <see cref="CultureInfo"/>.</summary>
+    public static class CultureInfoExtensions
+    {
+        /// <summary>Gets a <see cref="CultureInfoScope"/> based on the <see cref="CultureInfo"/>.</summary>
+        public static CultureInfoScope Scoped(this CultureInfo culture) => new CultureInfoScope(culture);
+    }
+}

--- a/test/Qowaiv.UnitTests/Globalization/CultureInfoScopeTest.cs
+++ b/test/Qowaiv.UnitTests/Globalization/CultureInfoScopeTest.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using System.Globalization;
+using Qowaiv.Globalization;
+
+namespace Qowaiv.UnitTests.Globalization
+{
+    public class CultureInfoScopeTest
+    {
+        [Test]
+        public void Scoped_Ctor()
+        {
+            var current = CultureInfo.CurrentCulture;
+            var currentUI = CultureInfo.CurrentUICulture;
+
+            using (new CultureInfoScope("es-ES", "fr-FR"))
+            {
+                Assert.AreEqual("es-ES", CultureInfo.CurrentCulture.Name);
+                Assert.AreEqual("fr-FR", CultureInfo.CurrentUICulture.Name);
+            }
+
+            Assert.AreEqual(current, CultureInfo.CurrentCulture);
+            Assert.AreEqual(currentUI, CultureInfo.CurrentUICulture);
+        }
+
+        [Test]
+        public void Scoped_ExtensionMethod()
+        {
+            var current = CultureInfo.CurrentCulture;
+            var currentUI = CultureInfo.CurrentUICulture;
+
+            using (new CultureInfo("es-ES").Scoped())
+            {
+                Assert.AreEqual("es-ES", CultureInfo.CurrentCulture.Name);
+                Assert.AreEqual("es-ES", CultureInfo.CurrentUICulture.Name);
+            }
+
+            Assert.AreEqual(current, CultureInfo.CurrentCulture);
+            Assert.AreEqual(currentUI, CultureInfo.CurrentUICulture);
+        }
+    }
+}


### PR DESCRIPTION
Syntactic sugar. Can lead to cleaner code if the preferred culture is already defined by a constant or variable.