### PR TITLE
TryParse returns Nullable<TSvo>

### DIFF
--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -219,10 +219,8 @@ namespace Email_address_specs
         }
 
         [Test]
-        public void from_invalid_as_empty_with_TryParse()
-        {
-            Assert.AreEqual(default(EmailAddress), EmailAddress.TryParse("invalid input"));
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => EmailAddress.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void with_TryParse_returns_SVO()

--- a/specs/Qowaiv.Specs/Gender_specs.cs
+++ b/specs/Qowaiv.Specs/Gender_specs.cs
@@ -258,10 +258,8 @@ namespace Gender_specs
         }
 
         [Test]
-        public void from_invalid_as_empty_with_TryParse()
-        {
-            Assert.AreEqual(default(Gender), Gender.TryParse("invalid input"));
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Gender.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void with_TryParse_returns_SVO()

--- a/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
+++ b/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
@@ -44,7 +44,7 @@ namespace IO.StreamSize_specs
 
         [Test]
         public void from_invalid_as_null_with_TryParse()
-            => StreamSize.TryParse("invalid input").Should().Be(StreamSize.Zero);
+            => StreamSize.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void with_TryParse_returns_SVO()

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -273,10 +273,8 @@ namespace Month_specs
         }
 
         [Test]
-        public void from_invalid_as_empty_with_TryParse()
-        {
-            Assert.AreEqual(default(Month), Month.TryParse("invalid input"));
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Month.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void with_TryParse_returns_SVO()

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -206,10 +206,8 @@ namespace Percentage_specs
         }
 
         [Test]
-        public void from_invalid_as_empty_with_TryParse()
-        {
-            Assert.AreEqual(default(Percentage), Percentage.TryParse("invalid input"));
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Percentage.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void with_TryParse_returns_SVO()

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -242,10 +242,8 @@ namespace Postal_code_specs
         }
 
         [Test]
-        public void from_invalid_as_empty_with_TryParse()
-        {
-            Assert.AreEqual(default(PostalCode), PostalCode.TryParse("invalid input"));
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => PostalCode.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void with_TryParse_returns_SVO()

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -637,7 +637,7 @@ namespace Postal_code_specs
         public PostalCodes(Country country, params string[] values)
         {
             Country = country;
-            Values = values.Select(v => PostalCode.TryParse(v)).ToArray();
+            Values = values.Select(v => PostalCode.Parse(v)).ToArray();
         }
 
         public Country Country { get; }

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -207,10 +207,8 @@ namespace UUID_specs
         }
 
         [Test]
-        public void from_invalid_as_empty_with_TryParse()
-        {
-            Assert.AreEqual(default(Uuid), Uuid.TryParse("invalid input"));
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Uuid.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void with_TryParse_returns_SVO()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
@@ -108,16 +108,8 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(DateSpan);
-                var act = DateSpan.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => DateSpan.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
@@ -123,16 +123,8 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Date);
-                var act = Date.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Date.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
@@ -96,16 +96,8 @@ namespace Qowaiv.Financial.UnitTests
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Amount);
-                var act = Amount.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Amount.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void Parse_CustomFormatProvider_ValidParsing()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
@@ -176,16 +176,8 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(BusinessIdentifierCode);
-                var act = BusinessIdentifierCode.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+           => BusinessIdentifierCode.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
@@ -225,16 +225,8 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Currency);
-                var act = Currency.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+           => Currency.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void Parse_EuroSign_EUR()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
@@ -122,16 +122,8 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(InternationalBankAccountNumber);
-                var act = InternationalBankAccountNumber.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => InternationalBankAccountNumber.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
@@ -81,16 +81,8 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Money);
-                var act = Money.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Money.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void Parse_EuroSpace12_Parsed()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -179,16 +179,8 @@ namespace Qowaiv.UnitTests.Globalization
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Country);
-                var act = Country.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Country.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
@@ -193,16 +193,8 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(HouseNumber);
-                var act = HouseNumber.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => HouseNumber.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
@@ -97,16 +97,8 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(LocalDateTime);
-                var act = LocalDateTime.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => LocalDateTime.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
@@ -118,15 +118,8 @@ namespace Qowaiv.UnitTests.Mathematics
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Fraction);
-                var act = Fraction.TryParse("InvalidInput");
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Fraction.TryParse("invalid input").Should().BeNull();
 
         [TestCase(0, 1, "0")]
         [TestCase(00000003, 000000010, "0.3")]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -83,15 +83,8 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (new CultureInfoScope("en-GB"))
