### PR TITLE
Extend Open API definitions with an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,7 +767,7 @@ and if the data type is nullable, all when applicable.
     "format": "country",
     "nullabe": true
   },
-  "Identifiers.Id`1": {
+  "Identifiers.Id<TIdentifier>": {
     "description": "identifier",
     "example": "8a1a8c42-d2ff-e254-e26e-b6abcbf19420",
     "type": "string/int",

--- a/README.md
+++ b/README.md
@@ -770,7 +770,7 @@ and if the data type is nullable, all when applicable.
   "Identifiers.Id<TIdentifier>": {
     "description": "identifier",
     "example": "8a1a8c42-d2ff-e254-e26e-b6abcbf19420",
-    "type": "string/int",
+    "type": "any",
     "nullabe": false
   },
   "IO.StreamSize": {

--- a/README.md
+++ b/README.md
@@ -614,84 +614,75 @@ and if the data type is nullable, all when applicable.
 ``` json
 {
   "Date": {
-    "description": "Full-date notation as defined by RFC 3339, section 5.6, for example, 2017-06-10.",
+    "description": "Full-date notation as defined by RFC 3339, section 5.6.",
+    "example": "2017-06-10",
     "type": "string",
     "format": "date",
     "nullabe": false
   },
   "DateSpan": {
-    "description": "Date span, specified in years, months and days, for example 1Y+10M+16D.",
+    "description": "Date span, specified in years, months and days.",
+    "example": "1Y+10M+16D",
     "type": "string",
     "format": "date-span",
     "pattern": "[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D",
     "nullabe": false
   },
   "EmailAddress": {
-    "description": "Email notation as defined by RFC 5322, for example, svo@qowaiv.org.",
+    "description": "Email notation as defined by RFC 5322.",
+    "example": "svo@qowaiv.org",
     "type": "string",
     "format": "email",
     "nullabe": true
   },
   "EmailAddressCollection": {
     "description": "Comma separated list of email addresses defined by RFC 5322.",
+    "example": "info@qowaiv.org,test@test.com",
     "type": "string",
     "format": "email-collection",
     "nullabe": true
   },
   "Gender": {
     "description": "Gender as specified by ISO/IEC 5218.",
+    "example": "female",
     "type": "string",
     "format": "gender",
     "nullabe": true,
-    "enum": [
-      "NotKnown",
-      "Male",
-      "Female",
-      "NotApplicable"
-    ]
+    "enum": ["NotKnown", "Male", "Female", "NotApplicable"]
   },
   "HouseNumber": {
     "description": "House number notation.",
+    "example": "13",
     "type": "string",
     "format": "house-number",
     "nullabe": true
   },
   "LocalDateTime": {
-    "description": "Date-time notation as defined by RFC 3339, without time zone information, for example, 2017-06-10 15:00.",
+    "description": "Date-time notation as defined by RFC 3339, without time zone information.",
+    "example": "2017-06-10 15:00",
     "type": "string",
     "format": "local-date-time",
     "nullabe": false
   },
   "Month": {
     "description": "Month(-only) notation.",
+    "example": "Jun",
     "type": "string",
     "format": "month",
     "nullabe": true,
-    "enum": [
-      "Jan",
-      "Feb",
-      "Mar",
-      "Apr",
-      "May",
-      "Jun",
-      "Jul",
-      "Aug",
-      "Sep",
-      "Oct",
-      "Nov",
-      "Dec",
-      "?"
-    ]
+    "enum": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "?"]
   },
   "MonthSpan": {
-    "description": "Month span, specified in years and months, for example 1Y+10M.",
+    "description": "Month span, specified in years and months.",
+    "example": "1Y+10M",
     "type": "string",
     "format": "month-span",
     "pattern": "[+-]?[0-9]+Y[+-][0-9]+M",
     "nullabe": false
   },
   "Percentage": {
-    "description": "Ratio expressed as a fraction of 100 denoted using the percent sign '%', for example 13.76%.",
+    "description": "Ratio expressed as a fraction of 100 denoted using the percent sign '%'.",
+    "example": "13.76%",
     "type": "string",
     "format": "percentage",
     "pattern": "-?[0-9]+(\\.[0-9]+)?%",
@@ -699,89 +690,99 @@ and if the data type is nullable, all when applicable.
   },
   "PostalCode": {
     "description": "Postal code notation.",
+    "example": "2624DP",
     "type": "string",
     "format": "postal-code",
     "nullabe": true
   },
   "Uuid": {
-    "description": "Universally unique identifier, Base64 encoded, for example lmZO_haEOTCwGsCcbIZFFg.",
+    "description": "Universally unique identifier, Base64 encoded.",
+    "example": "lmZO_haEOTCwGsCcbIZFFg",
     "type": "string",
     "format": "uuid-base64",
     "nullabe": true
   },
   "WeekDate": {
-    "description": "Full-date notation as defined by ISO 8601, for example, 1997-W14-6.",
+    "description": "Full-date notation as defined by ISO 8601.",
+    "example": "1997-W14-6",
     "type": "string",
     "format": "date-weekbased",
     "nullabe": false
   },
   "Year": {
     "description": "Year(-only) notation.",
+    "example": 1983,
     "type": "integer",
     "format": "year",
     "nullabe": true
   },
   "YesNo": {
     "description": "Yes-No notation.",
+    "example": "yes",
     "type": "string",
     "format": "yes-no",
     "nullabe": true,
-    "enum": [
-      "yes",
-      "no",
-      "?"
-    ]
+    "enum": ["yes", "no", "?"]
   },
   "Financial.Amount": {
     "description": "Decimal representation of a currency amount.",
+    "example": 15.95,
     "type": "number",
     "format": "amount",
     "nullabe": false
   },
   "Financial.BusinessIdentifierCode": {
-    "description": "Business Identifier Code, as defined by ISO 9362, for example, DEUTDEFF.",
+    "description": "Business Identifier Code, as defined by ISO 9362.",
+    "example": "DEUTDEFF",
     "type": "string",
     "format": "bic",
     "nullabe": true
   },
   "Financial.Currency": {
-    "description": "Currency notation as defined by ISO 4217, for example, EUR.",
+    "description": "Currency notation as defined by ISO 4217.",
+    "example": "EUR",
     "type": "string",
     "format": "currency",
     "nullabe": true
   },
   "Financial.InternationalBankAccountNumber": {
-    "description": "International Bank Account Number notation as defined by ISO 13616:2007, for example, BE71096123456769.",
+    "description": "International Bank Account Number notation as defined by ISO 13616:2007.",
+    "example": "BE71096123456769.",
     "type": "string",
     "format": "iban",
     "nullabe": true
   },
   "Financial.Money": {
-    "description": "Combined currency and amount notation as defined by ISO 4217, for example, EUR 12.47.",
+    "description": "Combined currency and amount notation as defined by ISO 4217.",
+    "example": "EUR12.47",
     "type": "string",
     "format": "money",
     "pattern": "[A-Z]{3} -?[0-9]+(\\.[0-9]+)?",
     "nullabe": false
   },
   "Globalization.Country": {
-    "description": "Country notation as defined by ISO 3166-1 alpha-2, for example, NL.",
+    "description": "Country notation as defined by ISO 3166-1 alpha-2.",
+    "example": "NL",
     "type": "string",
     "format": "country",
     "nullabe": true
   },
-  "Identifiers.Id<TIdentifier>": {
+  "Identifiers.Id`1": {
     "description": "identifier",
+    "example": "8a1a8c42-d2ff-e254-e26e-b6abcbf19420",
     "type": "string/int",
     "nullabe": false
   },
   "IO.StreamSize": {
     "description": "Stream size notation (in byte).",
+    "example": 1024",
     "type": "integer",
     "format": "stream-size",
     "nullabe": false
   },
   "Mathematics.Fraction": {
     "description": "Faction",
+    "example": "13/42",
     "type": "string",
     "format": "faction",
     "pattern": "-?[0-9]+(/[0-9]+)?",
@@ -789,18 +790,21 @@ and if the data type is nullable, all when applicable.
   },
   "Security.Cryptography.CryptographicSeed": {
     "description": "Base64 encoded cryptographic seed.",
+    "example": "Qowaiv==",
     "type": "string",
     "format": "cryptographic-seed",
     "nullabe": true
   },
   "Statistics.Elo": {
     "description": "Elo rating system notation.",
+    "example": 1600,
     "type": "number",
     "format": "elo",
     "nullabe": false
   },
   "Web.InternetMediaType": {
-    "description": "Media type notation as defined by RFC 6838, for example, text/html.",
+    "description": "Media type notation as defined by RFC 6838.",
+    "example": "text/html",
     "type": "string",
     "format": "internet-media-type",
     "nullabe": true
@@ -815,21 +819,22 @@ OpenApi this could be done like below:
 /// <summary>Extensions on <see cref="SwaggerGenOptions"/>.</summary>
 public static class SwaggerGenOptionsSvoExtensions
 {
-	/// <summary>Maps Qowaiv SVO's.</summary>
-	public static SwaggerGenOptions MapSingleValueObjects(this SwaggerGenOptions options)
-	{
-		var attributes = OpenApiDataTypeAttribute.From(typeof(Date).Assembly);
-		foreach (var attr in attributes)
-		{
-			options.MapType(attr.DataType, () => new OpenApiSchema
-			{
-				Type = attr.Type,
-				Format = attr.Format,
-				Pattern = attr.Pattern,
-				Nullable = attr.Nullable,
-			});
-		}
-	}
+    /// <summary>Maps Qowaiv SVO's.</summary>
+    public static SwaggerGenOptions MapSingleValueObjects(this SwaggerGenOptions options)
+    {
+        var attributes = OpenApiDataTypeAttribute.From(typeof(Date).Assembly);
+        foreach (var attr in attributes)
+        {
+            options.MapType(attr.DataType, () => new OpenApiSchema
+            {
+                Type = attr.Type,
+                Example = attr.Example, // convert to IOpenApiAny of choice
+                Format = attr.Format,
+                Pattern = attr.Pattern,
+                Nullable = attr.Nullable,
+            });
+        }
+    }
 }
 ```
             
@@ -949,7 +954,7 @@ public interface IClock
 
 public class Clock : IClock
 {
-	public DateTime UtcNow() => DateTime.UtcNow;
+    public DateTime UtcNow() => DateTime.UtcNow;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 | version                                                                       | package                                                                     |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-|![v](https://img.shields.io/badge/version-5.1.1-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
+|![v](https://img.shields.io/badge/version-5.1.2-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
 |![v](https://img.shields.io/badge/version-5.1.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Data.SqlCient](https://www.nuget.org/packages/Qowaiv.Data.SqlClient/)|
 |![v](https://img.shields.io/badge/version-3.1.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)         |
 

--- a/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
+++ b/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
@@ -9,11 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/props/common.props
+++ b/props/common.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.29.0.36737">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
+++ b/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
@@ -13,7 +13,7 @@ namespace Qowaiv.Sql
     /// <summary>Represents a timestamp.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(ulong))]
-    [OpenApiDataType(description: "SQL Server timestamp notation, for example 0x00000000000007D9.", type: "string", format: "timestamp")]
+    [OpenApiDataType(description: "SQL Server timestamp notation.", example: "0x00000000000007D9", type: "string", format: "timestamp")]
     [TypeConverter(typeof(TimestampTypeConverter))]
     public partial struct Timestamp : ISerializable, IXmlSerializable, IFormattable, IEquatable<Timestamp>, IComparable, IComparable<Timestamp>
     {

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -18,7 +18,7 @@ namespace Qowaiv
     /// <summary>Represents a date, so opposed to a date time without time precision.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All ^ SingleValueStaticOptions.HasEmptyValue ^ SingleValueStaticOptions.HasUnknownValue, typeof(DateTime))]
-    [OpenApiDataType(description: "Full-date notation as defined by RFC 3339, section 5.6, for example, 2017-06-10.", type: "string", format: "date")]
+    [OpenApiDataType(description: "Full-date notation as defined by RFC 3339, section 5.6.", example: "2017-06-10", type: "string", format: "date")]
     [TypeConverter(typeof(DateTypeConverter))]
     public partial struct Date : ISerializable, IXmlSerializable, IFormattable, IEquatable<Date>, IComparable, IComparable<Date>
     {

--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -19,7 +19,7 @@ namespace Qowaiv
     /// <summary>Represents a date span.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(ulong))]
-    [OpenApiDataType(description: "Date span, specified in years, months and days, for example 1Y+10M+16D.", type: "string", format: "date-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D")]
+    [OpenApiDataType(description: "Date span, specified in years, months and days.", example: "1Y+10M+16D", type: "string", format: "date-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D")]
     [TypeConverter(typeof(DateSpanTypeConverter))]
     public partial struct DateSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<DateSpan>, IComparable, IComparable<DateSpan>
     {

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -25,7 +25,7 @@ namespace Qowaiv
     /// <summary>Represents an email address.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
-    [OpenApiDataType(description: "Email notation as defined by RFC 5322, for example, svo@qowaiv.org.", type: "string", format: "email", nullable: true)]
+    [OpenApiDataType(description: "Email notation as defined by RFC 5322.", example: "svo@qowaiv.org", type: "string", format: "email", nullable: true)]
     [TypeConverter(typeof(EmailAddressTypeConverter))]
     public partial struct EmailAddress : ISerializable, IXmlSerializable, IFormattable, IEquatable<EmailAddress>, IComparable, IComparable<EmailAddress>
     {

--- a/src/Qowaiv/EmailAddressCollection.cs
+++ b/src/Qowaiv/EmailAddressCollection.cs
@@ -21,7 +21,7 @@ namespace Qowaiv
     /// Empty and unknown email addresses can not be added.
     /// </remarks>
     [Serializable]
-    [OpenApiDataType(description: "Comma separated list of email addresses defined by RFC 5322.", type: "string", format: "email-collection", nullable: true)]
+    [OpenApiDataType(description: "Comma separated list of email addresses defined by RFC 5322.",example: "info@qowaiv.org,test@test.com", type: "string", format: "email-collection", nullable: true)]
     public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSerializable, IFormattable
     {
         /// <summary>The email address separator is a comma.</summary>

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -19,7 +19,7 @@ namespace Qowaiv.Financial
     /// <summary>Represents an </summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(decimal))]
-    [OpenApiDataType(description: "Decimal representation of a currency amount.", example: "15.95", type: "number", format: "amount")]
+    [OpenApiDataType(description: "Decimal representation of a currency amount.", example: 15.95, type: "number", format: "amount")]
     [TypeConverter(typeof(AmountTypeConverter))]
     public partial struct Amount : ISerializable, IXmlSerializable, IFormattable, IEquatable<Amount>, IComparable, IComparable<Amount>
     {

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -19,7 +19,7 @@ namespace Qowaiv.Financial
     /// <summary>Represents an </summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(decimal))]
-    [OpenApiDataType(description: "Decimal representation of a currency amount.", type: "number", format: "amount")]
+    [OpenApiDataType(description: "Decimal representation of a currency amount.", example: "15.95", type: "number", format: "amount")]
     [TypeConverter(typeof(AmountTypeConverter))]
     public partial struct Amount : ISerializable, IXmlSerializable, IFormattable, IEquatable<Amount>, IComparable, IComparable<Amount>
     {

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -38,7 +38,7 @@ namespace Qowaiv.Financial
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
-    [OpenApiDataType(description: "Business Identifier Code, as defined by ISO 9362, for example, DEUTDEFF.", type: "string", format: "bic", nullable: true)]
+    [OpenApiDataType(description: "Business Identifier Code, as defined by ISO 9362.", example: "DEUTDEFF", type: "string", format: "bic", nullable: true)]
     [TypeConverter(typeof(BusinessIdentifierCodeTypeConverter))]
     public partial struct BusinessIdentifierCode : ISerializable, IXmlSerializable, IFormattable, IEquatable<BusinessIdentifierCode>, IComparable, IComparable<BusinessIdentifierCode>
     {

--- a/src/Qowaiv/Financial/Currency.cs
+++ b/src/Qowaiv/Financial/Currency.cs
@@ -41,7 +41,7 @@ namespace Qowaiv.Financial
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
-    [OpenApiDataType(description: "Currency notation as defined by ISO 4217, for example, EUR.", type: "string", format: "currency", nullable: true)]
+    [OpenApiDataType(description: "Currency notation as defined by ISO 4217.", example: "EUR", type: "string", format: "currency", nullable: true)]
     [TypeConverter(typeof(CurrencyTypeConverter))]
     public partial struct Currency : ISerializable, IXmlSerializable, IFormattable, IFormatProvider, IEquatable<Currency>, IComparable, IComparable<Currency>
     {

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -35,7 +35,7 @@ namespace Qowaiv.Financial
     /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
-    [OpenApiDataType(description: "International Bank Account Number notation as defined by ISO 13616:2007, for example, BE71096123456769.", type: "string", format: "iban", nullable: true)]
+    [OpenApiDataType(description: "International Bank Account Number notation as defined by ISO 13616:2007.", example: "BE71096123456769.", type: "string", format: "iban", nullable: true)]
     [TypeConverter(typeof(InternationalBankAccountNumberTypeConverter))]
     public partial struct InternationalBankAccountNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<InternationalBankAccountNumber>, IComparable, IComparable<InternationalBankAccountNumber>
     {

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -21,7 +21,7 @@ namespace Qowaiv.Financial
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.Continuous, typeof(decimal))]
-    [OpenApiDataType(description: "Combined currency and amount notation as defined by ISO 4217, for example, EUR 12.47.", type: "string", format: "money", pattern: @"[A-Z]{3} -?[0-9]+(\.[0-9]+)?")]
+    [OpenApiDataType(description: "Combined currency and amount notation as defined by ISO 4217.", example: "EUR12.47", type: "string", format: "money", pattern: @"[A-Z]{3} -?[0-9]+(\.[0-9]+)?")]
     [TypeConverter(typeof(MoneyTypeConverter))]
     public partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEquatable<Money>, IComparable, IComparable<Money>
     {

--- a/src/Qowaiv/Gender.cs
+++ b/src/Qowaiv/Gender.cs
@@ -39,7 +39,7 @@ namespace Qowaiv
     /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(byte))]
-    [OpenApiDataType(description: "Gender as specified by ISO/IEC 5218.", type: "string", format: "gender", nullable: true, @enum: "NotKnown,Male,Female,NotApplicable")]
+    [OpenApiDataType(description: "Gender as specified by ISO/IEC 5218.", example:"female", type: "string", format: "gender", nullable: true, @enum: "NotKnown,Male,Female,NotApplicable")]
     [TypeConverter(typeof(GenderTypeConverter))]
     public partial struct Gender : ISerializable, IXmlSerializable, IFormattable, IEquatable<Gender>, IComparable, IComparable<Gender>
     {

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -32,7 +32,7 @@ namespace Qowaiv.Globalization
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
-    [OpenApiDataType(description: "Country notation as defined by ISO 3166-1 alpha-2, for example, NL.", type: "string", format: "country", nullable: true)]
+    [OpenApiDataType(description: "Country notation as defined by ISO 3166-1 alpha-2.", example: "NL", type: "string", format: "country", nullable: true)]
     [TypeConverter(typeof(CountryTypeConverter))]
     public partial struct Country : ISerializable, IXmlSerializable, IFormattable, IEquatable<Country>, IComparable, IComparable<Country>
     {

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -19,7 +19,7 @@ namespace Qowaiv
     /// <summary>Represents a house number.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(int))]
-    [OpenApiDataType(description: "House number notation.", type: "string", format: "house-number", nullable: true)]
+    [OpenApiDataType(description: "House number notation.", example: "13", type: "string", format: "house-number", nullable: true)]
     [TypeConverter(typeof(HouseNumberTypeConverter))]
     public partial struct HouseNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<HouseNumber>, IComparable, IComparable<HouseNumber>
     {

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -31,7 +31,7 @@ namespace Qowaiv.IO
     /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(long))]
-    [OpenApiDataType(description: "Stream size notation (in byte).", example: "1024", type: "integer", format: "stream-size")]
+    [OpenApiDataType(description: "Stream size notation (in byte).", example: 1024, type: "integer", format: "stream-size")]
     [TypeConverter(typeof(StreamSizeTypeConverter))]
     public partial struct StreamSize : ISerializable, IXmlSerializable, IFormattable, IEquatable<StreamSize>, IComparable, IComparable<StreamSize>
     {

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -31,7 +31,7 @@ namespace Qowaiv.IO
     /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(long))]
-    [OpenApiDataType(description: "Stream size notation (in byte).", type: "integer", format: "stream-size")]
+    [OpenApiDataType(description: "Stream size notation (in byte).", example: "1024", type: "integer", format: "stream-size")]
     [TypeConverter(typeof(StreamSizeTypeConverter))]
     public partial struct StreamSize : ISerializable, IXmlSerializable, IFormattable, IEquatable<StreamSize>, IComparable, IComparable<StreamSize>
     {

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -29,7 +29,7 @@ namespace Qowaiv.Identifiers
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.AllExcludingCulture ^ SingleValueStaticOptions.HasUnknownValue, typeof(object))]
-    [OpenApiDataType(description: "identifier", type: "string/int")]
+    [OpenApiDataType(description: "identifier", example: "8a1a8c42-d2ff-e254-e26e-b6abcbf19420", type: "string/int")]
     [TypeConverter(typeof(IdTypeConverter))]
     public partial struct Id<TIdentifier> : ISerializable, IXmlSerializable, IFormattable, IEquatable<Id<TIdentifier>>, IComparable, IComparable<Id<TIdentifier>>
         where TIdentifier : IIdentifierBehavior, new()

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -29,7 +29,7 @@ namespace Qowaiv.Identifiers
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.AllExcludingCulture ^ SingleValueStaticOptions.HasUnknownValue, typeof(object))]
-    [OpenApiDataType(description: "identifier", example: "8a1a8c42-d2ff-e254-e26e-b6abcbf19420", type: "string/int")]
+    [OpenApiDataType(description: "identifier", example: "8a1a8c42-d2ff-e254-e26e-b6abcbf19420", type: "any")]
     [TypeConverter(typeof(IdTypeConverter))]
     public partial struct Id<TIdentifier> : ISerializable, IXmlSerializable, IFormattable, IEquatable<Id<TIdentifier>>, IComparable, IComparable<Id<TIdentifier>>
         where TIdentifier : IIdentifierBehavior, new()

--- a/src/Qowaiv/Json/OpenApiDataTypeAttribute.cs
+++ b/src/Qowaiv/Json/OpenApiDataTypeAttribute.cs
@@ -20,6 +20,26 @@ namespace Qowaiv.Json
         public OpenApiDataTypeAttribute(
             string description,
             string type,
+            string example,
+            string format = null,
+            bool nullable = false,
+            string pattern = null,
+            string @enum = null)
+        {
+            Description = Guard.NotNullOrEmpty(description, nameof(description));
+            Type = Guard.NotNullOrEmpty(type, nameof(type));
+            Example = Guard.NotNullOrEmpty(example, nameof(example));
+            Format = format;
+            Nullable = nullable;
+            Pattern = pattern;
+            Enum = @enum?.Split(',');
+        }
+
+        /// <summary>Creates a new instance of a <see cref="OpenApiDataTypeAttribute"/>.</summary>
+        [Obsolete("Use the constructor that provides an example as well.")]
+        public OpenApiDataTypeAttribute(
+            string description,
+            string type,
             string format = null,
             bool nullable = false,
             string pattern = null,
@@ -45,6 +65,9 @@ namespace Qowaiv.Json
         /// <summary>Gets the type of the OpenAPI Data Type.</summary>
         public string Type { get; }
 
+        /// <summary>Gets the example of the OpenAPI Data Type.</summary>
+        public string Example { get; }
+
         /// <summary>Gets the format of the OpenAPI Data Type.</summary>
         public string Format { get; }
 
@@ -63,7 +86,7 @@ namespace Qowaiv.Json
             get
             {
                 var sb = new StringBuilder();
-                sb.Append($@"{{ type: {Type}, desc: {Description}");
+                sb.Append($@"{{ type: {Type}, desc: {Description}, example: {Example}");
 
                 if (!string.IsNullOrEmpty(Format))
                 {

--- a/src/Qowaiv/Json/OpenApiDataTypeAttribute.cs
+++ b/src/Qowaiv/Json/OpenApiDataTypeAttribute.cs
@@ -20,7 +20,7 @@ namespace Qowaiv.Json
         public OpenApiDataTypeAttribute(
             string description,
             string type,
-            string example,
+            object example,
             string format = null,
             bool nullable = false,
             string pattern = null,
@@ -28,7 +28,7 @@ namespace Qowaiv.Json
         {
             Description = Guard.NotNullOrEmpty(description, nameof(description));
             Type = Guard.NotNullOrEmpty(type, nameof(type));
-            Example = Guard.NotNullOrEmpty(example, nameof(example));
+            Example = Guard.NotNull(example, nameof(example));
             Format = format;
             Nullable = nullable;
             Pattern = pattern;
@@ -66,7 +66,7 @@ namespace Qowaiv.Json
         public string Type { get; }
 
         /// <summary>Gets the example of the OpenAPI Data Type.</summary>
-        public string Example { get; }
+        public object Example { get; }
 
         /// <summary>Gets the format of the OpenAPI Data Type.</summary>
         public string Format { get; }

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -18,7 +18,7 @@ namespace Qowaiv
     /// <summary>Represents a local date time.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(DateTime))]
-    [OpenApiDataType(description: "Date-time notation as defined by RFC 3339, without time zone information, for example, 2017-06-10 15:00.", type: "string", format: "local-date-time")]
+    [OpenApiDataType(description: "Date-time notation as defined by RFC 3339, without time zone information.", example: "2017-06-10 15:00", type: "string", format: "local-date-time")]
     [TypeConverter(typeof(LocalDateTimeTypeConverter))]
     public partial struct LocalDateTime : ISerializable, IXmlSerializable, IFormattable, IEquatable<LocalDateTime>, IComparable, IComparable<LocalDateTime>
     {

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -24,7 +24,7 @@ namespace Qowaiv.Mathematics
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.Continuous, typeof(Tuple<long, long>))]
-    [OpenApiDataType(description: "Faction", type: "string", format: "faction", pattern: "-?[0-9]+(/[0-9]+)?")]
+    [OpenApiDataType(description: "Faction", type: "string", format: "faction", pattern: "-?[0-9]+(/[0-9]+)?", example: "13/42")]
     [TypeConverter(typeof(FractionTypeConverter))]
     [StructLayout(LayoutKind.Sequential)]
     public partial struct Fraction : ISerializable, IXmlSerializable, IFormattable, IEquatable<Fraction>, IComparable, IComparable<Fraction>

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -20,7 +20,7 @@ namespace Qowaiv
     /// <summary>Represents a month.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(byte))]
-    [OpenApiDataType(description: "Month(-only) notation.", type: "string", format: "month", nullable: true, @enum: "Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec,?")]
+    [OpenApiDataType(description: "Month(-only) notation.", example: "Jun", type: "string", format: "month", nullable: true, @enum: "Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec,?")]
     [TypeConverter(typeof(MonthTypeConverter))]
     public partial struct Month : ISerializable, IXmlSerializable, IFormattable, IEquatable<Month>, IComparable, IComparable<Month>
     {

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -14,7 +14,7 @@ namespace Qowaiv
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.Continuous, underlyingType: typeof(int))]
-    [OpenApiDataType(description: "Month span, specified in years and months, for example 1Y+10M.", type: "string", format: "month-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M")]
+    [OpenApiDataType(description: "Month span, specified in years and months.", example: "1Y+10M", type: "string", format: "month-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M")]
     [TypeConverter(typeof(Conversion.MonthSpanTypeConverter))]
     public partial struct MonthSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<MonthSpan>, IComparable, IComparable<MonthSpan>
     {

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -20,7 +20,7 @@ namespace Qowaiv
     /// <summary>Represents a Percentage.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All ^ SingleValueStaticOptions.HasEmptyValue ^ SingleValueStaticOptions.HasUnknownValue, typeof(decimal))]
-    [OpenApiDataType(description: "Ratio expressed as a fraction of 100 denoted using the percent sign '%', for example 13.76%.", type: "string", format: "percentage", pattern: @"-?[0-9]+(\.[0-9]+)?%")]
+    [OpenApiDataType(description: "Ratio expressed as a fraction of 100 denoted using the percent sign '%'.",  example:"13.76%", type: "string", format: "percentage", pattern: @"-?[0-9]+(\.[0-9]+)?%")]
     [TypeConverter(typeof(PercentageTypeConverter))]
     public partial struct Percentage : ISerializable, IXmlSerializable, IFormattable, IEquatable<Percentage>, IComparable, IComparable<Percentage>
     {

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -27,7 +27,7 @@ namespace Qowaiv
     /// <summary>Represents a postal code.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
-    [OpenApiDataType(description: "Postal code notation.", type: "string", format: "postal-code", nullable: true)]
+    [OpenApiDataType(description: "Postal code notation.", example: "2624DP", type: "string", format: "postal-code", nullable: true)]
     [TypeConverter(typeof(PostalCodeTypeConverter))]
     public partial struct PostalCode : ISerializable, IXmlSerializable, IFormattable, IEquatable<PostalCode>, IComparable, IComparable<PostalCode>
     {

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>5.1.1</Version>
+    <Version>5.1.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -24,7 +24,7 @@ namespace Qowaiv.Security.Cryptography
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.AllExcludingCulture ^ SingleValueStaticOptions.HasUnknownValue, typeof(byte[]))]
-    [OpenApiDataType(description: "Base64 encoded cryptographic seed.", type: "string", format: "cryptographic-seed", nullable: true)]
+    [OpenApiDataType(description: "Base64 encoded cryptographic seed.", example: "Qowaiv==", type: "string", format: "cryptographic-seed", nullable: true)]
     [TypeConverter(typeof(CryptographicSeedTypeConverter))]
     public partial struct CryptographicSeed : ISerializable, IXmlSerializable, IFormattable, IEquatable<CryptographicSeed>, IComparable, IComparable<CryptographicSeed>
     {

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -28,7 +28,7 @@ namespace Qowaiv.Statistics
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.Continuous, typeof(double))]
-    [OpenApiDataType(description: "Elo rating system notation.", type: "number", format: "elo")]
+    [OpenApiDataType(description: "Elo rating system notation.", example: "1600", type: "number", format: "elo")]
     [TypeConverter(typeof(EloTypeConverter))]
     public partial struct Elo : ISerializable, IXmlSerializable, IFormattable, IEquatable<Elo>, IComparable, IComparable<Elo>
     {

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -28,7 +28,7 @@ namespace Qowaiv.Statistics
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable]
     [SingleValueObject(SingleValueStaticOptions.Continuous, typeof(double))]
-    [OpenApiDataType(description: "Elo rating system notation.", example: "1600", type: "number", format: "elo")]
+    [OpenApiDataType(description: "Elo rating system notation.", example: 1600, type: "number", format: "elo")]
     [TypeConverter(typeof(EloTypeConverter))]
     public partial struct Elo : ISerializable, IXmlSerializable, IFormattable, IEquatable<Elo>, IComparable, IComparable<Elo>
     {

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -34,7 +34,7 @@ namespace Qowaiv
     /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.AllExcludingCulture ^ SingleValueStaticOptions.HasUnknownValue, typeof(Guid))]
-    [OpenApiDataType(description: "Universally unique identifier, Base64 encoded, for example lmZO_haEOTCwGsCcbIZFFg.", type: "string", format: "uuid-base64", nullable: true)]
+    [OpenApiDataType(description: "Universally unique identifier, Base64 encoded.", example:"lmZO_haEOTCwGsCcbIZFFg", type: "string", format: "uuid-base64", nullable: true)]
     [TypeConverter(typeof(UuidTypeConverter))]
     public partial struct Uuid : ISerializable, IXmlSerializable, IFormattable, IEquatable<Uuid>, IComparable, IComparable<Uuid>
     {

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -53,7 +53,7 @@ namespace Qowaiv.Web
     /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.AllExcludingCulture, typeof(string))]
-    [OpenApiDataType(description: "Media type notation as defined by RFC 6838, for example, text/html.", type: "string", format: "internet-media-type", nullable: true)]
+    [OpenApiDataType(description: "Media type notation as defined by RFC 6838.", example: "text/html", type: "string", format: "internet-media-type", nullable: true)]
     [TypeConverter(typeof(InternetMediaTypeTypeConverter))]
     public partial struct InternetMediaType : ISerializable, IXmlSerializable, IFormattable, IEquatable<InternetMediaType>, IComparable, IComparable<InternetMediaType>
     {

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -46,7 +46,7 @@ namespace Qowaiv
     /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All ^ SingleValueStaticOptions.HasEmptyValue ^ SingleValueStaticOptions.HasUnknownValue, typeof(Date))]
-    [OpenApiDataType(description: "Full-date notation as defined by ISO 8601, for example, 1997-W14-6.", type: "string", format: "date-weekbased")]
+    [OpenApiDataType(description: "Full-date notation as defined by ISO 8601.", example: "1997-W14-6", type: "string", format: "date-weekbased")]
     [TypeConverter(typeof(WeekDateTypeConverter))]
     public partial struct WeekDate : ISerializable, IXmlSerializable, IFormattable, IEquatable<WeekDate>, IComparable, IComparable<WeekDate>
     {

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -19,7 +19,7 @@ namespace Qowaiv
     /// <summary>Represents a year.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(short))]
-    [OpenApiDataType(description: "Year(-only) notation.", example: "1983", type: "integer", format: "year", nullable: true)]
+    [OpenApiDataType(description: "Year(-only) notation.", example: 1983, type: "integer", format: "year", nullable: true)]
     [TypeConverter(typeof(YearTypeConverter))]
     public partial struct Year : ISerializable, IXmlSerializable, IFormattable, IEquatable<Year>, IComparable, IComparable<Year>
     {

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -19,7 +19,7 @@ namespace Qowaiv
     /// <summary>Represents a year.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(short))]
-    [OpenApiDataType(description: "Year(-only) notation.", type: "integer", format: "year", nullable: true)]
+    [OpenApiDataType(description: "Year(-only) notation.", example: "1983", type: "integer", format: "year", nullable: true)]
     [TypeConverter(typeof(YearTypeConverter))]
     public partial struct Year : ISerializable, IXmlSerializable, IFormattable, IEquatable<Year>, IComparable, IComparable<Year>
     {

--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -31,7 +31,7 @@ namespace Qowaiv
     /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay}")]
     [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(byte))]
-    [OpenApiDataType(description: "Yes-No notation.", type: "string", format: "yes-no", nullable: true, @enum: "yes,no,?")]
+    [OpenApiDataType(description: "Yes-No notation.", example: "yes", type: "string", format: "yes-no", nullable: true, @enum: "yes,no,?")]
     [TypeConverter(typeof(YesNoTypeConverter))]
     public partial struct YesNo : ISerializable, IXmlSerializable, IFormattable, IEquatable<YesNo>, IComparable, IComparable<YesNo>
     {

--- a/test/Qowaiv.Data.SqlClient.UnitTests/Qowaiv.Data.SqlClient.UnitTests.csproj
+++ b/test/Qowaiv.Data.SqlClient.UnitTests/Qowaiv.Data.SqlClient.UnitTests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Qowaiv.TestTools.UnitTests/Qowaiv.TestTools.UnitTests.csproj
+++ b/test/Qowaiv.TestTools.UnitTests/Qowaiv.TestTools.UnitTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Qowaiv.UnitTests/Debug_specs.cs
+++ b/test/Qowaiv.UnitTests/Debug_specs.cs
@@ -28,12 +28,13 @@ namespace Debug_specs
         {
             var attribute = new OpenApiDataTypeAttribute(
                 description: "Year",
+                example: "1983",
                 type: "integer",
                 format: "0000",
                 nullable: true,
                 pattern: "^[0-9]{4}$");
 
-            DebuggerDisplayAssert.HasResult("{ type: integer, desc: Year, format: 0000, pattern: ^[0-9]{4}$, nullable: true }", attribute);
+            DebuggerDisplayAssert.HasResult("{ type: integer, desc: Year, example: 1983, format: 0000, pattern: ^[0-9]{4}$, nullable: true }", attribute);
 
         }
 

--- a/test/Qowaiv.UnitTests/Email_address_specs.cs
+++ b/test/Qowaiv.UnitTests/Email_address_specs.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using FluentAssertions;
+using NUnit.Framework;
 using Qowaiv;
 using Qowaiv.Globalization;
 using Qowaiv.Json;
@@ -482,29 +483,21 @@ namespace Email_address_specs
     public class Is_Open_API_data_type
     {
         internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(EmailAddress)).FirstOrDefault();
-        [Test]
-        public void with_description()
-        {
-            Assert.AreEqual("Email notation as defined by RFC 5322, for example, svo@qowaiv.org.", Attribute.Description);
-        }
 
         [Test]
-        public void has_type()
-        {
-            Assert.AreEqual("string", Attribute.Type);
-        }
+        public void with_description() => Attribute.Description.Should().Be("Email notation as defined by RFC 5322.");
 
         [Test]
-        public void has_format()
-        {
-            Assert.AreEqual("email", Attribute.Format);
-        }
+        public void with_example() => Attribute.Example.Should().Be("svo@qowaiv.org");
 
         [Test]
-        public void pattern_is_null()
-        {
-            Assert.IsNull(Attribute.Pattern);
-        }
+        public void has_type() => Attribute.Type.Should().Be("string");
+
+        [Test]
+        public void has_format() => Attribute.Format.Should().Be("email");
+
+        [Test]
+        public void pattern_is_null()=> Attribute.Pattern.Should().BeNull();
     }
 
     public class Supports_binary_serialization

--- a/test/Qowaiv.UnitTests/Json/OpenApiDataTypeTest.cs
+++ b/test/Qowaiv.UnitTests/Json/OpenApiDataTypeTest.cs
@@ -48,6 +48,7 @@ namespace Qowaiv.UnitTests.Json
                 all[name] = new OpenApiDataType
                 {
                     description = attribute.Description,
+                    example = attribute.Example,
                     type = attribute.Type,
                     format = attribute.Format,
                     pattern = attribute.Pattern,
@@ -67,6 +68,7 @@ namespace Qowaiv.UnitTests.Json
     internal class OpenApiDataType
     {
         public string description { get; set; }
+        public object example { get; set; }
         public string type { get; set; }
         public string format { get; set; }
         public string pattern { get; set; }

--- a/test/Qowaiv.UnitTests/NumericSvoTest.cs
+++ b/test/Qowaiv.UnitTests/NumericSvoTest.cs
@@ -31,7 +31,7 @@ namespace Qowaiv.UnitTests
                 .Where(pars => pars.Length == 0)
                 .ToArray();
 
-            Assert.IsTrue(methods.Length == 1, nameof(methods));
+            Assert.IsTrue(methods?.Length == 1, nameof(methods));
         }
 
         [TestCase(typeof(Amount))]

--- a/test/Qowaiv.UnitTests/Obsolete_code.cs
+++ b/test/Qowaiv.UnitTests/Obsolete_code.cs
@@ -2,6 +2,7 @@
 using Qowaiv;
 using Qowaiv.Financial;
 using Qowaiv.Globalization;
+using Qowaiv.Json;
 using Qowaiv.Reflection;
 using Qowaiv.TestTools.Globalization;
 using Qowaiv.UnitTests;
@@ -66,6 +67,9 @@ namespace Obsolete_code
 
         [Test]
         public void QowaivType_IsSingleValueObject() => Assert.IsTrue(QowaivType.IsSingleValueObject(typeof(Percentage)));
+
+        [Test]
+        public void OpenApiDataType_ctor_without_example()=> Assert.NotNull(new OpenApiDataTypeAttribute(description: "Postal code notation.", type: "string", format: "postal-code", nullable: true));
     }
 
     [Obsolete("Will become private when the next major version is released.")]

--- a/test/Qowaiv.UnitTests/Percentage_specs.cs
+++ b/test/Qowaiv.UnitTests/Percentage_specs.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using FluentAssertions;
+using NUnit.Framework;
 using Qowaiv;
 using Qowaiv.Financial;
 using Qowaiv.Globalization;
@@ -1245,36 +1246,22 @@ namespace Percentage_specs
         internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Percentage)).FirstOrDefault();
 
         [Test]
-        public void with_description()
-        {
-            Assert.AreEqual(
-                "Ratio expressed as a fraction of 100 denoted using the " +
-                "percent sign '%', for example 13.76%.",
-                Attribute.Description);
-        }
+        public void with_description() => Attribute.Description.Should().Be("Ratio expressed as a fraction of 100 denoted using the percent sign '%'.");
 
         [Test]
-        public void has_type()
-        {
-            Assert.AreEqual("string", Attribute.Type);
-        }
+        public void with_example() => Attribute.Example.Should().Be("13.76%");
 
         [Test]
-        public void has_format()
-        {
-            Assert.AreEqual("percentage", Attribute.Format);
-        }
+        public void has_type() => Attribute.Type.Should().Be("string");
 
+        [Test]
+        public void has_format() => Attribute.Format.Should().Be("percentage");
 
         [TestCase("17.51%")]
         [TestCase("-4.1%")]
         [TestCase("-0.1%")]
         [TestCase("31%")]
-        public void pattern_matches(string input)
-        {
-            Assert.IsTrue(Regex.IsMatch(input, Attribute.Pattern));
-        }
-
+        public void pattern_matches(string input) => Regex.IsMatch(input, Attribute.Pattern).Should().BeTrue();
     }
 
     public class Supports_binary_serialization

--- a/test/Qowaiv.UnitTests/Qowaiv.UnitTests.csproj
+++ b/test/Qowaiv.UnitTests/Qowaiv.UnitTests.csproj
@@ -11,6 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/test/Qowaiv.UnitTests/Qowaiv.UnitTests.csproj
+++ b/test/Qowaiv.UnitTests/Qowaiv.UnitTests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Qowaiv.UnitTests/UUID_specs.cs
+++ b/test/Qowaiv.UnitTests/UUID_specs.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using FluentAssertions;
+using NUnit.Framework;
 using Qowaiv;
 using Qowaiv.Globalization;
 using Qowaiv.Json;
@@ -659,32 +660,20 @@ Actual:   [{(string.Join(", ", act))}]");
         internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Uuid)).FirstOrDefault();
 
         [Test]
-        public void with_description()
-        {
-            Assert.AreEqual(
-                "Universally unique identifier, Base64 encoded, for example lmZO_haEOTCwGsCcbIZFFg.",
-                Attribute.Description);
-        }
+        public void with_description() => Attribute.Description.Should().Be("Universally unique identifier, Base64 encoded.");
 
         [Test]
-        public void has_type()
-        {
-            Assert.AreEqual("string", Attribute.Type);
-        }
+        public void with_example() => Attribute.Example.Should().Be("lmZO_haEOTCwGsCcbIZFFg");
 
         [Test]
-        public void has_format()
-        {
-            Assert.AreEqual("uuid-base64", Attribute.Format);
-        }
+        public void has_type() => Attribute.Type.Should().Be("string");
 
         [Test]
-        public void pattern_is_null()
-        {
-            Assert.IsNull(Attribute.Pattern);
-        }
+        public void has_format() => Attribute.Format.Should().Be("uuid-base64");
+
+        [Test]
+        public void pattern_is_null() => Attribute.Pattern.Should().BeNull();
     }
-
 
     public class Supports_binary_serialization
     {


### PR DESCRIPTION
As Swagger's Open API v3 supports separate [examples](https://swagger.io/docs/specification/adding-examples/) to be specified, so should Qowaiv decorate its SVO's:

``` C#
[OpenApiDataType(description: "International Bank Account Number notation as defined by ISO 13616:2007.", example: "BE71096123456769.", type: "string", format: "iban", nullable: true)]
```

As we do not want to introduce a breaking change (yet), an extra constructor has been added, and the old one has been marked as obsolete.

See #187