### PR TITLE
Introduction of Hash Helper

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,9 @@ dotnet_diagnostic.QW0003.severity = warning
 # S101: Types should be named in PascalCase
 dotnet_diagnostic.S101.severity = none
 
+# S3376: Attribute, EventArgs, and Exception type names should end with the type being extended
+dotnet_diagnostic.S3376.severity = none
+
 # S4136: Method overloads should be grouped together
 dotnet_diagnostic.S4136.severity = none
 dotnet_diagnostic.S2437.severity=warning

--- a/specs/Qowaiv.Specs/Hashing/Hash_specs.cs
+++ b/specs/Qowaiv.Specs/Hashing/Hash_specs.cs
@@ -1,0 +1,122 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Qowaiv.Hashing;
+using System;
+
+namespace Hashing.Hash_specs
+{
+    public class Get_hash_code
+    {
+        [Test]
+        public void Null_String_is_supported()
+        {
+            using (Hash.WithFixedRandomizer())
+            {
+                string nil = null;
+                var hash = Hash.Code(nil);
+                hash.Should().Be(740020621);
+            }
+        }
+    }
+    public class Get_hash_code_with_fixed_randomizer
+    {
+        [Test]
+        public void String_is_fixed()
+        {
+            using(Hash.WithFixedRandomizer())
+            {
+                var hash = Hash.Code("QOWAIV string");
+                hash.Should().Be(1211348473);
+            }
+        }
+
+        [Test]
+        public void Int32_is_fixed()
+        {
+            using (Hash.WithFixedRandomizer())
+            {
+                var hash = Hash.Code(17);
+                hash.Should().Be(20170594);
+            }
+        }
+
+        [Test]
+        public void Int64_is_fixed()
+        {
+            using (Hash.WithFixedRandomizer())
+            {
+                var hash = Hash.Code(12345678909876L);
+                hash.Should().Be(1929223677);
+            }
+        }
+    }
+
+    public class Get_hash_code_without_fixed_randomizer
+    {
+        [Test]
+        public void String_is_different_from_fixed()
+        {
+            int fix;
+            using (Hash.WithFixedRandomizer())
+            {
+                fix = Hash.Code("QOWAIV string");
+            }
+            fix.Should().NotBe(Hash.Code("QOWAIV string"));
+        }
+
+        [Test]
+        public void Int32_is_different_from_fixed()
+        {
+            int fix;
+            using (Hash.WithFixedRandomizer())
+            {
+                fix = Hash.Code(17);
+            }
+            fix.Should().NotBe(Hash.Code(17));
+        }
+
+        [Test]
+        public void Int64_is_different_from_fixed()
+        {
+            int fix;
+            using (Hash.WithFixedRandomizer())
+            {
+                fix = Hash.Code(12345678909876L);
+            }
+            fix.Should().NotBe(Hash.Code(1712345678909876L));
+        }
+
+        [Test]
+        public void String_gives_same_result()
+        {
+            var first = Hash.Code("QOWAIV string");
+            first.Should().Be(Hash.Code("QOWAIV string"));
+        }
+
+        [Test]
+        public void Int32_gives_same_result()
+        {
+            var first = Hash.Code(17);
+            first.Should().Be(Hash.Code(17));
+        }
+
+        [Test]
+        public void Int64_gives_same_result()
+        {
+            var first = Hash.Code(1712345678909876L);
+            first.Should().Be(Hash.Code(1712345678909876L));
+            Console.WriteLine(first);
+        }
+    }
+
+    public class Not_supported
+    {
+        [Test]
+        public void for_type_throws_exception()
+        {
+            Action hash = () => Hash.NotSupportedBy<string>();
+            hash.Should().Throw<HashingNotSupported>()
+                .WithMessage("Hashing is not supported by System.String.");
+        }
+    }
+}