-            {
-                var exp = default(MonthSpan);
-                var act = MonthSpan.TryParse("InvalidInput");
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+           => MonthSpan.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void FromYears_20k_Throws()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Security/Cryptography/CryptographicSeedTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Security/Cryptography/CryptographicSeedTest.cs
@@ -104,16 +104,8 @@ namespace Qowaiv.Security.Cryptography.UnitTests
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(CryptographicSeed);
-                var act = CryptographicSeed.TryParse("!");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => CryptographicSeed.TryParse("!").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
@@ -104,16 +104,8 @@ namespace Qowaiv.UnitTests.Sql
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = Timestamp.MinValue;
-                var act = Timestamp.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Timestamp.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
@@ -128,16 +128,8 @@ namespace Qowaiv.UnitTests.Statistics
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Elo);
-                var act = Elo.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Elo.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
@@ -188,16 +188,8 @@ namespace Qowaiv.UnitTests.Web
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(InternetMediaType);
-                var act = InternetMediaType.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => InternetMediaType.TryParse("invalid input").Should().BeNull();
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
@@ -163,16 +163,8 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(WeekDate);
-                var act = WeekDate.TryParse("InvalidInput");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => WeekDate.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void TryParse_Y0000W21D7_DefaultValue()

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -256,10 +256,8 @@ namespace Year_specs
         }
 
         [Test]
-        public void from_invalid_as_empty_with_TryParse()
-        {
-            Assert.AreEqual(default(Year), Year.TryParse("invalid input"));
-        }
+        public void from_invalid_as_null_with_TryParse()
+            => Year.TryParse("invalid input").Should().BeNull();
 
         [Test]
         public void with_TryParse_returns_SVO()

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -247,13 +247,11 @@ namespace YesNo_specs
         {
             Assert.IsFalse(YesNo.TryParse("invalid input", out _));
         }
-    
-        [Test]
-        public void from_invalid_as_empty_with_TryParse()
-        {
-            Assert.AreEqual(default(YesNo), YesNo.TryParse("invalid input"));
-        }
 
+        [Test]
+        public void from_invalid_as_null_with_TryParse()
+            => YesNo.TryParse("invalid input").Should().BeNull();
+            
         [Test]
         public void with_TryParse_returns_SVO()
         {

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -272,7 +272,7 @@ namespace Qowaiv.Sql
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Timestamp Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Timestamp val) ? val : throw new FormatException(QowaivMessages.FormatExceptionTimestamp);
+        public static Timestamp Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionTimestamp);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Timestamp"/>.</summary>
         /// <param name = "s">
         /// A string containing the timestamp to convert.
@@ -281,7 +281,19 @@ namespace Qowaiv.Sql
         /// The timestamp if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Timestamp TryParse(string s) => TryParse(s, null, out Timestamp val) ? val : default;
+        public static Timestamp? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Timestamp"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the timestamp to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The timestamp if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Timestamp? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Timestamp val) ? val : default(Timestamp? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Timestamp"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -308,10 +320,7 @@ namespace Qowaiv.Sql
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Timestamp Parse(string s)
-            => TryParse(s, out Timestamp val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionTimestamp);
+        public static Timestamp Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionTimestamp);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
         /// <param name="s">
@@ -321,7 +330,7 @@ namespace Qowaiv.Sql
         /// The timestamp if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Timestamp TryParse(string s) => TryParse(s, out Timestamp val) ? val : default;
+        public static Timestamp? TryParse(string s) => TryParse(s, out Timestamp val) ? val : default(Timestamp?);
 #endif
     }
 }

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -146,8 +146,9 @@ namespace Qowaiv.Financial
                 result = Unknown;
                 return true;
             }
-            else if (buffer.Matches(Pattern) && 
-                !Country.TryParse(buffer.Substring(4, 2)).IsEmptyOrUnknown())
+            else if (buffer.Matches(Pattern)
+                && Country.TryParse(buffer.Substring(4, 2), out var country)
+                && !country.IsEmptyOrUnknown())
             {
                 result = new BusinessIdentifierCode(buffer);
                 return true;

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -200,12 +200,10 @@ namespace Qowaiv.Financial
 
         [Pure]
         private static bool ValidForCountry(CharBuffer buffer)
-        {
-            var country = Country.TryParse(buffer.Substring(0, 2));
-            return !country.IsEmptyOrUnknown()
-                && (!LocalizedPatterns.TryGetValue(country, out Regex localizedPattern)
-                || buffer.Matches(localizedPattern));
-        }
+            => Country.TryParse(buffer.Substring(0, 2), out var country)
+            && !country.IsEmptyOrUnknown()
+            && (!LocalizedPatterns.TryGetValue(country, out Regex localizedPattern)
+            || buffer.Matches(localizedPattern));
 
         [Pure]
         private static bool Mod97(CharBuffer buffer)

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -273,7 +273,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Date Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Date val) ? val : throw new FormatException(QowaivMessages.FormatExceptionDate);
+        public static Date Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionDate);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Date"/>.</summary>
         /// <param name = "s">
         /// A string containing the date to convert.
