### PR TITLE
Support Money divided by money as ratio

### DIFF
--- a/specs/Qowaiv.Specs/Financial/Money_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Money_specs.cs
@@ -1,35 +1,43 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Financial;
-using Qowaiv.Specs;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System.Globalization;
+﻿namespace Financial.Money_specs;
 
-namespace Financial.Money_specs
+public class Supports_type_conversion
 {
-    public class Supports_type_conversion
+    [Test]
+    public void via_TypeConverter_registered_with_attribute()
+       => typeof(Money).Should().HaveTypeConverterDefined();
+
+    [Test]
+    public void from_string()
     {
-        [Test]
-        public void via_TypeConverter_registered_with_attribute()
-           => typeof(Money).Should().HaveTypeConverterDefined();
-
-        [Test]
-        public void from_string()
+        using (TestCultures.En_GB.Scoped())
         {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Converting.From("€42.17").To<Money>().Should().Be(Svo.Money);
-            }
+            Converting.From("€42.17").To<Money>().Should().Be(Svo.Money);
         }
+    }
 
-        [Test]
-        public void to_string()
+    [Test]
+    public void to_string()
+    {
+        using (TestCultures.En_GB.Scoped())
         {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Converting.ToString().From(Svo.Money).Should().Be("€42.17");
-            }
+            Converting.ToString().From(Svo.Money).Should().Be("€42.17");
         }
+    }
+}
+
+public class Has_operators
+{
+    [Test]
+    public void to_divide_money_by_money_with_same_currency_as_decimal()
+    {
+        var ratio = Svo.Money / (16 + Currency.EUR);
+        ratio.Should().Be(2.635625m);
+    }
+
+    [Test]
+    public void to_divide_money_by_money_with_diffrent_currencies_is_not_supported()
+    {
+        Func<decimal> division =  () => Svo.Money / (16 + Currency.USD);
+        division.Should().Throw<CurrencyMismatchException>();
     }
 }

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -248,6 +248,18 @@ public partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEq
     [Pure]
     public Money Divide(ushort factor) => Divide((decimal)factor);
 
+    /// <summary>Divides the money by a specified factor.
+    /// </summary>
+    /// <param name="denominator">
+    /// The factor to multiply with.
+    /// </param>
+    [Pure]
+    private decimal Divide(Money denominator)
+    {
+        _ = HaveSameCurrency(this, denominator, "division");
+        return m_Value / denominator.m_Value;
+    }
+
     /// <summary>Rounds the money value to the preferred number decimal places, based on its currency.</summary>
     [Pure]
     public Money Round() => Round(Currency.Digits);
@@ -371,6 +383,9 @@ public partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEq
     /// <summary>Divides the money by the factor.</summary>
     [CLSCompliant(false)]
     public static Money operator /(Money money, ushort factor) => money.Divide(factor);
+
+    /// <summary>Divides  money by money to get there ratio.</summary>
+    public static decimal operator /(Money numerator, Money denominator) => numerator.Divide(denominator);
 
     [DebuggerStepThrough]
     [Pure]


### PR DESCRIPTION
To get the ratio between two amounts (of money).