--- a/src/Qowaiv/Hashing/Hash.cs
+++ b/src/Qowaiv/Hashing/Hash.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Diagnostics.Contracts;
+
+namespace Qowaiv.Hashing
+{
+    /// <summary>Helper class for getting randomized hashcodes.</summary>
+    public static class Hash
+    {
+        /// <summary>Gets a randomized hashcode for a <see cref="string"/>.</summary>
+        [Pure]
+        public static int Code(string str)
+        {
+            str ??= string.Empty;
+            unchecked
+            {
+                int hash1 = (5381 << 16) + 5381;
+                int hash2 = hash1;
+
+                for (int i = 0; i < str.Length; i += 2)
+                {
+                    hash1 = ((hash1 << 5) + hash1) ^ str[i];
+                    if (i == str.Length - 1) break;
+                    else  hash2 = ((hash2 << 5) + hash2) ^ str[i + 1];
+                }
+                return Code(hash1 + (hash2 * 1566083941));
+            }
+        }
+
+        /// <summary>Gets a randomized hashcode for an <see cref="int"/>.</summary>
+        [Pure]
+        public static int Code(int value) => Randomizer ^ value;
+        
+        /// <summary>Gets a randomized hashcode for a struct.</summary>
+        [Pure]
+        public static int Code<T>(T value) where T : struct
+            => Randomizer ^ value.GetHashCode();
+
+        /// <summary>Randomizer hash based on <see cref="string.GetHashCode()"/>.</summary>
+        private static int Randomizer = "Qowaiv".GetHashCode();
+
+        /// <summary>Indicates that hashing is not supported by the type.</summary>
+        [Pure]
+        public static int NotSupportedBy<T>() 
+            => throw new HashingNotSupported(string.Format(QowaivMessages.HashingNotSupported, typeof(T)));
+
+        /// <summary>Fixes the base hash for the scope of the statement.</summary>
+        public static IDisposable WithFixedRandomizer() => new Scope();
+
+#pragma warning disable S3010 // Static fields should not be updated in constructors
+#pragma warning disable S2696 // Instance members should not write to "static" fields
+        /// <remarks>This class deals with temporary changing the state of a private static field.</remarks>
+        private sealed class Scope : IDisposable
+        {
+            private readonly int Current;
+
+            public Scope()
+            {
+                Current = Randomizer;
+                Randomizer = 20170611;
+            }
+
+            public void Dispose() => Randomizer = Current;
+        }
+    }
+}

--- a/src/Qowaiv/Hashing/HashingNotSupported.cs
+++ b/src/Qowaiv/Hashing/HashingNotSupported.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
+namespace Qowaiv.Hashing
+{
+    /// <summary>An exception to thrown to indicate that a sertain class/struct
+    /// is not designed to support hashing.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public class HashingNotSupported : NotSupportedException
+    {
+        /// <summary>Creates a new instance of the <see cref="HashingNotSupported"/> class.</summary>
+        public HashingNotSupported() { }
+
+        /// <summary>Creates a new instance of the <see cref="HashingNotSupported"/> class.</summary>
+        public HashingNotSupported(string message) : base(message) { }
+
+        /// <summary>Creates a new instance of the <see cref="HashingNotSupported"/> class.</summary>
+        public HashingNotSupported(string message, Exception innerException) : base(message, innerException) { }
+
+        /// <summary>Creates a new instance of the <see cref="HashingNotSupported"/> class.</summary>
+        protected HashingNotSupported(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -430,6 +430,15 @@ namespace Qowaiv {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hashing is not supported by {0}..
+        /// </summary>
+        public static string HashingNotSupported {
+            get {
+                return ResourceManager.GetString("HashingNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cast from {0} to {1} is not valid..
         /// </summary>
         public static string InvalidCastException_FromTo {

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -186,4 +186,7 @@
   <data name="InvalidOperation_SequentialUUID" xml:space="preserve">
     <value>Sequential UUID can only be generated between 1970-01-01 and 9276-12-03.</value>
   </data>
+  <data name="HashingNotSupported" xml:space="preserve">
+    <value>Hashing is not supported by {0}.</value>
+  </data>
 </root>

--- a/src/Qowaiv/Text/CharBuffer.cs
+++ b/src/Qowaiv/Text/CharBuffer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Qowaiv.Hashing;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
@@ -95,9 +96,7 @@ namespace Qowaiv.Text
 
         /// <inheritdoc />
         [Pure]
-#pragma warning disable S3877 // Exceptions should not be thrown from unexpected methods
-        public override int GetHashCode() => throw new NotSupportedException("Char Buffers can not be stored in hash sets.");
-#pragma warning restore S3877 // Exceptions should not be thrown from unexpected methods
+        public override int GetHashCode() => Hash.NotSupportedBy<CharBuffer>();
 
         /// <inheritdoc />
         [Pure]


### PR DESCRIPTION
- [x] Centralize `GetHashcode()` to support randomized hashes.
- [x] Central point with a helper to explicitly make some classes/structs not support hashing.