### PR TITLE
YesNo can also convert from and to boolean

### DIFF
--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -462,6 +462,26 @@ namespace YesNo_specs
                 Converting.Value(Svo.YesNo).ToString().Should().Be("yes");
             }
         }
+
+        [TestCase(true, "yes")]
+        [TestCase(false, "no")]
+        public void from_boolean(bool from, YesNo yesNo)
+        {
+            using (TestCultures.En_GB.Scoped())
+            {
+                Converting.To<YesNo>().From(from).Should().Be(yesNo);
+            }
+        }
+
+        [TestCase("yes", true)]
+        [TestCase( "no", false)]
+        public void to_boolean(YesNo yesNo, bool boolean)
+        {
+            using (TestCultures.En_GB.Scoped())
+            {
+                Converting.Value(yesNo).To<bool>().Should().Be(boolean);
+            }
+        }
     }
 
     public class Supports_JSON_serialization

--- a/src/Qowaiv/Conversion/YesNoTypeConverter.cs
+++ b/src/Qowaiv/Conversion/YesNoTypeConverter.cs
@@ -1,3 +1,5 @@
+using System;
+using System.ComponentModel;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 
@@ -6,6 +8,40 @@ namespace Qowaiv.Conversion
     /// <summary>Provides a conversion for a Yes-no.</summary>
     public class YesNoTypeConverter : SvoTypeConverter<YesNo>
     {
+        /// <inheritdoc/>
+        [Pure]
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            => sourceType == typeof(bool)
+            || base.CanConvertFrom(context, sourceType);
+
+        /// <inheritdoc/>
+        [Pure]
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            => destinationType == typeof(bool)
+            || base.CanConvertTo(context, destinationType);
+
+        /// <inheritdoc/>
+        [Pure]
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is bool boolean)
+            {
+                return (YesNo)boolean;
+            }
+            else return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(bool) && value is YesNo yesNo)
+            {
+                return (bool)yesNo;
+            }
+            else return base.ConvertTo(context, culture, value, destinationType);
+        }
+
         /// <inheritdoc/>
         [Pure]
         protected override YesNo FromString(string str, CultureInfo culture) => YesNo.Parse(str, culture);


### PR DESCRIPTION
`YesNo` could already convert from JSON boolean nodes, but lacked `TypeConverter` support. That have now been added. See #202 