@@ -282,7 +282,19 @@ namespace Qowaiv
         /// The date if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Date TryParse(string s) => TryParse(s, null, out Date val) ? val : default;
+        public static Date? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Date"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the date to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The date if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Date? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Date val) ? val : default(Date? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Date"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -309,10 +321,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Date Parse(string s)
-            => TryParse(s, out Date val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionDate);
+        public static Date Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionDate);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
         /// <param name="s">
@@ -322,7 +331,7 @@ namespace Qowaiv
         /// The date if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Date TryParse(string s) => TryParse(s, out Date val) ? val : default;
+        public static Date? TryParse(string s) => TryParse(s, out Date val) ? val : default(Date?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -273,7 +273,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static DateSpan Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out DateSpan val) ? val : throw new FormatException(QowaivMessages.FormatExceptionDateSpan);
+        public static DateSpan Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionDateSpan);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "DateSpan"/>.</summary>
         /// <param name = "s">
         /// A string containing the date span to convert.
@@ -282,7 +282,19 @@ namespace Qowaiv
         /// The date span if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static DateSpan TryParse(string s) => TryParse(s, null, out DateSpan val) ? val : default;
+        public static DateSpan? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "DateSpan"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the date span to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The date span if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static DateSpan? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out DateSpan val) ? val : default(DateSpan? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "DateSpan"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -309,10 +321,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static DateSpan Parse(string s)
-            => TryParse(s, out DateSpan val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionDateSpan);
+        public static DateSpan Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionDateSpan);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
         /// <param name="s">
@@ -322,7 +331,7 @@ namespace Qowaiv
         /// The date span if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static DateSpan TryParse(string s) => TryParse(s, out DateSpan val) ? val : default;
+        public static DateSpan? TryParse(string s) => TryParse(s, out DateSpan val) ? val : default(DateSpan?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static EmailAddress Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out EmailAddress val) ? val : throw new FormatException(QowaivMessages.FormatExceptionEmailAddress);
+        public static EmailAddress Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionEmailAddress);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "EmailAddress"/>.</summary>
         /// <param name = "s">
         /// A string containing the email address to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv
         /// The email address if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static EmailAddress TryParse(string s) => TryParse(s, null, out EmailAddress val) ? val : default;
+        public static EmailAddress? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "EmailAddress"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the email address to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The email address if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static EmailAddress? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out EmailAddress val) ? val : default(EmailAddress? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "EmailAddress"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static EmailAddress Parse(string s)
-            => TryParse(s, out EmailAddress val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionEmailAddress);
+        public static EmailAddress Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionEmailAddress);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv
         /// The email address if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static EmailAddress TryParse(string s) => TryParse(s, out EmailAddress val) ? val : default;
+        public static EmailAddress? TryParse(string s) => TryParse(s, out EmailAddress val) ? val : default(EmailAddress?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -272,7 +272,7 @@ namespace Qowaiv.Financial
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Amount Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Amount val) ? val : throw new FormatException(QowaivMessages.FormatExceptionFinancialAmount);
+        public static Amount Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionFinancialAmount);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Amount"/>.</summary>
         /// <param name = "s">
         /// A string containing the amount to convert.
@@ -281,7 +281,19 @@ namespace Qowaiv.Financial
         /// The amount if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Amount TryParse(string s) => TryParse(s, null, out Amount val) ? val : default;
+        public static Amount? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Amount"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the amount to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The amount if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Amount? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Amount val) ? val : default(Amount? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Amount"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -308,10 +320,7 @@ namespace Qowaiv.Financial
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Amount Parse(string s)
-            => TryParse(s, out Amount val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionFinancialAmount);
+        public static Amount Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionFinancialAmount);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
         /// <param name="s">
@@ -321,7 +330,7 @@ namespace Qowaiv.Financial
         /// The amount if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Amount TryParse(string s) => TryParse(s, out Amount val) ? val : default;
+        public static Amount? TryParse(string s) => TryParse(s, out Amount val) ? val : default(Amount?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv.Financial
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static BusinessIdentifierCode Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out BusinessIdentifierCode val) ? val : throw new FormatException(QowaivMessages.FormatExceptionBusinessIdentifierCode);
+        public static BusinessIdentifierCode Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionBusinessIdentifierCode);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "BusinessIdentifierCode"/>.</summary>
         /// <param name = "s">
         /// A string containing the BIC to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv.Financial
         /// The BIC if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static BusinessIdentifierCode TryParse(string s) => TryParse(s, null, out BusinessIdentifierCode val) ? val : default;
+        public static BusinessIdentifierCode? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "BusinessIdentifierCode"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the BIC to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The BIC if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static BusinessIdentifierCode? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out BusinessIdentifierCode val) ? val : default(BusinessIdentifierCode? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "BusinessIdentifierCode"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv.Financial
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static BusinessIdentifierCode Parse(string s)
-            => TryParse(s, out BusinessIdentifierCode val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionBusinessIdentifierCode);
+        public static BusinessIdentifierCode Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionBusinessIdentifierCode);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv.Financial
         /// The BIC if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static BusinessIdentifierCode TryParse(string s) => TryParse(s, out BusinessIdentifierCode val) ? val : default;
