### PR TITLE
Support casts between Qowaiv.Date and System.DateOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ var next = date++; // 2017-06-12
 var casted = (Date)new DateTime(2017, 06, 11, 06, 15);
 ```
 
+As, since .NET 6.0, `System.DateOnly` is available, `Qowaiv.Date` can be casted to (and from)
+this type, if (and only if), the .NET 6.0 version of the package is usaged.
+
 ### Date span
 Represents a date span. Opposed to a `TimeSpan` its duration is (a bit) resilient;
 Adding one month to a date in January result in adding a different number of days, 

--- a/specs/Qowaiv.Specs/Date_specs.cs
+++ b/specs/Qowaiv.Specs/Date_specs.cs
@@ -1,123 +1,129 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv;
-using Qowaiv.Hashing;
-using Qowaiv.Specs;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Globalization;
+﻿namespace Date_specs;
 
-namespace Date_specs
+public class Is_equal_by_value
 {
-    public class Is_equal_by_value
+    [Test]
+    public void not_equal_to_null()
+        => Svo.Date.Equals(null).Should().BeFalse();
+
+    [Test]
+    public void not_equal_to_other_type()
+        => Svo.Date.Equals(new object()).Should().BeFalse();
+
+    [Test]
+    public void not_equal_to_different_value()
+        => Svo.Date.Equals(Date.MinValue).Should().BeFalse();
+
+    [Test]
+    public void equal_to_same_value()
+        => Svo.Date.Equals(new Date(2017, 06, 11)).Should().BeTrue();
+
+    [Test]
+    public void equal_operator_returns_true_for_same_values()
+        => (new Date(2017, 06, 11) == Svo.Date).Should().BeTrue();
+
+    [Test]
+    public void equal_operator_returns_false_for_different_values()
+        => (new Date(2017, 06, 11) == Date.MinValue).Should().BeFalse();
+
+    [Test]
+    public void not_equal_operator_returns_false_for_same_values()
+        => (new Date(2017, 06, 11) != Svo.Date).Should().BeFalse();
+
+    [Test]
+    public void not_equal_operator_returns_true_for_different_values()
+        => (new Date(2017, 06, 11) != Date.MinValue).Should().BeTrue();
+
+    [TestCase("0001-01-01", 0)]
+    [TestCase("2017-06-11", -489585265)]
+    public void hash_code_is_value_based(Date svo, int hash)
     {
-        [Test]
-        public void not_equal_to_null()
-            => Svo.Date.Equals(null).Should().BeFalse();
-
-        [Test]
-        public void not_equal_to_other_type()
-            => Svo.Date.Equals(new object()).Should().BeFalse();
-
-        [Test]
-        public void not_equal_to_different_value()
-            => Svo.Date.Equals(Date.MinValue).Should().BeFalse();
-
-        [Test]
-        public void equal_to_same_value()
-            => Svo.Date.Equals(new Date(2017, 06, 11)).Should().BeTrue();
-
-        [Test]
-        public void equal_operator_returns_true_for_same_values()
-            => (new Date(2017, 06, 11) == Svo.Date).Should().BeTrue();
-
-        [Test]
-        public void equal_operator_returns_false_for_different_values()
-            => (new Date(2017, 06, 11) == Date.MinValue).Should().BeFalse();
-
-        [Test]
-        public void not_equal_operator_returns_false_for_same_values()
-            => (new Date(2017, 06, 11) != Svo.Date).Should().BeFalse();
-
-        [Test]
-        public void not_equal_operator_returns_true_for_different_values()
-            => (new Date(2017, 06, 11) != Date.MinValue).Should().BeTrue();
-
-        [TestCase("0001-01-01", 0)]
-        [TestCase("2017-06-11", -489585265)]
-        public void hash_code_is_value_based(Date svo, int hash)
+        using (Hash.WithoutRandomizer())
         {
-            using (Hash.WithoutRandomizer())
-            {
-                svo.GetHashCode().Should().Be(hash);
-            }
+            svo.GetHashCode().Should().Be(hash);
+        }
+    }
+}
+
+public class Supports_type_conversion
+{
+    [Test]
+    public void via_TypeConverter_registered_with_attribute()
+        => typeof(Date).Should().HaveTypeConverterDefined();
+
+    [Test]
+    public void from_null_string()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Converting.From<string>(null).To<Date>().Should().Be(default);
         }
     }
 
-    public class Supports_type_conversion
+    [Test]
+    public void from_string()
     {
-        [Test]
-        public void via_TypeConverter_registered_with_attribute()
-            => typeof(Date).Should().HaveTypeConverterDefined();
-
-        [Test]
-        public void from_null_string()
+        using (TestCultures.En_GB.Scoped())
         {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Converting.From<string>(null).To<Date>().Should().Be(default);
-            }
+            Converting.From("2017-06-11").To<Date>().Should().Be(Svo.Date);
         }
+    }
 
-        [Test]
-        public void from_string()
+    [Test]
+    public void to_string()
+    {
+        using (TestCultures.En_GB.Scoped())
         {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Converting.From("2017-06-11").To<Date>().Should().Be(Svo.Date);
-            }
+            Converting.ToString().From(Svo.Date).Should().Be("11/06/2017");
         }
+    }
 
-        [Test]
-        public void to_string()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Converting.ToString().From(Svo.Date).Should().Be("11/06/2017");
-            }
-        }
+    [Test]
+    public void from_DateTime()
+        => Converting.From(new DateTime(2017, 06, 11)).To<Date>().Should().Be(Svo.Date);
 
-        [Test]
-        public void from_DateTime()
-            => Converting.From(new DateTime(2017, 06, 11)).To<Date>().Should().Be(Svo.Date);
+    [Test]
+    public void from_DateTimeOffset()
+        => Converting.From(new DateTimeOffset(2017, 06, 11, 00, 00, 00, TimeSpan.Zero)).To<Date>().Should().Be(Svo.Date);
 
-        [Test]
-        public void from_DateTimeOffset()
-            => Converting.From(new DateTimeOffset(2017, 06, 11, 00, 00, 00, TimeSpan.Zero)).To<Date>().Should().Be(Svo.Date);
+    [Test]
+    public void from_LocalDateTime()
+        => Converting.From(new LocalDateTime(2017, 06, 11)).To<Date>().Should().Be(Svo.Date);
 
-        [Test]
-        public void from_LocalDateTime()
-            => Converting.From(new LocalDateTime(2017, 06, 11)).To<Date>().Should().Be(Svo.Date);
+    [Test]
+    public void from_WeekDate()
+        => Converting.From(new WeekDate(2017, 23, 7)).To<Date>().Should().Be(Svo.Date);
 
-        [Test]
-        public void from_WeekDate()
-            => Converting.From(new WeekDate(2017, 23, 7)).To<Date>().Should().Be(Svo.Date);
+    [Test]
+    public void to_DateTime()
+        => Converting.To<DateTime>().From(Svo.Date).Should().Be(new DateTime(2017, 06, 11));
 
-        [Test]
-        public void to_DateTime()
-            => Converting.To<DateTime>().From(Svo.Date).Should().Be(new DateTime(2017, 06, 11));
+    [Test]
+    public void to_DateTimeOffset()
+        => Converting.To<DateTimeOffset>().From(Svo.Date).Should().Be(new DateTimeOffset(2017, 06, 11, 00, 00, 00, TimeSpan.Zero));
 
-        [Test]
-        public void to_DateTimeOffset()
-            => Converting.To<DateTimeOffset>().From(Svo.Date).Should().Be(new DateTimeOffset(2017, 06, 11, 00, 00, 00, TimeSpan.Zero));
+    [Test]
+    public void to_LocalDateTime()
+        => Converting.To<LocalDateTime>().From(Svo.Date).Should().Be(new LocalDateTime(2017, 06, 11));
 
-        [Test]
-        public void to_LocalDateTime()
-            => Converting.To<LocalDateTime>().From(Svo.Date).Should().Be(new LocalDateTime(2017, 06, 11));
+    [Test]
+    public void to_WeekDate()
+        => Converting.To<WeekDate>().From(Svo.Date).Should().Be(new WeekDate(2017, 23, 7));
+}
 
-        [Test]
-        public void to_WeekDate()
-            => Converting.To<WeekDate>().From(Svo.Date).Should().Be(new WeekDate(2017, 23, 7));
+public class Casts_with_dotnet_6_0
+{
+    [Test]
+    public void implictly_from_DateOnly()
+    {
+        DateOnly casted = Svo.Date;
+        casted.Should().Be(new DateOnly(2017, 06, 11));
+    }
+
+    [Test]
+    public void explicitly_to_DateOnly()
+    {
+        var casted = (Date)new DateOnly(2017,06,11);
+        casted.Should().Be(Svo.Date);
     }
 }

--- a/src/Qowaiv/Date.net6.0.cs
+++ b/src/Qowaiv/Date.net6.0.cs
@@ -1,0 +1,13 @@
+﻿#if NET6_0_OR_GREATER
+
+namespace Qowaiv;
+
+public partial struct Date
+{
+    /// <summary>Casts a <see cref="Date"/> implictly to a <see cref="DateOnly"/>.</summary>
+    public static implicit operator DateOnly(Date date) => new(date.Year, date.Month, date.Day);
+
+    /// <summary>Casts a <see cref="DateOnly"/> explicitly to a <see cref="Date"/>.</summary>
+    public static explicit operator Date(DateOnly date) => new(date.Year, date.Month, date.Day);
+}
+#endif


### PR DESCRIPTION
Future releases might even flag Qowaiv.Date as obsolete (when net6.0 or higher) but for now: allow casting.