### PR TITLE
Revisit some (breaking) changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ var p = Percentage.Parse("3.14");  // Parse: 3.14%;
 var p = Percentage.Parse("3.14%"); // Parse: 3.14%;
 var p = Percentage.Parse("31.4‰"); // Parse: 3.14%;
 var p = 3.14.Percent(); // Extension on double: 3.14%;
+Percentage p = 0.0314m; // Implicit casting from decimal: 3.14%.
 
-// Casting
+// Explicit casting
 var p = (Percentage)0.500; // 50%
-var p = (Percentage)0.33m; // 33%
 
 // Manipulation
 var p = 13.2.Percent();

--- a/shared/Guard.cs
+++ b/shared/Guard.cs
@@ -5,448 +5,439 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Linq;
+namespace Qowaiv;
 
-namespace Qowaiv
+/// <summary>Supplies parameter guarding for methods and constructors.</summary>
+/// <remarks>
+/// Advised usage:
+/// * Change the namespace to maximum shared namespace amongst the using projects
+/// * Keep it internal and use [assembly: InternalsVisibleTo] to open up access
+/// * Add specific Guard methods if you software needs them.
+/// * Keep the checks cheap so that you also can run them in production code.
+/// </remarks>
+[ExcludeFromCodeCoverage]
+internal static partial class Guard
 {
-    /// <summary>Supplies parameter guarding for methods and constructors.</summary>
+    /// <summary>Guards the parameter if not null, otherwise throws an argument (null) exception.</summary>
+    /// <typeparam name="T">The type to guard; cannot be a structure.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T NotNull<T>([ValidatedNotNull] T parameter, string paramName)
+        where T : class
+        => parameter ?? throw new ArgumentNullException(paramName);
+
+    /// <summary>Throws an ArgumentException if the nullable parameter has no value, otherwise the parameter value is passed.</summary>
+    /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T HasValue<T>(T? parameter, string paramName)
+        where T : struct
+        => parameter ?? throw new ArgumentException(Messages.ArgumentException_NullableMustHaveValue, paramName);
+
+    /// <summary>
+    /// Throws an ArgumentException if the nullable parameter has no value or the default value,
+    /// otherwise the parameter value is passed.
+    /// </summary>
+    /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T NotDefault<T>(T? parameter, string paramName)
+        where T : struct => NotDefault(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter has the default value, otherwise the parameter value is passed.</summary>
+    /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T NotDefault<T>(T parameter, string paramName)
+        where T : struct
+        => parameter.Equals(default(T))
+        ? throw new ArgumentException(Messages.ArgumentException_IsDefaultValue, paramName)
+        : parameter;
+
+    /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if the parameter is not in the collection, otherwise the parameter is passed.</summary>
+    /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <param name="allowedRange">The allowed range of values.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T In<T>(T parameter, string paramName, params T[] allowedRange)
+        where T : struct
+        => allowedRange.Contains(parameter)
+        ? parameter
+        : throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_NotInCollection, string.Join(", ", allowedRange)));
+
+    /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if the parameter not in the collection, otherwise the parameter is passed.</summary>
+    /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <param name="forbiddenRange">The forbidden range of values.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T NotIn<T>(T parameter, string paramName, params T[] forbiddenRange)
+        where T : struct
+        => forbiddenRange.Contains(parameter)
+        ? throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_InCollection, string.Join(", ", forbiddenRange)))
+        : parameter;
+
+    /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if the parameter not in not a defined value of the enum, otherwise the parameter is passed.</summary>
+    /// <typeparam name="T">The type to guard; must be a structure (enum).</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
     /// <remarks>
-    /// Advised usage:
-    /// * Change the namespace to maximum shared namespace amongst the using projects
-    /// * Keep it internal and use [assembly: InternalsVisibleTo] to open up access
-    /// * Add specific Guard methods if you software needs them.
-    /// * Keep the checks cheap so that you also can run them in production code.
+    /// That <typeparamref name="T"/> is an enum is implicitly guard by <see cref="Enum.IsDefined(Type, object)"/>.
     /// </remarks>