+        public static BusinessIdentifierCode? TryParse(string s) => TryParse(s, out BusinessIdentifierCode val) ? val : default(BusinessIdentifierCode?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv.Financial
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Currency Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Currency val) ? val : throw new FormatException(QowaivMessages.FormatExceptionCurrency);
+        public static Currency Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionCurrency);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Currency"/>.</summary>
         /// <param name = "s">
         /// A string containing the currency to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv.Financial
         /// The currency if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Currency TryParse(string s) => TryParse(s, null, out Currency val) ? val : default;
+        public static Currency? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Currency"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the currency to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The currency if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Currency? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Currency val) ? val : default(Currency? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Currency"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv.Financial
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Currency Parse(string s)
-            => TryParse(s, out Currency val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionCurrency);
+        public static Currency Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionCurrency);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv.Financial
         /// The currency if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Currency TryParse(string s) => TryParse(s, out Currency val) ? val : default;
+        public static Currency? TryParse(string s) => TryParse(s, out Currency val) ? val : default(Currency?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv.Financial
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static InternationalBankAccountNumber Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out InternationalBankAccountNumber val) ? val : throw new FormatException(QowaivMessages.FormatExceptionInternationalBankAccountNumber);
+        public static InternationalBankAccountNumber Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionInternationalBankAccountNumber);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "InternationalBankAccountNumber"/>.</summary>
         /// <param name = "s">
         /// A string containing the IBAN to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv.Financial
         /// The IBAN if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static InternationalBankAccountNumber TryParse(string s) => TryParse(s, null, out InternationalBankAccountNumber val) ? val : default;
+        public static InternationalBankAccountNumber? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "InternationalBankAccountNumber"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the IBAN to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The IBAN if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static InternationalBankAccountNumber? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out InternationalBankAccountNumber val) ? val : default(InternationalBankAccountNumber? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "InternationalBankAccountNumber"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv.Financial
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static InternationalBankAccountNumber Parse(string s)
-            => TryParse(s, out InternationalBankAccountNumber val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionInternationalBankAccountNumber);
+        public static InternationalBankAccountNumber Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionInternationalBankAccountNumber);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv.Financial
         /// The IBAN if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static InternationalBankAccountNumber TryParse(string s) => TryParse(s, out InternationalBankAccountNumber val) ? val : default;
+        public static InternationalBankAccountNumber? TryParse(string s) => TryParse(s, out InternationalBankAccountNumber val) ? val : default(InternationalBankAccountNumber?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -250,7 +250,7 @@ namespace Qowaiv.Financial
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Money Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Money val) ? val : throw new FormatException(QowaivMessages.FormatExceptionMoney);
+        public static Money Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionMoney);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Money"/>.</summary>
         /// <param name = "s">
         /// A string containing the money to convert.
@@ -259,7 +259,19 @@ namespace Qowaiv.Financial
         /// The money if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Money TryParse(string s) => TryParse(s, null, out Money val) ? val : default;
+        public static Money? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Money"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the money to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The money if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Money? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Money val) ? val : default(Money? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Money"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -286,10 +298,7 @@ namespace Qowaiv.Financial
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Money Parse(string s)
-            => TryParse(s, out Money val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionMoney);
+        public static Money Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionMoney);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
         /// <param name="s">
@@ -299,7 +308,7 @@ namespace Qowaiv.Financial
         /// The money if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Money TryParse(string s) => TryParse(s, out Money val) ? val : default;
+        public static Money? TryParse(string s) => TryParse(s, out Money val) ? val : default(Money?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Gender Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Gender val) ? val : throw new FormatException(QowaivMessages.FormatExceptionGender);
+        public static Gender Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionGender);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Gender"/>.</summary>
         /// <param name = "s">
         /// A string containing the gender to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv
         /// The gender if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Gender TryParse(string s) => TryParse(s, null, out Gender val) ? val : default;
+        public static Gender? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Gender"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the gender to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The gender if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Gender? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Gender val) ? val : default(Gender? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Gender"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Gender Parse(string s)
-            => TryParse(s, out Gender val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionGender);
+        public static Gender Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionGender);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Gender"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv
         /// The gender if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Gender TryParse(string s) => TryParse(s, out Gender val) ? val : default;
+        public static Gender? TryParse(string s) => TryParse(s, out Gender val) ? val : default(Gender?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv.Globalization
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Country Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Country val) ? val : throw new FormatException(QowaivMessages.FormatExceptionCountry);
+        public static Country Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionCountry);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Country"/>.</summary>
         /// <param name = "s">
         /// A string containing the country to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv.Globalization
         /// The country if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Country TryParse(string s) => TryParse(s, null, out Country val) ? val : default;
