### PR TITLE
Simplify Hash.Code()

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,7 +908,7 @@ using(Hash.WithoutRandomizer())
 public int GetHashCode()
     => Hash.Code(Prop)
     .And(Other)
-    .AndEach(Collection);
+    .And(Collection); // takes all items into account
 ```
 
 This works out of the box because `Hash` can be implicitly cast to an `int`.

--- a/specs/Qowaiv.Specs/Date_specs.cs
+++ b/specs/Qowaiv.Specs/Date_specs.cs
@@ -44,9 +44,9 @@ namespace Date_specs
         public void not_equal_operator_returns_true_for_different_values()
             => (new Date(2017, 06, 11) != Date.MinValue).Should().BeTrue();
 
-        [TestCase("", 0)]
-        [TestCase("yes", 20170609)]
-        public void hash_code_is_value_based(YesNo svo, int hash)
+        [TestCase("0001-01-01", 0)]
+        [TestCase("2017-06-11", -489585265)]
+        public void hash_code_is_value_based(Date svo, int hash)
         {
             using (Hash.WithoutRandomizer())
             {

--- a/specs/Qowaiv.Specs/Gender_specs.cs
+++ b/specs/Qowaiv.Specs/Gender_specs.cs
@@ -193,8 +193,8 @@ namespace Gender_specs
         }
 
         [TestCase("", 0)]
-        [TestCase("Male", 20170609)]
-        [TestCase("Female", 20170615)]
+        [TestCase("Male", 665630161)]
+        [TestCase("Female", 665630167)]
         public void hash_code_is_value_based(Gender svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/Hashing/Hash_specs.cs
+++ b/specs/Qowaiv.Specs/Hashing/Hash_specs.cs
@@ -24,7 +24,7 @@ namespace Hashing.Hash_specs
                 int hash = Hash.Code(12)
                     .And(Svo.EmailAddress)
                     .And(Svo.DateTime);
-                hash.Should().Be(1013828080);
+                hash.Should().Be(-1238227536);
             }
         }
 
@@ -34,8 +34,8 @@ namespace Hashing.Hash_specs
             using (Hash.WithoutRandomizer())
             {
                 int hash = Hash.Code(12)
-                    .AndEach(Array.Empty<byte>());
-                hash.Should().Be(665630542);
+                    .And(Array.Empty<byte>());
+                hash.Should().Be(490959278);
             }
         }
 
@@ -43,7 +43,7 @@ namespace Hashing.Hash_specs
         public void Supports_fluent_syntax_null_collection()
         {
             var hash = Hash.Code(12);
-            var adjusted = hash.AndEach<int>(null);
+            var adjusted = hash.And<object>(null);
             adjusted.Should().Be(hash);
         }
 
@@ -53,8 +53,8 @@ namespace Hashing.Hash_specs
             using (Hash.WithoutRandomizer())
             {
                 int hash = Hash.Code(12)
-                    .AndEach(new[] { 1234, 123, 2345, 213 });
-                hash.Should().Be(2057503178);
+                    .And(new[] { 1234, 123, 2345, 213 });
+                hash.Should().Be(535185610);
             }
         }
 
@@ -63,9 +63,9 @@ namespace Hashing.Hash_specs
         {
             using (Hash.WithoutRandomizer())
             {
-                int hash = Hash.Code(12).AndEach(new[] { 1234, 123, 2345, 213 });
-                int other = Hash.Code(12).AndEach(new[] { 123, 1234, 2345, 213 });
-                hash.Should().NotBe(other);
+                int hash = Hash.Code(12).And(new[] { 1234, 123, 2345, 213 });
+                int othr = Hash.Code(12).And(new[] { 123, 1234, 2345, 213 });
+                hash.Should().NotBe(othr);
             }
         }
 
@@ -84,7 +84,7 @@ namespace Hashing.Hash_specs
             using (Hash.WithoutRandomizer())
             {
                 int hash = Hash.Code("QOWAIV string");
-                hash.Should().Be(1211348473);
+                hash.Should().Be(1856816985);
             }
         }
 
@@ -94,7 +94,7 @@ namespace Hashing.Hash_specs
             using (Hash.WithoutRandomizer())
             {
                 int hash = Hash.Code(17);
-                hash.Should().Be(20170594);
+                hash.Should().Be(665630146);
             }
         }
 
@@ -104,7 +104,7 @@ namespace Hashing.Hash_specs
             using (Hash.WithoutRandomizer())
             {
                 int hash = Hash.Code(12345678909876L);
-                hash.Should().Be(1929223677);
+                hash.Should().Be(1415769949);
             }
         }
     }

--- a/specs/Qowaiv.Specs/HouseNumber_specs.cs
+++ b/specs/Qowaiv.Specs/HouseNumber_specs.cs
@@ -41,7 +41,7 @@ namespace HouseNumber_specs
             => (HouseNumber.Create(123456789) != HouseNumber.MinValue).Should().BeTrue();
 
         [TestCase("", 0)]
-        [TestCase("yes", 20170609)]
+        [TestCase("yes", 665630161)]
         public void hash_code_is_value_based(YesNo svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
+++ b/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
@@ -85,7 +85,7 @@ namespace IO.StreamSize_specs
             => (StreamSize.Byte * 123456789 != StreamSize.MinValue).Should().BeTrue();
 
         [TestCase("0 byte", 0)]
-        [TestCase("123456789 byte", 107481702)]
+        [TestCase("123456789 byte", 553089222)]
         public void hash_code_is_value_based(StreamSize svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/LocalDateTime_specs.cs
+++ b/specs/Qowaiv.Specs/LocalDateTime_specs.cs
@@ -41,7 +41,7 @@ namespace LocalDateTime_specs
             => (new LocalDateTime(2017, 06, 11, 06, 15, 00) != LocalDateTime.MinValue).Should().BeTrue();
 
         [TestCase("0001-01-01", 0)]
-        [TestCase("2017-06-11 06:15", 961707490)]
+        [TestCase("2017-06-11 06:15", 533532482)]
         public void hash_code_is_value_based(LocalDateTime svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/MonthSpan_specs.cs
+++ b/specs/Qowaiv.Specs/MonthSpan_specs.cs
@@ -41,7 +41,7 @@ namespace MonthSpan_specs
             => (MonthSpan.FromMonths(69) != MonthSpan.MinValue).Should().BeTrue();
 
         [TestCase("0Y+0M", 0)]
-        [TestCase("5Y+9M", 20170550)]
+        [TestCase("5Y+9M", 665630102)]
         public void hash_code_is_value_based(MonthSpan svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -214,7 +214,7 @@ namespace Month_specs
         }
 
         [TestCase("", 0)]
-        [TestCase("February", 20170609)]
+        [TestCase("February", 665630161)]
         public void hash_code_is_value_based(Month svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -155,7 +155,7 @@ namespace Percentage_specs
         }
 
         [TestCase("0%", 0)]
-        [TestCase("17.51%", 20431268)]
+        [TestCase("17.51%", 665367300)]
         public void hash_code_is_value_based(Percentage svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/Sql/Timestamp_specs.cs
+++ b/specs/Qowaiv.Specs/Sql/Timestamp_specs.cs
@@ -41,7 +41,7 @@ namespace Sql.Timestamp_specs
             => (Timestamp.Create(1234567890L) != Timestamp.MinValue).Should().BeTrue();
 
         [TestCase("0", 0)]
-        [TestCase("1234567890", 1218823585)]
+        [TestCase("1234567890", 1849341697)]
         public void hash_code_is_value_based(Timestamp svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
+++ b/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
@@ -44,7 +44,7 @@ namespace Statistics.Elo_specs
             => (Elo.Create(1732.4) != Elo.MinValue).Should().BeTrue();
 
         [TestCase("0", 0)]
-        [TestCase("1732.4", -667857040)]
+        [TestCase("1732.4", -22135344)]
         public void hash_code_is_value_based(Elo svo, int hash)
         {
             using (Hash.WithoutRandomizer())
@@ -104,7 +104,7 @@ namespace Statistics.Elo_specs
             => Converting.To<double>().From(Svo.Elo).Should().Be(1732.4);
     
         [TestCase("0", 0)]
-        [TestCase("1732.4", -667857040)]
+        [TestCase("1732.4", -22135344)]
         public void hash_code_is_value_based(Elo svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/Text/CharBuffer_specs.cs
+++ b/specs/Qowaiv.Specs/Text/CharBuffer_specs.cs
@@ -7,7 +7,7 @@ namespace CharBuffer_specs
 {
     public class Add
     {
-        private CharBuffer WithCapacity() => CharBuffer.Empty(16);
+        private static CharBuffer WithCapacity() => CharBuffer.Empty(16);
 
         [Test]
         public void A_char_can_be_added()

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -155,7 +155,7 @@ namespace UUID_specs
         }
 
         [TestCase("", 0)]
-        [TestCase("Qowaiv_SVOLibrary_GUIA", -497088793)]
+        [TestCase("Qowaiv_SVOLibrary_GUIA", -994020281)]
         public void hash_code_is_value_based(Uuid svo, int hash)
         {
             using (Hash.WithoutRandomizer())
@@ -330,7 +330,7 @@ namespace UUID_specs
 
         private const int MultipleCount = 10000;
         
-        private DateTime MaxDate => new DateTime(9276, 12, 03, 18, 42, 01).AddTicks(3693920);
+        private static DateTime MaxDate => new DateTime(9276, 12, 03, 18, 42, 01).AddTicks(3693920);
 
         private static void AssertIsSorted(UuidComparer comparer)
         {
@@ -412,7 +412,7 @@ Actual:   [{(string.Join(", ", act))}]");
 
             foreach (var index in comparer.Priority)
             {
-                sb.Append(bytes[index].ToString("X2")).Append(" ");
+                sb.Append(bytes[index].ToString("X2")).Append(' ');
             }
             return sb.ToString();
         }

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -202,7 +202,7 @@ namespace Year_specs
         }
 
         [TestCase("", 0)]
-        [TestCase("1979", 20168904)]
+        [TestCase("1979", 665629288)]
         public void hash_code_is_value_based(Year svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -189,7 +189,7 @@ namespace YesNo_specs
         }
 
         [TestCase("", 0)]
-        [TestCase("yes", 20170609)]
+        [TestCase("yes", 665630161)]
         public void hash_code_is_value_based(YesNo svo, int hash)
         {
             using (Hash.WithoutRandomizer())

--- a/src/Qowaiv/Hashing/Hash.cs
+++ b/src/Qowaiv/Hashing/Hash.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
@@ -48,19 +47,10 @@ namespace Qowaiv.Hashing
         /// </param>
         /// <returns>The new hash.</returns>
         [Pure]
-        public Hash And<T>(T item) => new(Combine(Value, HashCode(item)));
-
-        /// <summary>
-        /// Adds the hash code of the specified items in the collection.
-        /// </summary>
-        /// <typeparam name="T">The type of the items.</typeparam>
-        /// <param name="items">The collection.</param>
-        /// <returns>The new hash code.</returns>
-        [Pure]
-        public Hash AndEach<T>(IEnumerable<T> items)
-            => items is null
+        public Hash And<T>(T item)
+            => Equals(default(T), item)
             ? this
-            : new(HashCode(Value, items));
+            : new(Combine(Value, HashCode(item)));
 
         /// <summary>Implicitly casts a <see cref="Hash"/> to an <see cref="int"/>.</summary>
         public static implicit operator int(Hash hash) => hash.Value;
@@ -70,7 +60,7 @@ namespace Qowaiv.Hashing
         public static Hash Code<T>(T item)
             => Equals(default(T), item)
             ? default
-            : new(Randomized ^ HashCode(item));
+            : new(Combine(Randomized, HashCode(item)));
 
         /// <summary>Indicates that hashing is not supported by the type.</summary>
         [Pure]
@@ -95,7 +85,7 @@ namespace Qowaiv.Hashing
                 null => 0,
                 int int32 => int32,
                 string str => HashCode(str),
-                IEnumerable enumerable => HashCode(0, enumerable),
+                IEnumerable enumerable => HashCodes(enumerable),
                 _ => obj.GetHashCode(),
             };
 
@@ -110,9 +100,9 @@ namespace Qowaiv.Hashing
 
                 for (int i = 0; i < str.Length; i += 2)
                 {
-                    hash1 = ((hash1 << 5) + hash1) ^ str[i];
+                    hash1 = Combine(hash1, str[i]);
                     if (i == str.Length - 1) break;
-                    else hash2 = ((hash2 << 5) + hash2) ^ str[i + 1];
+                    else hash2 = Combine(hash2, str[i + 1]);
                 }
                 return hash1 + (hash2 * 1566083941);
             }
@@ -120,8 +110,9 @@ namespace Qowaiv.Hashing
 
         /// <summary>Gets a hash for an enumerable.</summary>
         [Pure]
-        private static int HashCode(int hash, IEnumerable items)
+        private static int HashCodes(IEnumerable items)
         {
+            int hash = 0;
             var enumerator = items.GetEnumerator();
             if (enumerator.MoveNext())
             {
@@ -132,7 +123,7 @@ namespace Qowaiv.Hashing
                 }
                 return updated;
             }
-            else return Combine(hash, 17);
+            else return 17;
         }
 
 #pragma warning disable S3010 // Static fields should not be updated in constructors


### PR DESCRIPTION
Merged methods `Add` and `AddEach`, use `Combine()` also for merging with the Randomizer and within the string hash.