### PR TITLE
No cast from and to string any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,7 @@ as `double.Parse("14%")`, which is `0.14`.
 
 ``` C#
 // Creation
-Percentage p = 0.0314; // implicit cast: 3.14%
-var p = Percentage.Parse("3.14"); //  Parse: 3.14%;
+var p = Percentage.Parse("3.14");  // Parse: 3.14%;
 var p = Percentage.Parse("3.14%"); // Parse: 3.14%;
 var p = Percentage.Parse("31.4‰"); // Parse: 3.14%;
 var p = 3.14.Percent(); // Extension on double: 3.14%;

--- a/specs/Qowaiv.Specs/Cast_specs.cs
+++ b/specs/Qowaiv.Specs/Cast_specs.cs
@@ -38,44 +38,4 @@ namespace Cast_specs
         [TestCase(10_000)]
         public void int_to_Year(int num) => QAssert.InvalidCast(() => (Year)num);
     }
-    public class Invalid_string_to
-    {
-        private static readonly string InvalidString = "$%$!@$%$D!@@!!!!!";
-
-        [Test]
-        public void Date() => QAssert.InvalidCast(() => (Date)InvalidString);
-
-        [Test]
-        public void EmailAddress() => QAssert.InvalidCast(() => (EmailAddress)InvalidString);
-
-        [Test]
-        public void Gender() => QAssert.InvalidCast(() => (Gender)InvalidString);
-
-        [Test]
-        public void HouseNumber() => QAssert.InvalidCast(() => (HouseNumber)InvalidString);
-
-        [Test]
-        public void LocalDateTime() => QAssert.InvalidCast(() => (LocalDateTime)InvalidString);
-
-        [Test]
-        public void Month() => QAssert.InvalidCast(() => (Month)InvalidString);
-
-        [Test]
-        public void Percentage() => QAssert.InvalidCast(() => (Percentage)InvalidString);
-
-        [Test]
-        public void PostalCode() => QAssert.InvalidCast(() => (PostalCode)InvalidString);
-
-        [Test]
-        public void UUID() => QAssert.InvalidCast(() => (Uuid)InvalidString);
-        
-        [Test]
-        public void WeekDate() => QAssert.InvalidCast(() => (WeekDate)InvalidString);
-
-        [Test]
-        public void Year() => QAssert.InvalidCast(() => (Year)InvalidString);
-
-        [Test]
-        public void YesNo() => QAssert.InvalidCast(() => (YesNo)InvalidString);
-    }
 }

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -352,23 +352,6 @@ namespace Email_address_specs
         }
     }
 
-    public class Casts
-    {
-        [Test]
-        public void explicitly_from_string()
-        {
-            var casted = (EmailAddress)"info@qowaiv.org";
-            Assert.AreEqual(Svo.EmailAddress, casted);
-        }
-
-        [Test]
-        public void explicitly_to_string()
-        {
-            var casted = (string)Svo.EmailAddress;
-            Assert.AreEqual("info@qowaiv.org", casted);
-        }
-    }
-
     public class Supports_type_conversion
     {
         [Test]

--- a/specs/Qowaiv.Specs/Gender_specs.cs
+++ b/specs/Qowaiv.Specs/Gender_specs.cs
@@ -381,20 +381,6 @@ namespace Gender_specs
     public class Casts
     {
         [Test]
-        public void explicitly_from_string()
-        {
-            var casted = (Gender)"Female";
-            Assert.AreEqual(Svo.Gender, casted);
-        }
-
-        [Test]
-        public void explicitly_to_string()
-        {
-            var casted = (string)Svo.Gender;
-            Assert.AreEqual("Female", casted);
-        }
-
-        [Test]
         public void explicitly_to_byte()
         {
             var casted = (byte)Svo.Gender;

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -447,20 +447,6 @@ namespace Month_specs
     public class Casts
     {
         [Test]
-        public void explicitly_from_string()
-        {
-            var casted = (Month)"February";
-            Assert.AreEqual(Svo.Month, casted);
-        }
-
-        [Test]
-        public void explicitly_to_string()
-        {
-            var casted = (string)Svo.Month;
-            Assert.AreEqual("February", casted);
-        }
-
-        [Test]
         public void explicitly_from_byte()
         {
             var casted = (Month)2;

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -406,26 +406,6 @@ namespace Percentage_specs
     public class Casts
     {
         [Test]
-        public void explicitly_from_string()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var casted = (Percentage)"17.51%";
-                Assert.AreEqual(Svo.Percentage, casted);
-            }
-        }
-
-        [Test]
-        public void explicitly_to_string()
-        {
-            using (TestCultures.Nl_NL.Scoped())
-            {
-                var casted = (string)Svo.Percentage;
-                Assert.AreEqual("17,51%", casted);
-            }
-        }
-
-        [Test]
         public void explicitly_from_decimal()
         {
             var casted = (Percentage)0.1751m;

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -412,23 +412,6 @@ namespace Postal_code_specs
         }
     }
 
-    public class Casts
-    {
-        [Test]
-        public void explicitly_from_string()
-        {
-            var casted = (PostalCode)"H0H0H0";
-            Assert.AreEqual(Svo.PostalCode, casted);
-        }
-
-        [Test]
-        public void explicitly_to_string()
-        {
-            var casted = (string)Svo.PostalCode;
-            Assert.AreEqual("H0H0H0", casted);
-        }
-    }
-
     public class Supports_type_conversion
     {
         [Test]

--- a/specs/Qowaiv.Specs/Svo.cs
+++ b/specs/Qowaiv.Specs/Svo.cs
@@ -56,7 +56,7 @@ namespace Qowaiv.Specs
         public static readonly Timestamp Timestamp = 1234567890L;
         public static readonly Uuid Uuid = Uuid.Parse("Qowaiv_SVOLibrary_GUIA");
         public static readonly WeekDate WeekDate = new(2017, 23, 7);
-        public static readonly Year Year = 1979;
+        public static readonly Year Year = 1979.Year();
         public static readonly YesNo YesNo = YesNo.Yes;
 
         public static readonly Int32Id Int32Id = Int32Id.Create(17);

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -508,20 +508,6 @@ Actual:   [{(string.Join(", ", act))}]");
     public class Casts
     {
         [Test]
-        public void explicitly_from_string()
-        {
-            var casted = (Uuid)"Qowaiv_SVOLibrary_GUIA";
-            Assert.AreEqual(Svo.Uuid, casted);
-        }
-
-        [Test]
-        public void explicitly_to_string()
-        {
-            var casted = (string)Svo.Uuid;
-            Assert.AreEqual("Qowaiv_SVOLibrary_GUIA", casted);
-        }
-
-        [Test]
         public void explicitly_from_Guid()
         {
             var casted = (Uuid)Svo.Guid;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
@@ -513,26 +513,6 @@ namespace Qowaiv.UnitTests
         #region Casting tests
 
         [Test]
-        public void Explicit_StringToDate_AreEqual()
-        {
-            using (TestCultures.Es_EC.Scoped())
-            {
-                var exp = TestStruct;
-                var act = (Date)TestStruct.ToString(CultureInfo.CurrentCulture);
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-        [Test]
-        public void Explicit_DateToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
         public void Implicit_WeekDateToDate_AreEqual()
         {
             Date exp = new WeekDate(1970, 07, 6);

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
@@ -630,28 +630,6 @@ namespace Qowaiv.Financial.UnitTests
         }
         #endregion
 
-        #region Casting tests
-
-        [Test]
-        public void Explicit_StringToAmount_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (Amount)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_AmountToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-
         [TestCase(-1, -1000)]
         [TestCase(0, 0)]
         [TestCase(+1, 1600)]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
@@ -562,27 +562,6 @@ namespace Qowaiv.UnitTests.Financial
 
         #endregion
 
-        #region Casting tests
-
-        [Test]
-        public void Explicit_StringToBusinessIdentifierCode_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (BusinessIdentifierCode)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_BusinessIdentifierCodeToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
         #region Properties
 
         [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
@@ -717,52 +717,6 @@ namespace Qowaiv.UnitTests.Financial
         }
         #endregion
 
-        #region Casting tests
-
-        [Test]
-        public void Explicit_StringToCurrency_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (Currency)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_CurrencyToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Explicit_Int32ToCurrency_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (Currency)TestStruct.IsoCode;
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_Minus3ToCurrency_CurrencyEmpty()
-        {
-            var exp = Currency.Empty;
-            var act = (Currency)(-3);
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_CurrencyToInt32_AreEqual()
-        {
-            var exp = TestStruct.IsoNumericCode;
-            var act = (Int32)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
         #region Properties
 
         [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
@@ -541,27 +541,6 @@ namespace Qowaiv.UnitTests.Financial
         }
         #endregion
 
-        #region Casting tests
-
-        [Test]
-        public void Explicit_StringToInternationalBankAccountNumber_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (InternationalBankAccountNumber)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_InternationalBankAccountNumberToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
         #region Properties
 
         [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
@@ -601,30 +601,6 @@ namespace Qowaiv.UnitTests.Financial
         }
         #endregion
 
-        #region Casting tests
-
-        [Test]
-        public void Explicit_StringToMoney_AreEqual()
-        {
-            using (TestCultures.Fr_FR.Scoped())
-            {
-                var exp = TestStruct;
-                var act = (Money)TestStruct.ToString(CultureInfo.CurrentCulture);
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-        [Test]
-        public void Explicit_MoneyToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
         #region Properties
 
         [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -680,23 +680,6 @@ namespace Qowaiv.UnitTests.Globalization
         #region Casting tests
 
         [Test]
-        public void Explicit_StringToCountry_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (Country)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_CountryToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
         public void Implicit_RegionInfoToCountry_AreEqual()
         {
             Country exp = Country.NL;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
@@ -631,24 +631,6 @@ namespace Qowaiv.UnitTests
         #region Casting tests
 
         [Test]
-        public void Explicit_StringToHouseNumber_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (HouseNumber)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_HouseNumberToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-
-        [Test]
         public void Explicit_Int32ToHouseNumber_AreEqual()
         {
             var exp = TestStruct;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
@@ -674,23 +674,6 @@ namespace Qowaiv.UnitTests.IO
         #region Casting tests
 
         [Test]
-        public void Explicit_StringToStreamSize_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (StreamSize)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_StreamSizeToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
         public void Implicit_Int32ToStreamSize_AreEqual()
         {
             StreamSize exp = TestStruct;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
@@ -393,30 +393,6 @@ namespace Qowaiv.UnitTests
 
         #endregion
 
-        #region Casting tests
-
-        [Test]
-        public void Explicit_StringToLocalDateTime_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStructNoMilliseconds;
-                var act = (LocalDateTime)TestStructNoMilliseconds.ToString(CultureInfo.CurrentCulture);
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-        [Test]
-        public void Explicit_LocalDateTimeToString_AreEqual()
-        {
-            var exp = TestStructNoMilliseconds.ToString();
-            var act = (string)TestStructNoMilliseconds;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
         #region Properties
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -487,22 +487,6 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
-        public void Explicit_StringToMonthSpan_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (MonthSpan)TestStruct.ToString();
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Explicit_MonthSpanToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
         public void Explicit_Int32ToMonthSpan_AreEqual()
         {
             var exp = TestStruct;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Security/Cryptography/CryptographicSeedTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Security/Cryptography/CryptographicSeedTest.cs
@@ -391,8 +391,8 @@ namespace Qowaiv.Security.Cryptography.UnitTests
         [Test]
         public void Equals_SameLengthDifferentValues_IsFalse()
         {
-            CryptographicSeed left = new byte[] { 1, 2, 3 };
-            CryptographicSeed right = new byte[] { 1, 2, 4 };
+            var left = (CryptographicSeed)new byte[] { 1, 2, 3 };
+            var right = (CryptographicSeed)new byte[] { 1, 2, 4 };
 
             Assert.IsFalse(left.Equals(right));
         }
@@ -518,40 +518,12 @@ namespace Qowaiv.Security.Cryptography.UnitTests
         #region Casting tests
 
         [Test]
-        public void Explicit_StringToCryptographicSeed_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (CryptographicSeed)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_CryptographicSeedToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
         public void Explicit_ByteArrayToCryptographicSeed_AreEqual()
-        {
-            CryptographicSeed exp = TestStruct;
-            CryptographicSeed act = new Byte[] { 66, 140, 26, 138 };
+            => ((CryptographicSeed)new byte[] { 66, 140, 26, 138 }).Should().Be(TestStruct);
 
-            Assert.AreEqual(exp, act);
-            Assert.AreNotSame(exp, act);
-        }
         [Test]
         public void Explicit_CryptographicSeedToByteArray_AreEqual()
-        {
-            var exp = TestStruct.ToByteArray();
-            var act = (Byte[])TestStruct;
-
-            Assert.AreEqual(exp, act);
-            Assert.AreNotSame(exp, act);
-        }
+            => ((byte[])TestStruct).Should().BeEquivalentTo(new byte[] { 66, 140, 26, 138 });
 
         #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
@@ -546,25 +546,6 @@ namespace Qowaiv.UnitTests.Sql
         #region Casting tests
 
         [Test]
-        public void Explicit_StringToTimestamp_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (Timestamp)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_TimestampToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-
-
-        [Test]
         public void Explicit_ByteArrayToTimestamp_AreEqual()
         {
             var exp = TestStruct;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
@@ -507,27 +507,7 @@ namespace Qowaiv.UnitTests.Statistics
         #endregion
 
         #region Casting tests
-
-        [Test]
-        public void Explicit_StringToElo_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = (Elo)TestStruct.ToString(CultureInfo.CurrentCulture);
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-        [Test]
-        public void Explicit_EloToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
+        
         [Test]
         public void Implicit_DoubleToElo_AreEqual()
         {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Threading/ThreadDomainTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Threading/ThreadDomainTest.cs
@@ -67,7 +67,7 @@ namespace Qowaiv.UnitTests.Threading
         [Test]
         public void Set_MultiThreads_()
         {
-            ThreadDomain.Current.Set<Percentage>(0.031418m);
+            ThreadDomain.Current.Set<Percentage>(3.1418m.Percent());
 
             Task.Factory.StartNew(() =>
             {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
@@ -621,27 +621,6 @@ namespace Qowaiv.UnitTests.Web
         }
         #endregion
 
-        #region Casting tests
-
-        [Test]
-        public void Explicit_StringToInternetMediaType_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (InternetMediaType)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_InternetMediaTypeToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
         #region Properties
 
         [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
@@ -624,24 +624,6 @@ namespace Qowaiv.UnitTests
         #region Casting tests
 
         [Test]
-        public void Explicit_StringToWeekDate_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (WeekDate)TestStruct.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_WeekDateToString_AreEqual()
-        {
-            var exp = TestStruct.ToString();
-            var act = (string)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-
-        [Test]
         public void Explicit_Int32ToWeekDate_AreEqual()
         {
             var exp = TestStruct;

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -138,14 +138,14 @@ namespace Year_specs
         [Test]
         public void MinValue_represents_1()
         {
-            Year min = 1;
+            Year min = 1.Year();
             Assert.AreEqual(min, Year.MinValue);
         }
 
         [Test]
         public void MaxValue_represents_9999()
         {
-            Year max = 9999;
+            Year max = 9999.Year();
             Assert.AreEqual(max, Year.MaxValue);
         }
     }
@@ -167,38 +167,38 @@ namespace Year_specs
         [Test]
         public void not_equal_to_different_value()
         {
-            Year other = 2017;
+            Year other = 2017.Year();
             Assert.IsFalse(Svo.Year.Equals(other));
         }
 
         [Test]
         public void equal_to_same_value()
         {
-            Assert.IsTrue(Svo.Year.Equals(1979));
+            Assert.IsTrue(Svo.Year.Equals(1979.Year()));
         }
 
         [Test]
         public void equal_operator_returns_true_for_same_values()
         {
-            Assert.IsTrue(Svo.Year == 1979);
+            Assert.IsTrue(Svo.Year == 1979.Year());
         }
 
         [Test]
         public void equal_operator_returns_false_for_different_values()
         {
-            Assert.IsFalse(Svo.Year == 2017);
+            Assert.IsFalse(Svo.Year == 2017.Year());
         }
 
         [Test]
         public void not_equal_operator_returns_false_for_same_values()
         {
-            Assert.IsFalse(Svo.Year != 1979);
+            Assert.IsFalse(Svo.Year != 1979.Year());
         }
 
         [Test]
         public void not_equal_operator_returns_true_for_different_values()
         {
-            Assert.IsTrue(Svo.Year != 2017);
+            Assert.IsTrue(Svo.Year != 2017.Year());
         }
 
         [TestCase("", 0)]
@@ -366,9 +366,9 @@ namespace Year_specs
             {
                 default, 
                 default,
-                1970,
-                1971,
-                1972,
+                1970.Year(),
+                1971.Year(),
+                1972.Year(),
                 Year.Unknown,
             };
             var list = new List<Year> { sorted[3], sorted[5], sorted[4], sorted[2], sorted[0], sorted[1] };
@@ -379,8 +379,8 @@ namespace Year_specs
         [Test]
         public void by_operators_for_different_values()
         {
-            Year smaller = 1979;
-            Year bigger = 2017;
+            Year smaller = 1979.Year();
+            Year bigger = 2017.Year();
 
             Assert.IsTrue(smaller < bigger);
             Assert.IsTrue(smaller <= bigger);
@@ -391,8 +391,8 @@ namespace Year_specs
         [Test]
         public void by_operators_for_equal_values()
         {
-            Year left = 2071;
-            Year right = 2071;
+            Year left = 2071.Year();
+            Year right = 2071.Year();
 
             Assert.IsFalse(left < right);
             Assert.IsTrue(left <= right);
@@ -415,20 +415,6 @@ namespace Year_specs
 
     public class Casts
     {
-        [Test]
-        public void explicitly_from_string()
-        {
-            var casted = (Year)"1979";
-            Assert.AreEqual(Svo.Year, casted);
-        }
-
-        [Test]
-        public void explicitly_to_string()
-        {
-            var casted = (string)Svo.Year;
-            Assert.AreEqual("1979", casted);
-        }
-
         [Test]
         public void explicitly_from_short()
         {

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -369,20 +369,6 @@ namespace YesNo_specs
 
     public class Casts
     {
-        [Test]
-        public void explicitly_from_string()
-        {
-            var casted = (YesNo)"yes";
-            Assert.AreEqual(YesNo.Yes, casted);
-        }
-
-        [Test]
-        public void explicitly_to_string()
-        {
-            var casted = (string)Svo.YesNo;
-            Assert.AreEqual("yes", casted);
-        }
-
         [TestCase("yes", true)]
         [TestCase("no", false)]
         public void explicitly_from_boolean(YesNo casted, bool boolean)

--- a/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
+++ b/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
@@ -84,24 +84,22 @@ namespace Qowaiv.Sql
         [Pure]
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-        /// <summary>Casts a timestamp to a <see cref="string"/>.</summary>
-        public static explicit operator string(Timestamp val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a timestamp.</summary>
-        public static explicit operator Timestamp(string str) => Parse(str, CultureInfo.CurrentCulture);
-
         /// <summary>Casts a timestamp to a System.Int32.</summary>
         public static explicit operator byte[](Timestamp val) => val.ToByteArray();
+        
         /// <summary>Casts an System.Int32 to a timestamp.</summary>
         public static explicit operator Timestamp(byte[] val) => Create(val);
 
         /// <summary>Casts a timestamp to a System.Int64.</summary>
         public static explicit operator long(Timestamp val) => BitConverter.ToInt64(val.ToByteArray(), 0);
+        
         /// <summary>Casts a System.Int64 to a timestamp.</summary>
         public static explicit operator Timestamp(long val) => Create(val);
 
         /// <summary>Casts a timestamp to a System.UInt64.</summary>
         [CLSCompliant(false)]
         public static explicit operator ulong(Timestamp val) => val.m_Value;
+        
         /// <summary>Casts a System.UInt64 to a timestamp.</summary>
         [CLSCompliant(false)]
         public static implicit operator Timestamp(ulong val) => Create(val);

--- a/src/Qowaiv/Conversion/PercentageTypeConverter.cs
+++ b/src/Qowaiv/Conversion/PercentageTypeConverter.cs
@@ -8,7 +8,7 @@ namespace Qowaiv.Conversion
     {
         /// <inheritdoc/>
         [Pure]
-        protected override Percentage FromRaw(decimal raw) => raw;
+        protected override Percentage FromRaw(decimal raw) => Percentage.Create(raw);
 
         /// <inheritdoc/>
         [Pure]

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -436,18 +436,15 @@ namespace Qowaiv
 
         #region (Explicit) casting
 
-        /// <summary>Casts a date to a <see cref="string"/>.</summary>
-        public static explicit operator string(Date val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a date to a date time.</summary>
         public static implicit operator DateTime(Date val) => val.m_Value;
 
-        /// <summary>Casts a <see cref="string"/> to a date.</summary>
-        public static explicit operator Date(string str) => Cast.String<Date>(TryParse, str);
         /// <summary>Casts a date time to a date.</summary>
         public static explicit operator Date(DateTime val) => new(val);
 
         /// <summary>Casts a local date time to a date.</summary>
         public static explicit operator Date(LocalDateTime val) => val.Date;
+
         /// <summary>Casts a week date to a date.</summary>
         public static implicit operator Date(WeekDate val) => val.Date;
 

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -143,12 +143,6 @@ namespace Qowaiv
             { 'f', (svo, provider) => svo.m_Value ?? string.Empty },
         };
 
-        /// <summary>Casts an email address to a <see cref="string"/>.</summary>
-        public static explicit operator string(EmailAddress val) => val.ToString(CultureInfo.CurrentCulture);
-        
-        /// <summary>Casts a <see cref="string"/> to a email address.</summary>
-        public static explicit operator EmailAddress(string str) => Cast.String<EmailAddress>(TryParse, str);
-
         /// <summary>Converts the string to an email address.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Extensions/Humanize.Percentage.cs
+++ b/src/Qowaiv/Extensions/Humanize.Percentage.cs
@@ -7,14 +7,14 @@ namespace Qowaiv
     {
         /// <summary>Interprets the <see cref="int"/> if it was written with a '%' sign.</summary>
         [Pure]
-        public static Percentage Percent(this int number) => number * 0.01m;
+        public static Percentage Percent(this int number) => Percentage.Create(number * 0.01m);
 
         /// <summary>Interprets the <see cref="double"/> if it was written with a '%' sign.</summary>
         [Pure]
-        public static Percentage Percent(this double number) => number * 0.01;
+        public static Percentage Percent(this double number) => Percentage.Create(number * 0.01);
 
         /// <summary>Interprets the <see cref="decimal"/> if it was written with a '%' sign.</summary>
         [Pure]
-        public static Percentage Percent(this decimal number) => number * 0.01m;
+        public static Percentage Percent(this decimal number) => Percentage.Create(number * 0.01m);
     }
 }

--- a/src/Qowaiv/Extensions/Humanizer.Year.cs
+++ b/src/Qowaiv/Extensions/Humanizer.Year.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics.Contracts;
+
+namespace Qowaiv
+{
+    /// <summary>Extensions to create <see cref="Qowaiv.Year"/>s, inspired by Humanizer.NET.</summary>
+    public static class NumberToYearExtensions
+    {
+        /// <summary>Create a <see cref="Qowaiv.Year"/> from a <see cref="int"/>.</summary>
+        [Pure]
+        public static Year Year(this int year) => Qowaiv.Year.Create(year);
+    }
+}

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -424,12 +424,6 @@ namespace Qowaiv.Financial
         [Pure]
         public static Amount FromJson(long json) => new(json);
 
-        /// <summary>Casts an Amount to a <see cref="string"/>.</summary>
-        public static explicit operator string(Amount val) => val.ToString(CultureInfo.CurrentCulture);
-
-        /// <summary>Casts a <see cref="string"/> to a </summary>
-        public static explicit operator Amount(string str) => Cast.String<Amount>(TryParse, str);
-
         /// <summary>Casts a decimal an </summary>
         public static explicit operator Amount(decimal val) => Create(val);
 

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -116,12 +116,6 @@ namespace Qowaiv.Financial
         [Pure]
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-        /// <summary>Casts a BIC to a <see cref="string"/>.</summary>
-        public static explicit operator string(BusinessIdentifierCode val) => val.ToString(CultureInfo.CurrentCulture);
-        
-        /// <summary>Casts a <see cref="string"/> to a BIC.</summary>
-        public static explicit operator BusinessIdentifierCode(string str) => Cast.String<BusinessIdentifierCode>(TryParse, str);
-
         /// <summary>Converts the string to a BIC.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Financial/Currency.cs
+++ b/src/Qowaiv/Financial/Currency.cs
@@ -201,17 +201,6 @@ namespace Qowaiv.Financial
             return info;
         }
 
-        /// <summary>Casts a currency to a <see cref="string"/>.</summary>
-        public static explicit operator string(Currency val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a currency.</summary>
-        public static explicit operator Currency(string str) => Cast.String<Currency>(TryParse, str);
-
-        /// <summary>Casts a currency to a <see cref="string"/>.</summary>
-        public static explicit operator int(Currency val) => val.IsoNumericCode;
-
-        /// <summary>Casts a <see cref="string"/> to a currency.</summary>
-        public static explicit operator Currency(int val) => AllCurrencies.FirstOrDefault(c => c.IsoNumericCode == val);
-
         /// <summary>Converts the string to a currency.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -158,12 +158,6 @@ namespace Qowaiv.Financial
         [Pure]
         private string ToXmlString() => ToUnformattedString();
 
-        /// <summary>Casts an IBAN to a <see cref="string"/>.</summary>
-        public static explicit operator string(InternationalBankAccountNumber val) => val.ToString(CultureInfo.InvariantCulture);
-        
-        /// <summary>Casts a <see cref="string"/> to a IBAN.</summary>
-        public static explicit operator InternationalBankAccountNumber(string str) => Cast.String<InternationalBankAccountNumber>(TryParse, str);
-
         /// <summary>Converts the string to an IBAN.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -507,15 +507,12 @@ namespace Qowaiv.Financial
 
         #region (Explicit) casting
 
-        /// <summary>Casts Money to a <see cref="string"/>.</summary>
-        public static explicit operator string(Money val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a </summary>
-        public static explicit operator Money(string str) => Cast.String<Money>(TryParse, str);
-
         /// <summary>Casts Money to a decimal.</summary>
         public static explicit operator Amount(Money val) => (Amount)val.m_Value;
+        
         /// <summary>Casts Money to a decimal.</summary>
         public static explicit operator decimal(Money val) => val.m_Value;
+        
         /// <summary>Casts Money to a double.</summary>
         public static explicit operator double(Money val) => (double)val.m_Value;
 

--- a/src/Qowaiv/Gender.cs
+++ b/src/Qowaiv/Gender.cs
@@ -155,12 +155,6 @@ namespace Qowaiv
         [Pure]
         private string ToXmlString() => GenderLabels[m_Value] ?? string.Empty;
 
-        /// <summary>Casts a Gender to a <see cref="string"/>.</summary>
-        public static explicit operator string(Gender val) => val.ToString(CultureInfo.CurrentCulture);
-
-        /// <summary>Casts a <see cref="string"/> to a Gender.</summary>
-        public static explicit operator Gender(string str) => Cast.String<Gender>(TryParse, str);
-
         /// <summary>Casts a Gender to a <see cref="byte"/>.</summary>
         public static explicit operator byte(Gender val) => (byte)val.ToInt32();
 

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -222,11 +222,6 @@ namespace Qowaiv.Globalization
             { 'f', (svo, provider) => svo.GetResourceString("DisplayName", provider) },
         };
 
-        /// <summary>Casts a Country to a <see cref="string"/>.</summary>
-        public static explicit operator string(Country val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a </summary>
-        public static explicit operator Country(string str) => Cast.String<Country>(TryParse, str);
-
         /// <summary>Casts a System.Globalization.RegionInfo to a </summary>
         public static implicit operator Country(RegionInfo region) => Create(region);
 

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -122,18 +122,15 @@ namespace Qowaiv
         [Pure]
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-        /// <summary>Casts a house number to a <see cref="string"/>.</summary>
-        public static explicit operator string(HouseNumber val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a house number.</summary>
-        public static explicit operator HouseNumber(string str) => Cast.String<HouseNumber>(TryParse, str);
-
         /// <summary>Casts a house number to a System.Int32.</summary>
         public static explicit operator int(HouseNumber val) => val.m_Value;
+        
         /// <summary>Casts an System.Int32 to a house number.</summary>
         public static implicit operator HouseNumber(int val) => Cast.Primitive<int, HouseNumber>(TryCreate, val);
 
         /// <summary>Casts a house number to a System.Int64.</summary>
         public static explicit operator long(HouseNumber val) => val.m_Value;
+        
         /// <summary>Casts a System.Int64 to a house number.</summary>
         public static implicit operator HouseNumber(long val) => Cast.Primitive<int, HouseNumber>(TryCreate, (int)val);
 

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -553,28 +553,27 @@ namespace Qowaiv.IO
         private static readonly string[] ShortLabels1024 = { "B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB" };
         private static readonly string[] FullLabels1024 = { "byte", "kibibyte", "Mebibyte", "Gibibyte", "Tebibyte", "Pebibyte", "Exbibyte" };
 
-        /// <summary>Casts a stream size to a <see cref="string"/>.</summary>
-        public static explicit operator string(StreamSize val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a stream size.</summary>
-        public static explicit operator StreamSize(string str) => Cast.String<StreamSize>(TryParse, str);
-
         /// <summary>Casts a stream size to a System.int.</summary>
         public static explicit operator int(StreamSize val) => (int)val.m_Value;
+
         /// <summary>Casts an int to a stream size.</summary>
         public static implicit operator StreamSize(int val) => new(val);
 
         /// <summary>Casts a stream size to a System.long.</summary>
         public static explicit operator long(StreamSize val) => val.m_Value;
+
         /// <summary>Casts a long to a stream size.</summary>
         public static implicit operator StreamSize(long val) => new(val);
 
         /// <summary>Casts a stream size to a System.Double.</summary>
         public static explicit operator double(StreamSize val) => val.m_Value;
+
         /// <summary>Casts a double to a stream size.</summary>
         public static explicit operator StreamSize(double val) => new((long)val);
 
         /// <summary>Casts a stream size to a System.Decimal.</summary>
         public static explicit operator decimal(StreamSize val) => val.m_Value;
+        
         /// <summary>Casts a decimal to a stream size.</summary>
         public static explicit operator StreamSize(decimal val) => new((long)val);
 

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -543,19 +543,15 @@ namespace Qowaiv
 
         #region (Explicit) casting
 
-        /// <summary>Casts a local date time to a <see cref="string"/>.</summary>
-        public static explicit operator string(LocalDateTime val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a local date time to a date time.</summary>
         public static implicit operator DateTime(LocalDateTime val) => val.m_Value;
 
-
-        /// <summary>Casts a <see cref="string"/> to a local date time.</summary>
-        public static explicit operator LocalDateTime(string str) => Cast.String<LocalDateTime>(TryParse, str);
         /// <summary>Casts a date time to a local date time.</summary>
         public static implicit operator LocalDateTime(DateTime val) => new(val);
 
         /// <summary>Casts a date to a local date time.</summary>
         public static explicit operator LocalDateTime(Date val) => new(val);
+
         /// <summary>Casts a week date to a week date.</summary>
         public static implicit operator LocalDateTime(WeekDate val) => (LocalDateTime)val.Date;
 

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -606,7 +606,7 @@ namespace Qowaiv.Mathematics
         /// <summary>Casts a <see cref="Percentage"/> to a <see cref="Fraction"/>.</summary>
         public static explicit operator Fraction(Percentage number) => Cast((decimal)number);
         /// <summary>Casts a <see cref="Percentage"/> to a <see cref="Fraction"/>.</summary>
-        public static explicit operator Percentage(Fraction fraction) => fraction.ToDecimal();
+        public static explicit operator Percentage(Fraction fraction) => Percentage.Create(fraction.ToDecimal());
 
         /// <summary>Casts a <see cref="double"/> to a <see cref="Fraction"/>.</summary>
         public static explicit operator Fraction(double number) => Cast(number);

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -171,17 +171,11 @@ namespace Qowaiv
             { 'm', (svo, provider) => svo.IsEmptyOrUnknown() ? svo.ToDefaultString() : svo.m_Value.ToString("00", provider) },
         };
 
-        /// <summary>Casts a month to a <see cref="string"/>.</summary>
-        public static explicit operator string(Month val) => val.ToString(CultureInfo.CurrentCulture);
-
-        /// <summary>Casts a <see cref="string"/> to a month.</summary>
-        public static explicit operator Month(string str) => Cast.String<Month>(TryParse, str);
-
         /// <summary>Casts a month to a System.Int32.</summary>
         public static explicit operator int(Month val) => val.m_Value;
 
         /// <summary>Casts an System.Int32 to a month.</summary>
-        public static implicit operator Month(int val) => Cast.Primitive<int, Month>(TryCreate, val);
+        public static explicit operator Month(int val) => Cast.Primitive<int, Month>(TryCreate, val);
 
         /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
         public static bool operator <(Month l, Month r) => HaveValue(l, r) && l.CompareTo(r) < 0;

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -238,18 +238,15 @@ namespace Qowaiv
 
         #region (Explicit) casting
 
-        /// <summary>Casts the month span to a <see cref = "string"/>.</summary>
-        public static explicit operator string(MonthSpan val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref = "string "/> to a month span.</summary>
-        public static explicit operator MonthSpan(string str) => Parse(str, CultureInfo.CurrentCulture);
-
         /// <summary>Casts the month span to a <see cref = "int"/>.</summary>
         public static explicit operator int(MonthSpan val) => val.m_Value;
+
         /// <summary>Casts a <see cref = "int "/> to a month span.</summary>
         public static explicit operator MonthSpan(int val) => FromMonths(val);
 
         /// <summary>Casts the month span to a <see cref="DateSpan"/>.</summary>
         public static implicit operator DateSpan(MonthSpan val) => DateSpan.FromMonths(val.m_Value);
+
         /// <summary>Casts a <see cref = "DateSpan"/> to a month span.</summary>
         public static explicit operator MonthSpan(DateSpan val) => FromMonths(val.TotalMonths);
 

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -40,10 +40,10 @@ namespace Qowaiv
         public static readonly Percentage Hundred = 100.Percent();
 
         /// <summary>Gets the minimum value of a percentage.</summary>
-        public static readonly Percentage MinValue = decimal.MinValue;
+        public static readonly Percentage MinValue = new(decimal.MinValue);
 
         /// <summary>Gets the maximum value of a percentage.</summary>
-        public static readonly Percentage MaxValue = decimal.MaxValue;
+        public static readonly Percentage MaxValue = new(decimal.MaxValue);
 
         #region Percentage manipulation
 
@@ -53,7 +53,7 @@ namespace Qowaiv
 
         /// <summary>Returns the absolute value of the percentage.</summary>
         [Pure]
-        public Percentage Abs() => Math.Abs(m_Value);
+        public Percentage Abs() => new(Math.Abs(m_Value));
 
         /// <summary>Increases the percentage with one percent.</summary>
         [Pure]
@@ -65,25 +65,25 @@ namespace Qowaiv
 
         /// <summary>Pluses the percentage.</summary>
         [Pure]
-        internal Percentage Plus() => +m_Value;
+        internal Percentage Plus() => new(+m_Value);
 
         /// <summary>Negates the percentage.</summary>
         [Pure]
-        internal Percentage Negate() => -m_Value;
+        internal Percentage Negate() => new(-m_Value);
 
         /// <summary>Gets a percentage of the current percentage.</summary>
         /// <param name="p">
         /// The percentage to multiply with.
         /// </param>
         [Pure]
-        public Percentage Multiply(Percentage p) => m_Value * p.m_Value;
+        public Percentage Multiply(Percentage p) =>new(m_Value * p.m_Value);
 
         /// <summary>Divides the current percentage by a specified percentage.</summary>
         /// <param name="p">
         /// The percentage to divides to.
         /// </param>
         [Pure]
-        public Percentage Divide(Percentage p) => m_Value / p.m_Value;
+        public Percentage Divide(Percentage p) => new(m_Value / p.m_Value);
 
         /// <summary>Adds a percentage to the current percentage.
         /// </summary>
@@ -91,7 +91,7 @@ namespace Qowaiv
         /// The percentage to add.
         /// </param>
         [Pure]
-        public Percentage Add(Percentage p) => m_Value + p.m_Value;
+        public Percentage Add(Percentage p) => new(m_Value + p.m_Value);
 
         /// <summary>Subtracts a percentage from the current percentage.
         /// </summary>
@@ -99,7 +99,7 @@ namespace Qowaiv
         /// The percentage to Subtract.
         /// </param>
         [Pure]
-        public Percentage Subtract(Percentage p) => m_Value - p.m_Value;
+        public Percentage Subtract(Percentage p) => new(m_Value - p.m_Value);
 
         #region Multiply
 
@@ -109,7 +109,7 @@ namespace Qowaiv
         /// The factor to multiply with.
         /// </param>
         [Pure]
-        public Percentage Multiply(decimal factor) => m_Value * factor;
+        public Percentage Multiply(decimal factor) => new(m_Value * factor);
 
         /// <summary>Multiplies the percentage with a specified factor.
         /// </summary>
@@ -188,7 +188,7 @@ namespace Qowaiv
         /// The factor to multiply with.
         /// </param>
         [Pure]
-        public Percentage Divide(decimal factor) => m_Value / factor;
+        public Percentage Divide(decimal factor) => new(m_Value / factor);
 
         /// <summary>Divide the percentage by a specified factor.
         /// </summary>
@@ -551,20 +551,17 @@ namespace Qowaiv
         /// </exception>
         [Pure]
         public Percentage Round(int decimals, DecimalRounding mode)
-        {
-            if ((decimals < -26) || (decimals > 26))
-            {
-                throw new ArgumentOutOfRangeException(nameof(decimals), QowaivMessages.ArgumentOutOfRange_PercentageRound);
-            }
-            return m_Value.Round(decimals + 2, mode);
-        }
+            => decimals >= -26 && decimals <= 26
+            ? new(m_Value.Round(decimals + 2, mode))
+            : throw new ArgumentOutOfRangeException(nameof(decimals), QowaivMessages.ArgumentOutOfRange_PercentageRound);
 
         /// <summary>Rounds the percentage to a specified multiple of the specified percentage.</summary>
         /// <param name="multipleOf">
         /// The percentage of which the number should be multiple of.
         /// </param>
         [Pure]
-        public Percentage RoundToMultiple(Percentage multipleOf) => RoundToMultiple(multipleOf, DecimalRounding.AwayFromZero);
+        public Percentage RoundToMultiple(Percentage multipleOf)
+            => RoundToMultiple(multipleOf, DecimalRounding.AwayFromZero);
 
         /// <summary>Rounds the percentage to a specified multiple of the specified percentage.</summary>
         /// <param name="multipleOf">
@@ -578,9 +575,7 @@ namespace Qowaiv
         /// </exception>
         [Pure]
         public Percentage RoundToMultiple(Percentage multipleOf, DecimalRounding mode)
-        {
-            return m_Value.RoundToMultiple((decimal)multipleOf, mode);
-        }
+            => new(m_Value.RoundToMultiple((decimal)multipleOf, mode));
 
         #endregion
 
@@ -658,18 +653,15 @@ namespace Qowaiv
 
         #region (Explicit) casting
 
-        /// <summary>Casts a Percentage to a <see cref="string"/>.</summary>
-        public static explicit operator string(Percentage val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a Percentage.</summary>
-        public static explicit operator Percentage(string str) => Cast.String<Percentage>(TryParse, str);
-
         /// <summary>Casts a decimal a Percentage.</summary>
-        public static implicit operator Percentage(decimal val) => Create(val);
+        public static explicit operator Percentage(decimal val) => Create(val);
+        
         /// <summary>Casts a decimal a Percentage.</summary>
-        public static implicit operator Percentage(double val) => Create(val);
+        public static explicit operator Percentage(double val) => Create(val);
 
         /// <summary>Casts a Percentage to a decimal.</summary>
         public static explicit operator decimal(Percentage val) => val.m_Value;
+        
         /// <summary>Casts a Percentage to a double.</summary>
         public static explicit operator double(Percentage val) => (double)val.m_Value;
 

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -110,11 +110,6 @@ namespace Qowaiv
         [Pure]
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-        /// <summary>Casts a postal code to a <see cref="string"/>.</summary>
-        public static explicit operator string(PostalCode val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a postal code.</summary>
-        public static explicit operator PostalCode(string str) => Cast.String<PostalCode>(TryParse, str);
-
         /// <summary>Converts the string to a postal code.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -122,15 +122,11 @@ namespace Qowaiv.Security.Cryptography
             return Length.CompareTo(other.Length);
         }
 
-        /// <summary>Casts a cryptographic seed to a <see cref="string"/>.</summary>
-        public static explicit operator string(CryptographicSeed val) => val.ToString(CultureInfo.InvariantCulture);
-        /// <summary>Casts a <see cref="string"/> to a cryptographic seed.</summary>
-        public static explicit operator CryptographicSeed(string str) => Cast.InvariantString<CryptographicSeed>(TryParse, str);
-
         /// <summary>Casts a cryptographic seed to a System.byte[].</summary>
         public static explicit operator byte[](CryptographicSeed val) => val.ToByteArray();
+        
         /// <summary>Casts a System.byte[] to a cryptographic seed.</summary>
-        public static implicit operator CryptographicSeed(byte[] bytes) => Create(bytes);
+        public static explicit operator CryptographicSeed(byte[] bytes) => Create(bytes);
 
         /// <summary>Converts the string to a cryptographic seed.
         /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -171,22 +171,21 @@ namespace Qowaiv.Statistics
         [Pure]
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-        /// <summary>Casts an Elo to a <see cref="string"/>.</summary>
-        public static explicit operator string(Elo val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a Elo.</summary>
-        public static explicit operator Elo(string str) => Cast.String<Elo>(TryParse, str);
-
         /// <summary>Casts a decimal to an Elo.</summary>
         public static implicit operator Elo(decimal val) => new((double)val);
+        
         /// <summary>Casts a decimal to an Elo.</summary>
         public static implicit operator Elo(double val) => Create(val);
+        
         /// <summary>Casts an integer to an Elo.</summary>
         public static implicit operator Elo(int val) => new(val);
 
         /// <summary>Casts an Elo to a decimal.</summary>
         public static explicit operator decimal(Elo val) => (decimal)val.m_Value;
+        
         /// <summary>Casts an Elo to a double.</summary>
         public static explicit operator double(Elo val) => val.m_Value;
+        
         /// <summary>Casts an Elo to an integer.</summary>
         public static explicit operator int(Elo val) => (int)Math.Round(val.m_Value);
 

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -115,12 +115,6 @@ namespace Qowaiv
         [Pure]
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-        /// <summary>Casts a UUID to a <see cref="string"/>.</summary>
-        public static explicit operator string(Uuid val) => val.ToString(CultureInfo.CurrentCulture);
-
-        /// <summary>Casts a <see cref="string"/> to a UUID.</summary>
-        public static explicit operator Uuid(string str) => Cast.InvariantString<Uuid>(TryParse, str);
-
         /// <summary>Casts a Qowaiv.UUID to a System.GUID.</summary>
         public static implicit operator Guid(Uuid val) => val.m_Value;
 

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -167,12 +167,6 @@ namespace Qowaiv.Web
         [Pure]
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-        /// <summary>Casts an Internet media type to a <see cref="string"/>.</summary>
-        public static explicit operator string(InternetMediaType val) => val.ToString(CultureInfo.CurrentCulture);
-        
-        /// <summary>Casts a <see cref="string"/> to a Internet media type.</summary>
-        public static explicit operator InternetMediaType(string str) => Cast.InvariantString<InternetMediaType>(TryParse, str);
-
         /// <summary>Converts the string to an Internet media type.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -238,18 +238,15 @@ namespace Qowaiv
         /// <summary>Bind XML value.</summary>
         partial void OnReadXml(WeekDate value) => m_Value = value.m_Value;
 
-        /// <summary>Casts a week date to a <see cref="string"/>.</summary>
-        public static explicit operator string(WeekDate val) => val.ToString(CultureInfo.CurrentCulture);
         /// <summary>Casts a week date to a date time.</summary>
         public static implicit operator DateTime(WeekDate val) => val.m_Value;
 
-        /// <summary>Casts a <see cref="string"/> to a week date.</summary>
-        public static explicit operator WeekDate(string str) => Cast.String<WeekDate>(TryParse, str);
         /// <summary>Casts a date time to a week date.</summary>
         public static explicit operator WeekDate(DateTime val) => Create((Date)val);
 
         /// <summary>Casts a date to a week date.</summary>
         public static implicit operator WeekDate(Date val) => Create(val);
+        
         /// <summary>Casts a local date time to a week date.</summary>
         public static explicit operator WeekDate(LocalDateTime val) => Create(val.Date);
 

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -115,17 +115,11 @@ namespace Qowaiv
         [Pure]
         private static bool HaveValue(Year l, Year r) => !l.IsEmptyOrUnknown() && !r.IsEmptyOrUnknown();
 
-        /// <summary>Casts a year to a <see cref="string"/>.</summary>
-        public static explicit operator string(Year val) => val.ToString(CultureInfo.CurrentCulture);
-        
-        /// <summary>Casts a <see cref="string"/> to a year.</summary>
-        public static explicit operator Year(string str) => Cast.String<Year>(TryParse, str);
-
         /// <summary>Casts a year to a System.Int32.</summary>
         public static explicit operator int(Year val) => val.m_Value;
 
         /// <summary>Casts an System.Int32 to a year.</summary>
-        public static implicit operator Year(int val) => Cast.Primitive<int, Year>(TryCreate, val);
+        public static explicit operator Year(int val) => Cast.Primitive<int, Year>(TryCreate, val);
 
         /// <summary>Converts the string to a year.
         /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -151,11 +151,6 @@ namespace Qowaiv
         [Pure]
         private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-        /// <summary>Casts a yes-no to a <see cref="string"/>.</summary>
-        public static explicit operator string(YesNo val) => val.ToString(CultureInfo.CurrentCulture);
-        /// <summary>Casts a <see cref="string"/> to a yes-no.</summary>
-        public static explicit operator YesNo(string str) => Cast.String<YesNo>(TryParse, str);
-
         /// <summary>Casts a yes-no to a nullable <see cref="bool"/>.</summary>
         public static explicit operator bool?(YesNo val) => BooleanValues[val.m_Value];
 
@@ -169,7 +164,7 @@ namespace Qowaiv
             {
                 return val.Value ? Yes : No;
             }
-            return Empty;
+            else return Empty;
         }
 
         /// <summary>Casts a <see cref="bool"/> to a yes-no.</summary>


### PR DESCRIPTION
A feature hardly used, that not let to better code. So, it is not long available in version 6. Considered exception is explicit cast from string to Id<T>.