+        public static Country? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Country"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the country to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The country if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Country? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Country val) ? val : default(Country? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Country"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv.Globalization
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Country Parse(string s)
-            => TryParse(s, out Country val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionCountry);
+        public static Country Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionCountry);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv.Globalization
         /// The country if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Country TryParse(string s) => TryParse(s, out Country val) ? val : default;
+        public static Country? TryParse(string s) => TryParse(s, out Country val) ? val : default(Country?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -269,7 +269,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static HouseNumber Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out HouseNumber val) ? val : throw new FormatException(QowaivMessages.FormatExceptionHouseNumber);
+        public static HouseNumber Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionHouseNumber);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "HouseNumber"/>.</summary>
         /// <param name = "s">
         /// A string containing the house number to convert.
@@ -278,7 +278,19 @@ namespace Qowaiv
         /// The house number if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static HouseNumber TryParse(string s) => TryParse(s, null, out HouseNumber val) ? val : default;
+        public static HouseNumber? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "HouseNumber"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the house number to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The house number if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static HouseNumber? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out HouseNumber val) ? val : default(HouseNumber? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "HouseNumber"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -305,10 +317,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static HouseNumber Parse(string s)
-            => TryParse(s, out HouseNumber val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionHouseNumber);
+        public static HouseNumber Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionHouseNumber);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
         /// <param name="s">
@@ -318,7 +327,7 @@ namespace Qowaiv
         /// The house number if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static HouseNumber TryParse(string s) => TryParse(s, out HouseNumber val) ? val : default;
+        public static HouseNumber? TryParse(string s) => TryParse(s, out HouseNumber val) ? val : default(HouseNumber?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -247,7 +247,7 @@ namespace Qowaiv.IO
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static StreamSize Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out StreamSize val) ? val : throw new FormatException(QowaivMessages.FormatExceptionStreamSize);
+        public static StreamSize Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionStreamSize);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "StreamSize"/>.</summary>
         /// <param name = "s">
         /// A string containing the stream size to convert.
@@ -256,7 +256,19 @@ namespace Qowaiv.IO
         /// The stream size if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static StreamSize TryParse(string s) => TryParse(s, null, out StreamSize val) ? val : default;
+        public static StreamSize? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "StreamSize"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the stream size to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The stream size if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static StreamSize? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out StreamSize val) ? val : default(StreamSize? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "StreamSize"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -283,10 +295,7 @@ namespace Qowaiv.IO
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static StreamSize Parse(string s)
-            => TryParse(s, out StreamSize val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionStreamSize);
+        public static StreamSize Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionStreamSize);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
         /// <param name="s">
@@ -296,7 +305,7 @@ namespace Qowaiv.IO
         /// The stream size if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static StreamSize TryParse(string s) => TryParse(s, out StreamSize val) ? val : default;
+        public static StreamSize? TryParse(string s) => TryParse(s, out StreamSize val) ? val : default(StreamSize?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -273,7 +273,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static LocalDateTime Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out LocalDateTime val) ? val : throw new FormatException(QowaivMessages.FormatExceptionLocalDateTime);
+        public static LocalDateTime Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionLocalDateTime);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "LocalDateTime"/>.</summary>
         /// <param name = "s">
         /// A string containing the local date time to convert.
@@ -282,7 +282,19 @@ namespace Qowaiv
         /// The local date time if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static LocalDateTime TryParse(string s) => TryParse(s, null, out LocalDateTime val) ? val : default;
+        public static LocalDateTime? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "LocalDateTime"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the local date time to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The local date time if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static LocalDateTime? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out LocalDateTime val) ? val : default(LocalDateTime? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "LocalDateTime"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -309,10 +321,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static LocalDateTime Parse(string s)
-            => TryParse(s, out LocalDateTime val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionLocalDateTime);
+        public static LocalDateTime Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionLocalDateTime);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
         /// <param name="s">
@@ -322,7 +331,7 @@ namespace Qowaiv
         /// The local date time if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static LocalDateTime TryParse(string s) => TryParse(s, out LocalDateTime val) ? val : default;
+        public static LocalDateTime? TryParse(string s) => TryParse(s, out LocalDateTime val) ? val : default(LocalDateTime?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -250,7 +250,7 @@ namespace Qowaiv.Mathematics
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Fraction Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Fraction val) ? val : throw new FormatException(QowaivMessages.FormatExceptionFraction);
+        public static Fraction Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionFraction);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Fraction"/>.</summary>
         /// <param name = "s">
         /// A string containing the fraction to convert.
@@ -259,7 +259,19 @@ namespace Qowaiv.Mathematics
         /// The fraction if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Fraction TryParse(string s) => TryParse(s, null, out Fraction val) ? val : default;