-    [ExcludeFromCodeCoverage]
-    internal static partial class Guard
+    public static T DefinedEnum<T>(T parameter, string paramName)
+        where T : struct
+        => Enum.IsDefined(typeof(T), parameter)
+        ? parameter
+        : throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_DefinedEnum, parameter, typeof(T)));
+
+    /// <summary>
+    /// Guards that the parameter is an instance of T, otherwise throws an argument (null) exception.
+    /// It only makes sense to use this function if the original type of the <paramref name="parameter"/>
+    /// is <see cref="object"/>, otherwise one should simply use <see cref="NotNull{T}(T, string)"/>.
+    /// </summary>
+    /// <typeparam name="T">The type to guard.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T IsInstanceOf<T>([ValidatedNotNull] object parameter, string paramName)
+        => NotNull(parameter, paramName) is T instance
+        ? instance
+        : throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Messages.ArgumentException_NotAnInstanceOf, typeof(T)), paramName);
+
+
+    /// <summary>Guards that the parameter is not null or an empty collection, otherwise throws an argument (null) exception.</summary>
+    /// <typeparam name="T">The type to guard; must be an <see cref="ICollection" />.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T HasAny<T>([ValidatedNotNull] T parameter, string paramName)
+        where T : class, ICollection
+        => NotNull(parameter, paramName).Count == 0
+        ? throw new ArgumentException(Messages.ArgumentException_EmptyCollection, paramName)
+        : parameter;
+
+    /// <summary>Guards that the parameter is not null or an empty enumerable, otherwise throws an argument (null) exception.</summary>
+    /// <typeparam name="T">The type to guard; must be an <see cref="IEnumerable" />.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static IEnumerable<T> HasAny<T>([ValidatedNotNull] IEnumerable<T> parameter, string paramName)
+        => NotNull(parameter, paramName).Any()
+        ? parameter
+        : throw new ArgumentException(Messages.ArgumentException_EmptyCollection, paramName);
+
+    /// <summary>Guards that the parameter is not null or an empty string, otherwise throws an argument (null) exception.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static string NotNullOrEmpty([ValidatedNotNull] string parameter, string paramName)
+        => NotNull(parameter, paramName) == string.Empty
+        ? throw new ArgumentException(Messages.ArgumentException_StringEmpty, paramName)
+        : parameter;
+
+    /// <summary>Guards that the parameter is not an empty <see cref="Guid"/>, otherwise throws an argument exception.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static Guid NotEmpty(Guid? parameter, string paramName)
+        => NotEmpty(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Guards that the parameter is not an empty <see cref="Guid"/>, otherwise throws an argument exception.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static Guid NotEmpty(Guid parameter, string paramName)
+        => parameter == Guid.Empty
+        ? throw new ArgumentException(Messages.ArgumentException_GuidEmpty, paramName)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static int Positive(int? parameter, string paramName)
+        => Positive(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static int Positive(int parameter, string paramName)
+        => parameter <= 0
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static long Positive(long? parameter, string paramName) => Positive(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static long Positive(long parameter, string paramName)
+        => parameter <= 0
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static double Positive(double? parameter, string paramName)
+        => Positive(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static double Positive(double parameter, string paramName)
+        => parameter <= 0
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static decimal Positive(decimal? parameter, string paramName)
+        => Positive(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static decimal Positive(decimal parameter, string paramName)
+        => parameter <= 0
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static TimeSpan Positive(TimeSpan? parameter, string paramName)
+        => Positive(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static TimeSpan Positive(TimeSpan parameter, string paramName)
+        => parameter <= TimeSpan.Zero
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static int NotNegative(int? parameter, string paramName)
+        => NotNegative(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static int NotNegative(int parameter, string paramName)
+        => parameter < 0
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static long NotNegative(long? parameter, string paramName)
+        => NotNegative(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static long NotNegative(long parameter, string paramName)
+        => parameter < 0
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static double NotNegative(double? parameter, string paramName)
+        => NotNegative(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static double NotNegative(double parameter, string paramName)
+        => parameter < 0
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static decimal NotNegative(decimal? parameter, string paramName)
+        => NotNegative(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static decimal NotNegative(decimal parameter, string paramName)
+        => parameter < 0
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+        : parameter;
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static TimeSpan NotNegative(TimeSpan? parameter, string paramName)
+        => NotNegative(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static TimeSpan NotNegative(TimeSpan parameter, string paramName)
+        => parameter < TimeSpan.Zero
+        ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
+        : parameter;
+
+    /// <summary>Messages class to group the constants.</summary>
+    private static class Messages
     {
-        /// <summary>Guards the parameter if not null, otherwise throws an argument (null) exception.</summary>
-        /// <typeparam name="T">The type to guard; cannot be a structure.</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static T NotNull<T>([ValidatedNotNull] T parameter, string paramName)
-            where T : class
-            => parameter ?? throw new ArgumentNullException(paramName);
-
-        /// <summary>Throws an ArgumentException if the nullable parameter has no value, otherwise the parameter value is passed.</summary>
-        /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static T HasValue<T>(T? parameter, string paramName)
-            where T : struct
-            => parameter ?? throw new ArgumentException(Messages.ArgumentException_NullableMustHaveValue, paramName);
-
-        /// <summary>
-        /// Throws an ArgumentException if the nullable parameter has no value or the default value,
-        /// otherwise the parameter value is passed.
-        /// </summary>
-        /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static T NotDefault<T>(T? parameter, string paramName)
-            where T : struct => NotDefault(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter has the default value, otherwise the parameter value is passed.</summary>
-        /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static T NotDefault<T>(T parameter, string paramName)
-            where T : struct
-            => parameter.Equals(default(T))
-            ? throw new ArgumentException(Messages.ArgumentException_IsDefaultValue, paramName)
-            : parameter;
-
-        /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if the parameter is not in the collection, otherwise the parameter is passed.</summary>
-        /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <param name="allowedRange">The allowed range of values.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static T In<T>(T parameter, string paramName, params T[] allowedRange)
-            where T : struct
-            => allowedRange.Contains(parameter)
-            ? parameter
-            : throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_NotInCollection, string.Join(", ", allowedRange)));
-
-        /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if the parameter not in the collection, otherwise the parameter is passed.</summary>
-        /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <param name="forbiddenRange">The forbidden range of values.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static T NotIn<T>(T parameter, string paramName, params T[] forbiddenRange)
-            where T : struct
-            => forbiddenRange.Contains(parameter)
-            ? throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_InCollection, string.Join(", ", forbiddenRange)))
-            : parameter;
-
-        /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if the parameter not in not a defined value of the enum, otherwise the parameter is passed.</summary>
-        /// <typeparam name="T">The type to guard; must be a structure (enum).</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        /// <remarks>
-        /// That <typeparamref name="T"/> is an enum is implicitly guard by <see cref="Enum.IsDefined(Type, object)"/>.
-        /// </remarks>
-        public static T DefinedEnum<T>(T parameter, string paramName)
-            where T : struct
-            => Enum.IsDefined(typeof(T), parameter)
-            ? parameter
-            : throw new ArgumentOutOfRangeException(paramName, string.Format(CultureInfo.CurrentCulture, Messages.ArgumentOutOfRangeException_DefinedEnum, parameter, typeof(T)));
-
-        /// <summary>
-        /// Guards that the parameter is an instance of T, otherwise throws an argument (null) exception.
-        /// It only makes sense to use this function if the original type of the <paramref name="parameter"/>
-        /// is <see cref="object"/>, otherwise one should simply use <see cref="NotNull{T}(T, string)"/>.
-        /// </summary>
-        /// <typeparam name="T">The type to guard.</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static T IsInstanceOf<T>([ValidatedNotNull] object parameter, string paramName)
-            => NotNull(parameter, paramName) is T instance
-            ? instance
-            : throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Messages.ArgumentException_NotAnInstanceOf, typeof(T)), paramName);
-
-
-        /// <summary>Guards that the parameter is not null or an empty collection, otherwise throws an argument (null) exception.</summary>
-        /// <typeparam name="T">The type to guard; must be an <see cref="ICollection" />.</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static T HasAny<T>([ValidatedNotNull] T parameter, string paramName)
-            where T : class, ICollection
-            => NotNull(parameter, paramName).Count == 0
-            ? throw new ArgumentException(Messages.ArgumentException_EmptyCollection, paramName)
-            : parameter;
-
-        /// <summary>Guards that the parameter is not null or an empty enumerable, otherwise throws an argument (null) exception.</summary>
-        /// <typeparam name="T">The type to guard; must be an <see cref="IEnumerable" />.</typeparam>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static IEnumerable<T> HasAny<T>([ValidatedNotNull] IEnumerable<T> parameter, string paramName)
-            => NotNull(parameter, paramName).Any()
-            ? parameter
-            : throw new ArgumentException(Messages.ArgumentException_EmptyCollection, paramName);
-
-        /// <summary>Guards that the parameter is not null or an empty string, otherwise throws an argument (null) exception.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static string NotNullOrEmpty([ValidatedNotNull] string parameter, string paramName)
-            => NotNull(parameter, paramName) == string.Empty
-            ? throw new ArgumentException(Messages.ArgumentException_StringEmpty, paramName)
-            : parameter;
-
-        /// <summary>Guards that the parameter is not an empty <see cref="Guid"/>, otherwise throws an argument exception.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static Guid NotEmpty(Guid? parameter, string paramName)
-            => NotEmpty(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Guards that the parameter is not an empty <see cref="Guid"/>, otherwise throws an argument exception.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static Guid NotEmpty(Guid parameter, string paramName)
-            => parameter == Guid.Empty
-            ? throw new ArgumentException(Messages.ArgumentException_GuidEmpty, paramName)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static int Positive(int? parameter, string paramName)
-            => Positive(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static int Positive(int parameter, string paramName)
-            => parameter <= 0
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static long Positive(long? parameter, string paramName) => Positive(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static long Positive(long parameter, string paramName)
-            => parameter <= 0
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static double Positive(double? parameter, string paramName)
-            => Positive(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static double Positive(double parameter, string paramName)
-            => parameter <= 0
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static decimal Positive(decimal? parameter, string paramName)
-            => Positive(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static decimal Positive(decimal parameter, string paramName)
-            => parameter <= 0
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static TimeSpan Positive(TimeSpan? parameter, string paramName)
-            => Positive(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is not positive, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static TimeSpan Positive(TimeSpan parameter, string paramName)
-            => parameter <= TimeSpan.Zero
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_NotPositive)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static int NotNegative(int? parameter, string paramName)
-            => NotNegative(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static int NotNegative(int parameter, string paramName)
-            => parameter < 0
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static long NotNegative(long? parameter, string paramName)
-            => NotNegative(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static long NotNegative(long parameter, string paramName)
-            => parameter < 0
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static double NotNegative(double? parameter, string paramName)
-            => NotNegative(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static double NotNegative(double parameter, string paramName)
-            => parameter < 0
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static decimal NotNegative(decimal? parameter, string paramName)
-            => NotNegative(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static decimal NotNegative(decimal parameter, string paramName)
-            => parameter < 0
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
-            : parameter;
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static TimeSpan NotNegative(TimeSpan? parameter, string paramName)
-            => NotNegative(HasValue(parameter, paramName), paramName);
-
-        /// <summary>Throws an ArgumentException if the parameter is negative, otherwise the parameter is passed.</summary>
-        /// <param name="parameter">The parameter to guard.</param>
-        /// <param name="paramName">The name of the parameter.</param>
-        /// <returns>
-        /// The guarded parameter.
-        /// </returns>
-        [DebuggerStepThrough]
-        public static TimeSpan NotNegative(TimeSpan parameter, string paramName)
-            => parameter < TimeSpan.Zero
-            ? throw new ArgumentOutOfRangeException(paramName, Messages.ArgumentOutOfRangeException_Negative)
-            : parameter;
-
-        /// <summary>Messages class to group the constants.</summary>
-        private static class Messages
-        {
-            public const string ArgumentException_EmptyCollection = "Argument cannot be an empty collection.";
-            public const string ArgumentException_GuidEmpty = "Argument cannot be an empty GUID.";
-            public const string ArgumentException_IsDefaultValue = "Argument is the not initialized/default value.";
-            public const string ArgumentException_NotAnInstanceOf = "Argument is not an instance of {0}.";
-            public const string ArgumentException_NullableMustHaveValue = "Nullable argument must have a value.";
-            public const string ArgumentException_StringEmpty = "Argument cannot be an empty string.";
-            public const string ArgumentOutOfRangeException_InCollection = "Argument was in the collection of forbidden values. Forbidden are {0}.";
-            public const string ArgumentOutOfRangeException_NotInCollection = "Argument was not in the collection of allowed values. Allowed are {0}.";
-            public const string ArgumentOutOfRangeException_DefinedEnum = "Argument {0} is not a defined value of {1}.";
-            public const string ArgumentOutOfRangeException_Negative = "Argument should not be negative.";
-            public const string ArgumentOutOfRangeException_NotPositive = "Argument should be positive.";
-        }
-
-        /// <summary>Marks the NotNull argument as being validated for not being null, to satisfy the static code analysis.</summary>
-        /// <remarks>
-        /// Notice that it does not matter what this attribute does, as long as
-        /// it is named ValidatedNotNullAttribute.
-        ///
-        /// It is marked as conditional, as does not add anything to have the attribute compiled.
-        /// </remarks>
-        [Conditional("Analysis")]
-        [AttributeUsage(AttributeTargets.Parameter)]
-        private sealed class ValidatedNotNullAttribute : Attribute { }
+        public const string ArgumentException_EmptyCollection = "Argument cannot be an empty collection.";
+        public const string ArgumentException_GuidEmpty = "Argument cannot be an empty GUID.";
+        public const string ArgumentException_IsDefaultValue = "Argument is the not initialized/default value.";
+        public const string ArgumentException_NotAnInstanceOf = "Argument is not an instance of {0}.";
+        public const string ArgumentException_NullableMustHaveValue = "Nullable argument must have a value.";
+        public const string ArgumentException_StringEmpty = "Argument cannot be an empty string.";
+        public const string ArgumentOutOfRangeException_InCollection = "Argument was in the collection of forbidden values. Forbidden are {0}.";
+        public const string ArgumentOutOfRangeException_NotInCollection = "Argument was not in the collection of allowed values. Allowed are {0}.";
+        public const string ArgumentOutOfRangeException_DefinedEnum = "Argument {0} is not a defined value of {1}.";
+        public const string ArgumentOutOfRangeException_Negative = "Argument should not be negative.";
+        public const string ArgumentOutOfRangeException_NotPositive = "Argument should be positive.";
     }
+
+    /// <summary>Marks the NotNull argument as being validated for not being null, to satisfy the static code analysis.</summary>
+    /// <remarks>
+    /// Notice that it does not matter what this attribute does, as long as
+    /// it is named ValidatedNotNullAttribute.
+    ///
+    /// It is marked as conditional, as does not add anything to have the attribute compiled.
+    /// </remarks>
+    [Conditional("Analysis")]
+    [AttributeUsage(AttributeTargets.Parameter)]
+    private sealed class ValidatedNotNullAttribute : Attribute { }
 }

--- a/specs/Qowaiv.Specs/Financial/Amount_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Amount_specs.cs
@@ -58,4 +58,14 @@ namespace Financial.Amount_specs
             => Converting.To<double>().From(Svo.Amount).Should().Be(42.17);
     }
 
+
+    public class Has_operators
+    {
+        [Test]
+        public void to_divide_amount_by_amount_as_decimal()
+        {
+            var ratio = Svo.Amount / 2.Amount();
+            ratio.Should().Be(21.085m);
+        }
+    }
 }

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -404,9 +404,9 @@ namespace Percentage_specs
     public class Casts
     {
         [Test]
-        public void explicitly_from_decimal()
+        public void immplictly_from_decimal()
         {
-            var casted = (Percentage)0.1751m;
+            Percentage casted = 0.1751m;
             Assert.AreEqual(Svo.Percentage, casted);
         }
 

--- a/specs/Qowaiv.Specs/Svo.cs
+++ b/specs/Qowaiv.Specs/Svo.cs
@@ -60,7 +60,7 @@ public static class Svo
     public static readonly Timestamp Timestamp = 1234567890L;
     public static readonly Uuid Uuid = Uuid.Parse("Qowaiv_SVOLibrary_GUIA");
     public static readonly WeekDate WeekDate = new(2017, 23, 7);
-    public static readonly Year Year = 1979.Year();
+    public static readonly Year Year = 1979.CE();
     public static readonly YesNo YesNo = YesNo.Yes;
 
     /// <summary>PREFIX17</summary>

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -138,14 +138,14 @@ namespace Year_specs
         [Test]
         public void MinValue_represents_1()
         {
-            Year min = 1.Year();
+            Year min = 1.CE();
             Assert.AreEqual(min, Year.MinValue);
         }
 
         [Test]
         public void MaxValue_represents_9999()
         {
-            Year max = 9999.Year();
+            Year max = 9999.CE();
             Assert.AreEqual(max, Year.MaxValue);
         }
     }
@@ -167,38 +167,38 @@ namespace Year_specs
         [Test]
         public void not_equal_to_different_value()
         {
-            Year other = 2017.Year();
+            Year other = 2017.CE();
             Assert.IsFalse(Svo.Year.Equals(other));
         }
 
         [Test]
         public void equal_to_same_value()
         {
-            Assert.IsTrue(Svo.Year.Equals(1979.Year()));
+            Assert.IsTrue(Svo.Year.Equals(1979.CE()));
         }
 
         [Test]
         public void equal_operator_returns_true_for_same_values()
         {
-            Assert.IsTrue(Svo.Year == 1979.Year());
+            Assert.IsTrue(Svo.Year == 1979.CE());
         }
 
         [Test]
         public void equal_operator_returns_false_for_different_values()
         {
-            Assert.IsFalse(Svo.Year == 2017.Year());
+            Assert.IsFalse(Svo.Year == 2017.CE());
         }
 
         [Test]
         public void not_equal_operator_returns_false_for_same_values()
         {
-            Assert.IsFalse(Svo.Year != 1979.Year());
+            Assert.IsFalse(Svo.Year != 1979.CE());
         }
 
         [Test]
         public void not_equal_operator_returns_true_for_different_values()
         {
-            Assert.IsTrue(Svo.Year != 2017.Year());
+            Assert.IsTrue(Svo.Year != 2017.CE());
         }
 
         [TestCase("", 0)]
@@ -364,9 +364,9 @@ namespace Year_specs
             {
                 default, 
                 default,
-                1970.Year(),
-                1971.Year(),
-                1972.Year(),
+                1970.CE(),
+                1971.CE(),
+                1972.CE(),
                 Year.Unknown,
             };
             var list = new List<Year> { sorted[3], sorted[5], sorted[4], sorted[2], sorted[0], sorted[1] };
@@ -377,8 +377,8 @@ namespace Year_specs
         [Test]
         public void by_operators_for_different_values()
         {
-            Year smaller = 1979.Year();
-            Year bigger = 2017.Year();
+            Year smaller = 1979.CE();
+            Year bigger = 2017.CE();
 
             Assert.IsTrue(smaller < bigger);
             Assert.IsTrue(smaller <= bigger);
@@ -389,8 +389,8 @@ namespace Year_specs
         [Test]
         public void by_operators_for_equal_values()
         {
-            Year left = 2071.Year();
-            Year right = 2071.Year();
+            Year left = 2071.CE();
+            Year right = 2071.CE();
 
             Assert.IsFalse(left < right);
             Assert.IsTrue(left <= right);

--- a/src/Qowaiv/Conversion/GenderTypeConverter.cs
+++ b/src/Qowaiv/Conversion/GenderTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a Gender.</summary>
+[Obsolete("Will be dropped in version 7. Use Qowaiv.Sex instead.")]
 public class GenderTypeConverter : SvoTypeConverter<Gender>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Extensions/Humanizer.Year.cs
+++ b/src/Qowaiv/Extensions/Humanizer.Year.cs
@@ -1,9 +1,9 @@
 ﻿namespace Qowaiv;
 
-/// <summary>Extensions to create <see cref="Qowaiv.Year"/>s, inspired by Humanizer.NET.</summary>
+/// <summary>Extensions to create <see cref="Year"/>s, inspired by Humanizer.NET.</summary>
 public static class NumberToYearExtensions
 {
-    /// <summary>Create a <see cref="Qowaiv.Year"/> from a <see cref="int"/>.</summary>
+    /// <summary>Create a <see cref="Year"/> from a <see cref="int"/>  as Common Era. (also known as Anno Domini).</summary>
     [Pure]
-    public static Year Year(this int year) => Qowaiv.Year.Create(year);
+    public static Year CE(this int year) => Year.Create(year);
 }

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -329,6 +329,9 @@ public partial struct Amount : ISerializable, IXmlSerializable, IFormattable, IE
     [CLSCompliant(false)]
     public static Amount operator *(Amount amount, ushort factor) => amount.Multiply(factor);
 
+    /// <summary>Divides the amount by an other amount.</summary>
+    public static decimal operator /(Amount numerator, Amount denominator) => numerator.m_Value / denominator.m_Value;
+
     /// <summary>Divides the amount by the percentage.</summary>
     public static Amount operator /(Amount amount, Percentage p) => amount.Divide(p);
     /// <summary>Divides the amount by the factor.</summary>

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -640,7 +640,7 @@ public partial struct Percentage : ISerializable, IXmlSerializable, IFormattable
     #region (Explicit) casting
 
     /// <summary>Casts a decimal a Percentage.</summary>
-    public static explicit operator Percentage(decimal val) => Create(val);
+    public static implicit operator Percentage(decimal val) => new(val);
 
     /// <summary>Casts a decimal a Percentage.</summary>
     public static explicit operator Percentage(double val) => Create(val);


### PR DESCRIPTION
- [x] Decided to keep the implicit cast from `decimal` to `Percentage`
- [x] Humanized method to create a year renamoed to `.EC()`
- [x] Added / operator for Amounts (resulting in a decimal)