+        public static Fraction? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Fraction"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the fraction to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The fraction if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Fraction? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Fraction val) ? val : default(Fraction? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Fraction"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -286,10 +298,7 @@ namespace Qowaiv.Mathematics
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Fraction Parse(string s)
-            => TryParse(s, out Fraction val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionFraction);
+        public static Fraction Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionFraction);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
         /// <param name="s">
@@ -299,7 +308,7 @@ namespace Qowaiv.Mathematics
         /// The fraction if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Fraction TryParse(string s) => TryParse(s, out Fraction val) ? val : default;
+        public static Fraction? TryParse(string s) => TryParse(s, out Fraction val) ? val : default(Fraction?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Month Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Month val) ? val : throw new FormatException(QowaivMessages.FormatExceptionMonth);
+        public static Month Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionMonth);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Month"/>.</summary>
         /// <param name = "s">
         /// A string containing the month to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv
         /// The month if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Month TryParse(string s) => TryParse(s, null, out Month val) ? val : default;
+        public static Month? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Month"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the month to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The month if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Month? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Month val) ? val : default(Month? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Month"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Month Parse(string s)
-            => TryParse(s, out Month val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionMonth);
+        public static Month Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionMonth);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv
         /// The month if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Month TryParse(string s) => TryParse(s, out Month val) ? val : default;
+        public static Month? TryParse(string s) => TryParse(s, out Month val) ? val : default(Month?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -272,7 +272,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static MonthSpan Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out MonthSpan val) ? val : throw new FormatException(QowaivMessages.FormatExceptionMonthSpan);
+        public static MonthSpan Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionMonthSpan);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "MonthSpan"/>.</summary>
         /// <param name = "s">
         /// A string containing the month span to convert.
@@ -281,7 +281,19 @@ namespace Qowaiv
         /// The month span if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static MonthSpan TryParse(string s) => TryParse(s, null, out MonthSpan val) ? val : default;
+        public static MonthSpan? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "MonthSpan"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the month span to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The month span if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static MonthSpan? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out MonthSpan val) ? val : default(MonthSpan? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "MonthSpan"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -308,10 +320,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static MonthSpan Parse(string s)
-            => TryParse(s, out MonthSpan val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionMonthSpan);
+        public static MonthSpan Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionMonthSpan);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
         /// <param name="s">
@@ -321,7 +330,7 @@ namespace Qowaiv
         /// The month span if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static MonthSpan TryParse(string s) => TryParse(s, out MonthSpan val) ? val : default;
+        public static MonthSpan? TryParse(string s) => TryParse(s, out MonthSpan val) ? val : default(MonthSpan?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -272,7 +272,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Percentage Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Percentage val) ? val : throw new FormatException(QowaivMessages.FormatExceptionPercentage);
+        public static Percentage Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionPercentage);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Percentage"/>.</summary>
         /// <param name = "s">
         /// A string containing the percentage to convert.
@@ -281,7 +281,19 @@ namespace Qowaiv
         /// The percentage if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Percentage TryParse(string s) => TryParse(s, null, out Percentage val) ? val : default;
+        public static Percentage? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Percentage"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the percentage to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The percentage if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Percentage? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Percentage val) ? val : default(Percentage? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Percentage"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -308,10 +320,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Percentage Parse(string s)
-            => TryParse(s, out Percentage val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionPercentage);
+        public static Percentage Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionPercentage);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
         /// <param name="s">
@@ -321,7 +330,7 @@ namespace Qowaiv
         /// The percentage if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Percentage TryParse(string s) => TryParse(s, out Percentage val) ? val : default;
+        public static Percentage? TryParse(string s) => TryParse(s, out Percentage val) ? val : default(Percentage?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static PostalCode Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out PostalCode val) ? val : throw new FormatException(QowaivMessages.FormatExceptionPostalCode);
+        public static PostalCode Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionPostalCode);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "PostalCode"/>.</summary>
         /// <param name = "s">
         /// A string containing the postal code to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv
         /// The postal code if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static PostalCode TryParse(string s) => TryParse(s, null, out PostalCode val) ? val : default;
+        public static PostalCode? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "PostalCode"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the postal code to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The postal code if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static PostalCode? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out PostalCode val) ? val : default(PostalCode? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "PostalCode"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static PostalCode Parse(string s)
-            => TryParse(s, out PostalCode val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionPostalCode);
+        public static PostalCode Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionPostalCode);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv
         /// The postal code if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static PostalCode TryParse(string s) => TryParse(s, out PostalCode val) ? val : default;
+        public static PostalCode? TryParse(string s) => TryParse(s, out PostalCode val) ? val : default(PostalCode?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Security/Cryptography/CryptographicSeed.generated.cs
+++ b/src/Qowaiv/Generated/Security/Cryptography/CryptographicSeed.generated.cs
@@ -274,7 +274,7 @@ namespace Qowaiv.Security.Cryptography
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static CryptographicSeed Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out CryptographicSeed val) ? val : throw new FormatException(QowaivMessages.FormatExceptionCryptographicSeed);
+        public static CryptographicSeed Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionCryptographicSeed);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "CryptographicSeed"/>.</summary>
         /// <param name = "s">
         /// A string containing the cryptographic seed to convert.
@@ -283,7 +283,19 @@ namespace Qowaiv.Security.Cryptography
         /// The cryptographic seed if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static CryptographicSeed TryParse(string s) => TryParse(s, null, out CryptographicSeed val) ? val : default;
+        public static CryptographicSeed? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "CryptographicSeed"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the cryptographic seed to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The cryptographic seed if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static CryptographicSeed? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out CryptographicSeed val) ? val : default(CryptographicSeed? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "CryptographicSeed"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -310,10 +322,7 @@ namespace Qowaiv.Security.Cryptography
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static CryptographicSeed Parse(string s)
-            => TryParse(s, out CryptographicSeed val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionCryptographicSeed);
+        public static CryptographicSeed Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionCryptographicSeed);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="CryptographicSeed"/>.</summary>
         /// <param name="s">
@@ -323,7 +332,7 @@ namespace Qowaiv.Security.Cryptography
         /// The cryptographic seed if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static CryptographicSeed TryParse(string s) => TryParse(s, out CryptographicSeed val) ? val : default;
+        public static CryptographicSeed? TryParse(string s) => TryParse(s, out CryptographicSeed val) ? val : default(CryptographicSeed?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -272,7 +272,7 @@ namespace Qowaiv.Statistics
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Elo Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Elo val) ? val : throw new FormatException(QowaivMessages.FormatExceptionElo);
+        public static Elo Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionElo);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Elo"/>.</summary>
         /// <param name = "s">
         /// A string containing the elo to convert.
@@ -281,7 +281,19 @@ namespace Qowaiv.Statistics
         /// The elo if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Elo TryParse(string s) => TryParse(s, null, out Elo val) ? val : default;
+        public static Elo? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Elo"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the elo to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The elo if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Elo? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Elo val) ? val : default(Elo? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Elo"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -308,10 +320,7 @@ namespace Qowaiv.Statistics
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Elo Parse(string s)
-            => TryParse(s, out Elo val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionElo);
+        public static Elo Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionElo);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
         /// <param name="s">
@@ -321,7 +330,7 @@ namespace Qowaiv.Statistics
         /// The elo if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Elo TryParse(string s) => TryParse(s, out Elo val) ? val : default;
+        public static Elo? TryParse(string s) => TryParse(s, out Elo val) ? val : default(Elo?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -273,7 +273,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Uuid Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Uuid val) ? val : throw new FormatException(QowaivMessages.FormatExceptionUuid);
+        public static Uuid Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionUuid);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Uuid"/>.</summary>
         /// <param name = "s">
         /// A string containing the UUID to convert.
@@ -282,7 +282,19 @@ namespace Qowaiv
         /// The UUID if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Uuid TryParse(string s) => TryParse(s, null, out Uuid val) ? val : default;
+        public static Uuid? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Uuid"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the UUID to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The UUID if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Uuid? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Uuid val) ? val : default(Uuid? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Uuid"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -309,10 +321,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Uuid Parse(string s)
-            => TryParse(s, out Uuid val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionUuid);
+        public static Uuid Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionUuid);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
         /// <param name="s">
@@ -322,7 +331,7 @@ namespace Qowaiv
         /// The UUID if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Uuid TryParse(string s) => TryParse(s, out Uuid val) ? val : default;
+        public static Uuid? TryParse(string s) => TryParse(s, out Uuid val) ? val : default(Uuid?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -271,7 +271,7 @@ namespace Qowaiv.Web
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static InternetMediaType Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out InternetMediaType val) ? val : throw new FormatException(QowaivMessages.FormatExceptionInternetMediaType);
+        public static InternetMediaType Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionInternetMediaType);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "InternetMediaType"/>.</summary>
         /// <param name = "s">
         /// A string containing the Internet media type to convert.
@@ -280,7 +280,19 @@ namespace Qowaiv.Web
         /// The Internet media type if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static InternetMediaType TryParse(string s) => TryParse(s, null, out InternetMediaType val) ? val : default;
+        public static InternetMediaType? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "InternetMediaType"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the Internet media type to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The Internet media type if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static InternetMediaType? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out InternetMediaType val) ? val : default(InternetMediaType? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "InternetMediaType"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -307,10 +319,7 @@ namespace Qowaiv.Web
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static InternetMediaType Parse(string s)
-            => TryParse(s, out InternetMediaType val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionInternetMediaType);
+        public static InternetMediaType Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionInternetMediaType);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
         /// <param name="s">
@@ -320,7 +329,7 @@ namespace Qowaiv.Web
         /// The Internet media type if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static InternetMediaType TryParse(string s) => TryParse(s, out InternetMediaType val) ? val : default;
+        public static InternetMediaType? TryParse(string s) => TryParse(s, out InternetMediaType val) ? val : default(InternetMediaType?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -249,7 +249,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static WeekDate Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out WeekDate val) ? val : throw new FormatException(QowaivMessages.FormatExceptionWeekDate);
+        public static WeekDate Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionWeekDate);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "WeekDate"/>.</summary>
         /// <param name = "s">
         /// A string containing the week date to convert.
@@ -258,7 +258,19 @@ namespace Qowaiv
         /// The week date if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static WeekDate TryParse(string s) => TryParse(s, null, out WeekDate val) ? val : default;
+        public static WeekDate? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "WeekDate"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the week date to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The week date if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static WeekDate? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out WeekDate val) ? val : default(WeekDate? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "WeekDate"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -285,10 +297,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static WeekDate Parse(string s)
-            => TryParse(s, out WeekDate val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionWeekDate);
+        public static WeekDate Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionWeekDate);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
         /// <param name="s">
@@ -298,7 +307,7 @@ namespace Qowaiv
         /// The week date if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static WeekDate TryParse(string s) => TryParse(s, out WeekDate val) ? val : default;
+        public static WeekDate? TryParse(string s) => TryParse(s, out WeekDate val) ? val : default(WeekDate?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Year Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Year val) ? val : throw new FormatException(QowaivMessages.FormatExceptionYear);
+        public static Year Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionYear);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Year"/>.</summary>
         /// <param name = "s">
         /// A string containing the year to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv
         /// The year if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Year TryParse(string s) => TryParse(s, null, out Year val) ? val : default;
+        public static Year? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "Year"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the year to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The year if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static Year? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Year val) ? val : default(Year? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "Year"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static Year Parse(string s)
-            => TryParse(s, out Year val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionYear);
+        public static Year Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionYear);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv
         /// The year if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static Year TryParse(string s) => TryParse(s, out Year val) ? val : default;
+        public static Year? TryParse(string s) => TryParse(s, out Year val) ? val : default(Year?);
 #endif
     }
 }

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -270,7 +270,7 @@ namespace Qowaiv
         /// <paramref name = "s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static YesNo Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out YesNo val) ? val : throw new FormatException(QowaivMessages.FormatExceptionYesNo);
+        public static YesNo Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionYesNo);
         /// <summary>Converts the <see cref = "string "/> to <see cref = "YesNo"/>.</summary>
         /// <param name = "s">
         /// A string containing the yes-no to convert.
@@ -279,7 +279,19 @@ namespace Qowaiv
         /// The yes-no if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static YesNo TryParse(string s) => TryParse(s, null, out YesNo val) ? val : default;
+        public static YesNo? TryParse(string s) => TryParse(s, null);
+        /// <summary>Converts the <see cref = "string "/> to <see cref = "YesNo"/>.</summary>
+        /// <param name = "s">
+        /// A string containing the yes-no to convert.
+        /// </param>
+        /// <param name = "formatProvider">
+        /// The specified format provider.
+        /// </param>
+        /// <returns>
+        /// The yes-no if the string was converted successfully, otherwise default.
+        /// </returns>
+        [Pure]
+        public static YesNo? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out YesNo val) ? val : default(YesNo? );
         /// <summary>Converts the <see cref = "string "/> to <see cref = "YesNo"/>.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -306,10 +318,7 @@ namespace Qowaiv
         /// <paramref name="s"/> is not in the correct format.
         /// </exception>
         [Pure]
-        public static YesNo Parse(string s)
-            => TryParse(s, out YesNo val)
-            ? val
-            : throw new FormatException(QowaivMessages.FormatExceptionYesNo);
+        public static YesNo Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionYesNo);
 
         /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
         /// <param name="s">
@@ -319,7 +328,7 @@ namespace Qowaiv
         /// The yes-no if the string was converted successfully, otherwise default.
         /// </returns>
         [Pure]
-        public static YesNo TryParse(string s) => TryParse(s, out YesNo val) ? val : default;
+        public static YesNo? TryParse(string s) => TryParse(s, out YesNo val) ? val : default(YesNo?);
 #endif
     }
 }

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -86,7 +86,7 @@ namespace Qowaiv
             {
                 return formatted;
             }
-            return ToString(Country.TryParse(format));
+            return ToString(Country.TryParse(format) ?? default);
         }
 
         /// <summary>Returns a formatted <see cref="string"/> that represents the current postal code.</summary>


### PR DESCRIPTION
Decided to change the return type for `Svo.TryParse(string) => Svo` to `Svo.TryParse(string) => Nullable<Svo>`. See #159