### PR TITLE
Simplify generated code

### DIFF
--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -6,37 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-
 namespace Qowaiv.Sql;
 
 public partial struct Timestamp
 {
-#if !NotField
     private Timestamp(ulong value) => m_Value = value;
 
     /// <summary>The inner value of the timestamp.</summary>
     private ulong m_Value;
-#endif
 
-#if !NotIsEmpty
-    /// <summary>Returns true if the  timestamp is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  timestamp is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  timestamp is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Timestamp : IEquatable<Timestamp>
@@ -45,18 +23,15 @@ public partial struct Timestamp : IEquatable<Timestamp>
     [Pure]
     public override bool Equals(object obj) => obj is Timestamp other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other timestamp are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Timestamp" /> to compare with.</param>
     [Pure]
     public bool Equals(Timestamp other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -78,12 +53,9 @@ public partial struct Timestamp : IComparable, IComparable<Timestamp>
         else if (obj is Timestamp other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Timestamp other) => Comparer<ulong>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(Timestamp l, Timestamp r) => l.CompareTo(r) < 0;
 
@@ -95,7 +67,6 @@ public partial struct Timestamp : IComparable, IComparable<Timestamp>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(Timestamp l, Timestamp r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Timestamp : IFormattable
@@ -146,13 +117,8 @@ public partial struct Timestamp
     /// <returns>
     /// The deserialized timestamp.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Timestamp FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Timestamp FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Timestamp : IXmlSerializable
@@ -170,17 +136,11 @@ public partial struct Timestamp : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Timestamp other);
+    partial void OnReadXml(Timestamp value);
 
     /// <summary>Writes the timestamp to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -193,7 +153,6 @@ public partial struct Timestamp : IXmlSerializable
 
 public partial struct Timestamp
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
     /// <param name="s">
     /// A string containing the timestamp to convert.
@@ -260,35 +219,10 @@ public partial struct Timestamp
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Timestamp result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
-    /// <param name="s">
-    /// A string containing the timestamp to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed timestamp.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Timestamp Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionTimestamp);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
-    /// <param name="s">
-    /// A string containing the timestamp to convert.
-    /// </param>
-    /// <returns>
-    /// The timestamp if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Timestamp? TryParse(string s) => TryParse(s, out Timestamp val) ? val : default(Timestamp?);
-#endif
 }
 
 public partial struct Timestamp
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid timestamp.</summary>
     /// <param name="val">
@@ -308,15 +242,5 @@ public partial struct Timestamp
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid timestamp.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -6,38 +6,11 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotField
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-
 namespace Qowaiv;
 
 public partial struct Date
 {
-#if !NotField
-    private Date(DateTime value) => m_Value = value;
 
-    /// <summary>The inner value of the date.</summary>
-    private DateTime m_Value;
-#endif
-
-#if !NotIsEmpty
-    /// <summary>Returns true if the  date is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  date is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  date is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Date : IEquatable<Date>
@@ -46,18 +19,15 @@ public partial struct Date : IEquatable<Date>
     [Pure]
     public override bool Equals(object obj) => obj is Date other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other date are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Date" /> to compare with.</param>
     [Pure]
     public bool Equals(Date other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -79,12 +49,9 @@ public partial struct Date : IComparable, IComparable<Date>
         else if (obj is Date other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Date other) => Comparer<DateTime>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(Date l, Date r) => l.CompareTo(r) < 0;
 
@@ -96,7 +63,6 @@ public partial struct Date : IComparable, IComparable<Date>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(Date l, Date r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Date : IFormattable
@@ -147,13 +113,8 @@ public partial struct Date
     /// <returns>
     /// The deserialized date.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Date FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Date FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Date : IXmlSerializable
@@ -171,17 +132,10 @@ public partial struct Date : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
-        m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Date other);
+    partial void OnReadXml(Date value);
 
     /// <summary>Writes the date to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -194,7 +148,6 @@ public partial struct Date : IXmlSerializable
 
 public partial struct Date
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
     /// <param name="s">
     /// A string containing the date to convert.
@@ -261,35 +214,10 @@ public partial struct Date
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Date result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
-    /// <param name="s">
-    /// A string containing the date to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed date.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Date Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionDate);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
-    /// <param name="s">
-    /// A string containing the date to convert.
-    /// </param>
-    /// <returns>
-    /// The date if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Date? TryParse(string s) => TryParse(s, out Date val) ? val : default(Date?);
-#endif
 }
 
 public partial struct Date
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid date.</summary>
     /// <param name="val">
@@ -309,15 +237,5 @@ public partial struct Date
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid date.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -6,38 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-#define NotEqualsSvo
-
 namespace Qowaiv;
 
 public partial struct DateSpan
 {
-#if !NotField
     private DateSpan(ulong value) => m_Value = value;
 
     /// <summary>The inner value of the date span.</summary>
     private ulong m_Value;
-#endif
 
-#if !NotIsEmpty
-    /// <summary>Returns true if the  date span is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  date span is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  date span is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct DateSpan : IEquatable<DateSpan>
@@ -46,18 +23,6 @@ public partial struct DateSpan : IEquatable<DateSpan>
     [Pure]
     public override bool Equals(object obj) => obj is DateSpan other && Equals(other);
 
-#if !NotEqualsSvo
-    /// <summary>Returns true if this instance and the other date span are equal, otherwise false.</summary>
-    /// <param name="other">The <see cref="DateSpan" /> to compare with.</param>
-    [Pure]
-    public bool Equals(DateSpan other) => m_Value == other.m_Value;
-
-#if !NotGetHashCode
-    /// <inheritdoc />
-    [Pure]
-    public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -79,12 +44,6 @@ public partial struct DateSpan : IComparable, IComparable<DateSpan>
         else if (obj is DateSpan other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
-    /// <inheritdoc />
-    [Pure]
-    public int CompareTo(DateSpan other) => Comparer<ulong>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(DateSpan l, DateSpan r) => l.CompareTo(r) < 0;
 
@@ -96,7 +55,6 @@ public partial struct DateSpan : IComparable, IComparable<DateSpan>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(DateSpan l, DateSpan r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct DateSpan : IFormattable
@@ -147,13 +105,8 @@ public partial struct DateSpan
     /// <returns>
     /// The deserialized date span.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static DateSpan FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static DateSpan FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct DateSpan : IXmlSerializable
@@ -171,17 +124,11 @@ public partial struct DateSpan : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(DateSpan other);
+    partial void OnReadXml(DateSpan value);
 
     /// <summary>Writes the date span to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -194,7 +141,6 @@ public partial struct DateSpan : IXmlSerializable
 
 public partial struct DateSpan
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
     /// <param name="s">
     /// A string containing the date span to convert.
@@ -261,35 +207,10 @@ public partial struct DateSpan
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out DateSpan result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
-    /// <param name="s">
-    /// A string containing the date span to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed date span.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static DateSpan Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionDateSpan);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
-    /// <param name="s">
-    /// A string containing the date span to convert.
-    /// </param>
-    /// <returns>
-    /// The date span if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static DateSpan? TryParse(string s) => TryParse(s, out DateSpan val) ? val : default(DateSpan?);
-#endif
 }
 
 public partial struct DateSpan
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid date span.</summary>
     /// <param name="val">
@@ -309,15 +230,5 @@ public partial struct DateSpan
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid date span.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv;
 
 public partial struct EmailAddress
 {
-#if !NotField
     private EmailAddress(string value) => m_Value = value;
 
     /// <summary>The inner value of the email address.</summary>
     private string m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  email address is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  email address is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  email address is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct EmailAddress : IEquatable<EmailAddress>
@@ -43,18 +32,15 @@ public partial struct EmailAddress : IEquatable<EmailAddress>
     [Pure]
     public override bool Equals(object obj) => obj is EmailAddress other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other email address are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="EmailAddress" /> to compare with.</param>
     [Pure]
     public bool Equals(EmailAddress other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct EmailAddress : IComparable, IComparable<EmailAddress>
         else if (obj is EmailAddress other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(EmailAddress other) => Comparer<string>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(EmailAddress l, EmailAddress r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(EmailAddress l, EmailAddress r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(EmailAddress l, EmailAddress r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(EmailAddress l, EmailAddress r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct EmailAddress : IFormattable
@@ -144,13 +115,8 @@ public partial struct EmailAddress
     /// <returns>
     /// The deserialized email address.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static EmailAddress FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static EmailAddress FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct EmailAddress : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct EmailAddress : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(EmailAddress other);
+    partial void OnReadXml(EmailAddress value);
 
     /// <summary>Writes the email address to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct EmailAddress : IXmlSerializable
 
 public partial struct EmailAddress
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
     /// <param name="s">
     /// A string containing the email address to convert.
@@ -258,35 +217,10 @@ public partial struct EmailAddress
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out EmailAddress result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
-    /// <param name="s">
-    /// A string containing the email address to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed email address.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static EmailAddress Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionEmailAddress);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
-    /// <param name="s">
-    /// A string containing the email address to convert.
-    /// </param>
-    /// <returns>
-    /// The email address if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static EmailAddress? TryParse(string s) => TryParse(s, out EmailAddress val) ? val : default(EmailAddress?);
-#endif
 }
 
 public partial struct EmailAddress
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid email address.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct EmailAddress
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid email address.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -6,37 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-
 namespace Qowaiv.Financial;
 
 public partial struct Amount
 {
-#if !NotField
     private Amount(decimal value) => m_Value = value;
 
     /// <summary>The inner value of the amount.</summary>
     private decimal m_Value;
-#endif
 
-#if !NotIsEmpty
-    /// <summary>Returns true if the  amount is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  amount is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  amount is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Amount : IEquatable<Amount>
@@ -45,18 +23,15 @@ public partial struct Amount : IEquatable<Amount>
     [Pure]
     public override bool Equals(object obj) => obj is Amount other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other amount are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Amount" /> to compare with.</param>
     [Pure]
     public bool Equals(Amount other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -78,12 +53,9 @@ public partial struct Amount : IComparable, IComparable<Amount>
         else if (obj is Amount other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Amount other) => Comparer<decimal>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(Amount l, Amount r) => l.CompareTo(r) < 0;
 
@@ -95,7 +67,6 @@ public partial struct Amount : IComparable, IComparable<Amount>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(Amount l, Amount r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Amount : IFormattable
@@ -146,13 +117,8 @@ public partial struct Amount
     /// <returns>
     /// The deserialized amount.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Amount FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Amount FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Amount : IXmlSerializable
@@ -170,17 +136,11 @@ public partial struct Amount : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Amount other);
+    partial void OnReadXml(Amount value);
 
     /// <summary>Writes the amount to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -193,7 +153,6 @@ public partial struct Amount : IXmlSerializable
 
 public partial struct Amount
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
     /// <param name="s">
     /// A string containing the amount to convert.
@@ -260,35 +219,10 @@ public partial struct Amount
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Amount result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
-    /// <param name="s">
-    /// A string containing the amount to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed amount.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Amount Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionFinancialAmount);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
-    /// <param name="s">
-    /// A string containing the amount to convert.
-    /// </param>
-    /// <returns>
-    /// The amount if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Amount? TryParse(string s) => TryParse(s, out Amount val) ? val : default(Amount?);
-#endif
 }
 
 public partial struct Amount
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid amount.</summary>
     /// <param name="val">
@@ -308,15 +242,5 @@ public partial struct Amount
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid amount.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv.Financial;
 
 public partial struct BusinessIdentifierCode
 {
-#if !NotField
     private BusinessIdentifierCode(string value) => m_Value = value;
 
     /// <summary>The inner value of the BIC.</summary>
     private string m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  BIC is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  BIC is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  BIC is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct BusinessIdentifierCode : IEquatable<BusinessIdentifierCode>
@@ -43,18 +32,15 @@ public partial struct BusinessIdentifierCode : IEquatable<BusinessIdentifierCode
     [Pure]
     public override bool Equals(object obj) => obj is BusinessIdentifierCode other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other BIC are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="BusinessIdentifierCode" /> to compare with.</param>
     [Pure]
     public bool Equals(BusinessIdentifierCode other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct BusinessIdentifierCode : IComparable, IComparable<Business
         else if (obj is BusinessIdentifierCode other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(BusinessIdentifierCode other) => Comparer<string>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(BusinessIdentifierCode l, BusinessIdentifierCode r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(BusinessIdentifierCode l, BusinessIdentifierCode r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(BusinessIdentifierCode l, BusinessIdentifierCode r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(BusinessIdentifierCode l, BusinessIdentifierCode r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct BusinessIdentifierCode : IFormattable
@@ -144,13 +115,8 @@ public partial struct BusinessIdentifierCode
     /// <returns>
     /// The deserialized BIC.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static BusinessIdentifierCode FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static BusinessIdentifierCode FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct BusinessIdentifierCode : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct BusinessIdentifierCode : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(BusinessIdentifierCode other);
+    partial void OnReadXml(BusinessIdentifierCode value);
 
     /// <summary>Writes the BIC to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct BusinessIdentifierCode : IXmlSerializable
 
 public partial struct BusinessIdentifierCode
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
     /// <param name="s">
     /// A string containing the BIC to convert.
@@ -258,35 +217,10 @@ public partial struct BusinessIdentifierCode
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out BusinessIdentifierCode result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
-    /// <param name="s">
-    /// A string containing the BIC to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed BIC.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static BusinessIdentifierCode Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionBusinessIdentifierCode);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
-    /// <param name="s">
-    /// A string containing the BIC to convert.
-    /// </param>
-    /// <returns>
-    /// The BIC if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static BusinessIdentifierCode? TryParse(string s) => TryParse(s, out BusinessIdentifierCode val) ? val : default(BusinessIdentifierCode?);
-#endif
 }
 
 public partial struct BusinessIdentifierCode
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid BIC.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct BusinessIdentifierCode
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid BIC.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv.Financial;
 
 public partial struct Currency
 {
-#if !NotField
     private Currency(string value) => m_Value = value;
 
     /// <summary>The inner value of the currency.</summary>
     private string m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  currency is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  currency is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  currency is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Currency : IEquatable<Currency>
@@ -43,18 +32,15 @@ public partial struct Currency : IEquatable<Currency>
     [Pure]
     public override bool Equals(object obj) => obj is Currency other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other currency are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Currency" /> to compare with.</param>
     [Pure]
     public bool Equals(Currency other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct Currency : IComparable, IComparable<Currency>
         else if (obj is Currency other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Currency other) => Comparer<string>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(Currency l, Currency r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(Currency l, Currency r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(Currency l, Currency r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(Currency l, Currency r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Currency : IFormattable
@@ -144,13 +115,8 @@ public partial struct Currency
     /// <returns>
     /// The deserialized currency.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Currency FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Currency FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Currency : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct Currency : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Currency other);
+    partial void OnReadXml(Currency value);
 
     /// <summary>Writes the currency to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct Currency : IXmlSerializable
 
 public partial struct Currency
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
     /// <param name="s">
     /// A string containing the currency to convert.
@@ -258,35 +217,10 @@ public partial struct Currency
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Currency result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
-    /// <param name="s">
-    /// A string containing the currency to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed currency.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Currency Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionCurrency);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
-    /// <param name="s">
-    /// A string containing the currency to convert.
-    /// </param>
-    /// <returns>
-    /// The currency if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Currency? TryParse(string s) => TryParse(s, out Currency val) ? val : default(Currency?);
-#endif
 }
 
 public partial struct Currency
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid currency.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct Currency
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid currency.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv.Financial;
 
 public partial struct InternationalBankAccountNumber
 {
-#if !NotField
     private InternationalBankAccountNumber(string value) => m_Value = value;
 
     /// <summary>The inner value of the IBAN.</summary>
     private string m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  IBAN is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  IBAN is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  IBAN is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct InternationalBankAccountNumber : IEquatable<InternationalBankAccountNumber>
@@ -43,18 +32,15 @@ public partial struct InternationalBankAccountNumber : IEquatable<InternationalB
     [Pure]
     public override bool Equals(object obj) => obj is InternationalBankAccountNumber other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other IBAN are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="InternationalBankAccountNumber" /> to compare with.</param>
     [Pure]
     public bool Equals(InternationalBankAccountNumber other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct InternationalBankAccountNumber : IComparable, IComparable<
         else if (obj is InternationalBankAccountNumber other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(InternationalBankAccountNumber other) => Comparer<string>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(InternationalBankAccountNumber l, InternationalBankAccountNumber r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(InternationalBankAccountNumber l, InternationalBankAccountNumber r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(InternationalBankAccountNumber l, InternationalBankAccountNumber r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(InternationalBankAccountNumber l, InternationalBankAccountNumber r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct InternationalBankAccountNumber : IFormattable
@@ -144,13 +115,8 @@ public partial struct InternationalBankAccountNumber
     /// <returns>
     /// The deserialized IBAN.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static InternationalBankAccountNumber FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static InternationalBankAccountNumber FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct InternationalBankAccountNumber : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct InternationalBankAccountNumber : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(InternationalBankAccountNumber other);
+    partial void OnReadXml(InternationalBankAccountNumber value);
 
     /// <summary>Writes the IBAN to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct InternationalBankAccountNumber : IXmlSerializable
 
 public partial struct InternationalBankAccountNumber
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
     /// <param name="s">
     /// A string containing the IBAN to convert.
@@ -258,35 +217,10 @@ public partial struct InternationalBankAccountNumber
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out InternationalBankAccountNumber result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
-    /// <param name="s">
-    /// A string containing the IBAN to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed IBAN.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static InternationalBankAccountNumber Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionInternationalBankAccountNumber);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
-    /// <param name="s">
-    /// A string containing the IBAN to convert.
-    /// </param>
-    /// <returns>
-    /// The IBAN if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static InternationalBankAccountNumber? TryParse(string s) => TryParse(s, out InternationalBankAccountNumber val) ? val : default(InternationalBankAccountNumber?);
-#endif
 }
 
 public partial struct InternationalBankAccountNumber
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid IBAN.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct InternationalBankAccountNumber
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid IBAN.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -6,39 +6,11 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotField
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-#define NotEqualsSvo
-
 namespace Qowaiv.Financial;
 
 public partial struct Money
 {
-#if !NotField
-    private Money(decimal value) => m_Value = value;
 
-    /// <summary>The inner value of the money.</summary>
-    private decimal m_Value;
-#endif
-
-#if !NotIsEmpty
-    /// <summary>Returns true if the  money is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  money is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  money is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Money : IEquatable<Money>
@@ -47,18 +19,6 @@ public partial struct Money : IEquatable<Money>
     [Pure]
     public override bool Equals(object obj) => obj is Money other && Equals(other);
 
-#if !NotEqualsSvo
-    /// <summary>Returns true if this instance and the other money are equal, otherwise false.</summary>
-    /// <param name="other">The <see cref="Money" /> to compare with.</param>
-    [Pure]
-    public bool Equals(Money other) => m_Value == other.m_Value;
-
-#if !NotGetHashCode
-    /// <inheritdoc />
-    [Pure]
-    public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -80,12 +40,6 @@ public partial struct Money : IComparable, IComparable<Money>
         else if (obj is Money other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
-    /// <inheritdoc />
-    [Pure]
-    public int CompareTo(Money other) => Comparer<decimal>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(Money l, Money r) => l.CompareTo(r) < 0;
 
@@ -97,7 +51,6 @@ public partial struct Money : IComparable, IComparable<Money>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(Money l, Money r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Money : IFormattable
@@ -121,7 +74,6 @@ public partial struct Money : IFormattable
     public string ToString(IFormatProvider provider) => ToString(null, provider);
 }
 
-
 public partial struct Money
 {
     /// <summary>Creates the money from a JSON string.</summary>
@@ -131,13 +83,8 @@ public partial struct Money
     /// <returns>
     /// The deserialized money.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Money FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Money FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Money : IXmlSerializable
@@ -155,17 +102,10 @@ public partial struct Money : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
-        m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Money other);
+    partial void OnReadXml(Money value);
 
     /// <summary>Writes the money to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -178,7 +118,6 @@ public partial struct Money : IXmlSerializable
 
 public partial struct Money
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
     /// <param name="s">
     /// A string containing the money to convert.
@@ -245,35 +184,10 @@ public partial struct Money
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Money result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
-    /// <param name="s">
-    /// A string containing the money to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed money.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Money Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionMoney);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
-    /// <param name="s">
-    /// A string containing the money to convert.
-    /// </param>
-    /// <returns>
-    /// The money if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Money? TryParse(string s) => TryParse(s, out Money val) ? val : default(Money?);
-#endif
 }
 
 public partial struct Money
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid money.</summary>
     /// <param name="val">
@@ -293,15 +207,5 @@ public partial struct Money
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid money.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv;
 
 public partial struct Gender
 {
-#if !NotField
     private Gender(byte value) => m_Value = value;
 
     /// <summary>The inner value of the gender.</summary>
     private byte m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  gender is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  gender is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  gender is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Gender : IEquatable<Gender>
@@ -43,18 +32,15 @@ public partial struct Gender : IEquatable<Gender>
     [Pure]
     public override bool Equals(object obj) => obj is Gender other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other gender are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Gender" /> to compare with.</param>
     [Pure]
     public bool Equals(Gender other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct Gender : IComparable, IComparable<Gender>
         else if (obj is Gender other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Gender other) => Comparer<byte>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(Gender l, Gender r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(Gender l, Gender r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(Gender l, Gender r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(Gender l, Gender r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Gender : IFormattable
@@ -144,13 +115,8 @@ public partial struct Gender
     /// <returns>
     /// The deserialized gender.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Gender FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Gender FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Gender : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct Gender : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Gender other);
+    partial void OnReadXml(Gender value);
 
     /// <summary>Writes the gender to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct Gender : IXmlSerializable
 
 public partial struct Gender
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Gender"/>.</summary>
     /// <param name="s">
     /// A string containing the gender to convert.
@@ -258,35 +217,10 @@ public partial struct Gender
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Gender result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Gender"/>.</summary>
-    /// <param name="s">
-    /// A string containing the gender to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed gender.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Gender Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionGender);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Gender"/>.</summary>
-    /// <param name="s">
-    /// A string containing the gender to convert.
-    /// </param>
-    /// <returns>
-    /// The gender if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Gender? TryParse(string s) => TryParse(s, out Gender val) ? val : default(Gender?);
-#endif
 }
 
 public partial struct Gender
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid gender.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct Gender
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid gender.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv.Globalization;
 
 public partial struct Country
 {
-#if !NotField
     private Country(string value) => m_Value = value;
 
     /// <summary>The inner value of the country.</summary>
     private string m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  country is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  country is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  country is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Country : IEquatable<Country>
@@ -43,18 +32,15 @@ public partial struct Country : IEquatable<Country>
     [Pure]
     public override bool Equals(object obj) => obj is Country other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other country are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Country" /> to compare with.</param>
     [Pure]
     public bool Equals(Country other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct Country : IComparable, IComparable<Country>
         else if (obj is Country other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Country other) => Comparer<string>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(Country l, Country r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(Country l, Country r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(Country l, Country r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(Country l, Country r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Country : IFormattable
@@ -144,13 +115,8 @@ public partial struct Country
     /// <returns>
     /// The deserialized country.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Country FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Country FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Country : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct Country : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Country other);
+    partial void OnReadXml(Country value);
 
     /// <summary>Writes the country to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct Country : IXmlSerializable
 
 public partial struct Country
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
     /// <param name="s">
     /// A string containing the country to convert.
@@ -258,35 +217,10 @@ public partial struct Country
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Country result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
-    /// <param name="s">
-    /// A string containing the country to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed country.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Country Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionCountry);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
-    /// <param name="s">
-    /// A string containing the country to convert.
-    /// </param>
-    /// <returns>
-    /// The country if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Country? TryParse(string s) => TryParse(s, out Country val) ? val : default(Country?);
-#endif
 }
 
 public partial struct Country
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid country.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct Country
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid country.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-
-
 namespace Qowaiv;
 
 public partial struct HouseNumber
 {
-#if !NotField
     private HouseNumber(int value) => m_Value = value;
 
     /// <summary>The inner value of the house number.</summary>
     private int m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  house number is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  house number is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  house number is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct HouseNumber : IEquatable<HouseNumber>
@@ -43,18 +32,15 @@ public partial struct HouseNumber : IEquatable<HouseNumber>
     [Pure]
     public override bool Equals(object obj) => obj is HouseNumber other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other house number are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="HouseNumber" /> to compare with.</param>
     [Pure]
     public bool Equals(HouseNumber other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,12 +62,9 @@ public partial struct HouseNumber : IComparable, IComparable<HouseNumber>
         else if (obj is HouseNumber other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(HouseNumber other) => Comparer<int>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(HouseNumber l, HouseNumber r) => l.CompareTo(r) < 0;
 
@@ -93,7 +76,6 @@ public partial struct HouseNumber : IComparable, IComparable<HouseNumber>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(HouseNumber l, HouseNumber r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct HouseNumber : IFormattable
@@ -144,13 +126,8 @@ public partial struct HouseNumber
     /// <returns>
     /// The deserialized house number.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static HouseNumber FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static HouseNumber FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct HouseNumber : IXmlSerializable
@@ -168,17 +145,11 @@ public partial struct HouseNumber : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(HouseNumber other);
+    partial void OnReadXml(HouseNumber value);
 
     /// <summary>Writes the house number to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +162,6 @@ public partial struct HouseNumber : IXmlSerializable
 
 public partial struct HouseNumber
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
     /// <param name="s">
     /// A string containing the house number to convert.
@@ -258,35 +228,10 @@ public partial struct HouseNumber
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out HouseNumber result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
-    /// <param name="s">
-    /// A string containing the house number to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed house number.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static HouseNumber Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionHouseNumber);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
-    /// <param name="s">
-    /// A string containing the house number to convert.
-    /// </param>
-    /// <returns>
-    /// The house number if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static HouseNumber? TryParse(string s) => TryParse(s, out HouseNumber val) ? val : default(HouseNumber?);
-#endif
 }
 
 public partial struct HouseNumber
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid house number.</summary>
     /// <param name="val">
@@ -306,15 +251,5 @@ public partial struct HouseNumber
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid house number.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -6,38 +6,11 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotField
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-
 namespace Qowaiv.IO;
 
 public partial struct StreamSize
 {
-#if !NotField
-    private StreamSize(long value) => m_Value = value;
 
-    /// <summary>The inner value of the stream size.</summary>
-    private long m_Value;
-#endif
-
-#if !NotIsEmpty
-    /// <summary>Returns true if the  stream size is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  stream size is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  stream size is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct StreamSize : IEquatable<StreamSize>
@@ -46,18 +19,15 @@ public partial struct StreamSize : IEquatable<StreamSize>
     [Pure]
     public override bool Equals(object obj) => obj is StreamSize other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other stream size are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="StreamSize" /> to compare with.</param>
     [Pure]
     public bool Equals(StreamSize other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -79,12 +49,9 @@ public partial struct StreamSize : IComparable, IComparable<StreamSize>
         else if (obj is StreamSize other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(StreamSize other) => Comparer<long>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(StreamSize l, StreamSize r) => l.CompareTo(r) < 0;
 
@@ -96,9 +63,7 @@ public partial struct StreamSize : IComparable, IComparable<StreamSize>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(StreamSize l, StreamSize r) => l.CompareTo(r) >= 0;
-#endif
 }
-
 
 public partial struct StreamSize : ISerializable
 {
@@ -127,13 +92,8 @@ public partial struct StreamSize
     /// <returns>
     /// The deserialized stream size.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static StreamSize FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static StreamSize FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct StreamSize : IXmlSerializable
@@ -151,17 +111,10 @@ public partial struct StreamSize : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
-        m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(StreamSize other);
+    partial void OnReadXml(StreamSize value);
 
     /// <summary>Writes the stream size to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -174,7 +127,6 @@ public partial struct StreamSize : IXmlSerializable
 
 public partial struct StreamSize
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
     /// <param name="s">
     /// A string containing the stream size to convert.
@@ -241,35 +193,10 @@ public partial struct StreamSize
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out StreamSize result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
-    /// <param name="s">
-    /// A string containing the stream size to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed stream size.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static StreamSize Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionStreamSize);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
-    /// <param name="s">
-    /// A string containing the stream size to convert.
-    /// </param>
-    /// <returns>
-    /// The stream size if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static StreamSize? TryParse(string s) => TryParse(s, out StreamSize val) ? val : default(StreamSize?);
-#endif
 }
 
 public partial struct StreamSize
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid stream size.</summary>
     /// <param name="val">
@@ -289,15 +216,5 @@ public partial struct StreamSize
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid stream size.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -6,38 +6,11 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotField
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-
 namespace Qowaiv;
 
 public partial struct LocalDateTime
 {
-#if !NotField
-    private LocalDateTime(DateTime value) => m_Value = value;
 
-    /// <summary>The inner value of the local date time.</summary>
-    private DateTime m_Value;
-#endif
-
-#if !NotIsEmpty
-    /// <summary>Returns true if the  local date time is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  local date time is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  local date time is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct LocalDateTime : IEquatable<LocalDateTime>
@@ -46,18 +19,15 @@ public partial struct LocalDateTime : IEquatable<LocalDateTime>
     [Pure]
     public override bool Equals(object obj) => obj is LocalDateTime other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other local date time are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="LocalDateTime" /> to compare with.</param>
     [Pure]
     public bool Equals(LocalDateTime other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -79,12 +49,9 @@ public partial struct LocalDateTime : IComparable, IComparable<LocalDateTime>
         else if (obj is LocalDateTime other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(LocalDateTime other) => Comparer<DateTime>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(LocalDateTime l, LocalDateTime r) => l.CompareTo(r) < 0;
 
@@ -96,7 +63,6 @@ public partial struct LocalDateTime : IComparable, IComparable<LocalDateTime>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(LocalDateTime l, LocalDateTime r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct LocalDateTime : IFormattable
@@ -147,13 +113,8 @@ public partial struct LocalDateTime
     /// <returns>
     /// The deserialized local date time.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static LocalDateTime FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static LocalDateTime FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct LocalDateTime : IXmlSerializable
@@ -171,17 +132,10 @@ public partial struct LocalDateTime : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
-        m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(LocalDateTime other);
+    partial void OnReadXml(LocalDateTime value);
 
     /// <summary>Writes the local date time to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -194,7 +148,6 @@ public partial struct LocalDateTime : IXmlSerializable
 
 public partial struct LocalDateTime
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
     /// <param name="s">
     /// A string containing the local date time to convert.
@@ -261,35 +214,10 @@ public partial struct LocalDateTime
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out LocalDateTime result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
-    /// <param name="s">
-    /// A string containing the local date time to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed local date time.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static LocalDateTime Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionLocalDateTime);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
-    /// <param name="s">
-    /// A string containing the local date time to convert.
-    /// </param>
-    /// <returns>
-    /// The local date time if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static LocalDateTime? TryParse(string s) => TryParse(s, out LocalDateTime val) ? val : default(LocalDateTime?);
-#endif
 }
 
 public partial struct LocalDateTime
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid local date time.</summary>
     /// <param name="val">
@@ -309,15 +237,5 @@ public partial struct LocalDateTime
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid local date time.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -6,39 +6,11 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotField
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-#define NotEqualsSvo
-
 namespace Qowaiv.Mathematics;
 
 public partial struct Fraction
 {
-#if !NotField
-    private Fraction(long value) => m_Value = value;
 
-    /// <summary>The inner value of the fraction.</summary>
-    private long m_Value;
-#endif
-
-#if !NotIsEmpty
-    /// <summary>Returns true if the  fraction is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  fraction is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  fraction is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Fraction : IEquatable<Fraction>
@@ -47,18 +19,6 @@ public partial struct Fraction : IEquatable<Fraction>
     [Pure]
     public override bool Equals(object obj) => obj is Fraction other && Equals(other);
 
-#if !NotEqualsSvo
-    /// <summary>Returns true if this instance and the other fraction are equal, otherwise false.</summary>
-    /// <param name="other">The <see cref="Fraction" /> to compare with.</param>
-    [Pure]
-    public bool Equals(Fraction other) => m_Value == other.m_Value;
-
-#if !NotGetHashCode
-    /// <inheritdoc />
-    [Pure]
-    public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -80,12 +40,6 @@ public partial struct Fraction : IComparable, IComparable<Fraction>
         else if (obj is Fraction other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
-    /// <inheritdoc />
-    [Pure]
-    public int CompareTo(Fraction other) => Comparer<long>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(Fraction l, Fraction r) => l.CompareTo(r) < 0;
 
@@ -97,7 +51,6 @@ public partial struct Fraction : IComparable, IComparable<Fraction>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(Fraction l, Fraction r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Fraction : IFormattable
@@ -121,7 +74,6 @@ public partial struct Fraction : IFormattable
     public string ToString(IFormatProvider provider) => ToString(null, provider);
 }
 
-
 public partial struct Fraction
 {
     /// <summary>Creates the fraction from a JSON string.</summary>
@@ -131,13 +83,8 @@ public partial struct Fraction
     /// <returns>
     /// The deserialized fraction.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Fraction FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Fraction FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Fraction : IXmlSerializable
@@ -155,17 +102,10 @@ public partial struct Fraction : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
-        m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Fraction other);
+    partial void OnReadXml(Fraction value);
 
     /// <summary>Writes the fraction to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -178,7 +118,6 @@ public partial struct Fraction : IXmlSerializable
 
 public partial struct Fraction
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
     /// <param name="s">
     /// A string containing the fraction to convert.
@@ -245,35 +184,10 @@ public partial struct Fraction
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Fraction result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
-    /// <param name="s">
-    /// A string containing the fraction to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed fraction.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Fraction Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionFraction);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
-    /// <param name="s">
-    /// A string containing the fraction to convert.
-    /// </param>
-    /// <returns>
-    /// The fraction if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Fraction? TryParse(string s) => TryParse(s, out Fraction val) ? val : default(Fraction?);
-#endif
 }
 
 public partial struct Fraction
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid fraction.</summary>
     /// <param name="val">
@@ -293,15 +207,5 @@ public partial struct Fraction
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid fraction.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv;
 
 public partial struct Month
 {
-#if !NotField
     private Month(byte value) => m_Value = value;
 
     /// <summary>The inner value of the month.</summary>
     private byte m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  month is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  month is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  month is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Month : IEquatable<Month>
@@ -43,18 +32,15 @@ public partial struct Month : IEquatable<Month>
     [Pure]
     public override bool Equals(object obj) => obj is Month other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other month are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Month" /> to compare with.</param>
     [Pure]
     public bool Equals(Month other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct Month : IComparable, IComparable<Month>
         else if (obj is Month other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Month other) => Comparer<byte>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(Month l, Month r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(Month l, Month r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(Month l, Month r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(Month l, Month r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Month : IFormattable
@@ -144,13 +115,8 @@ public partial struct Month
     /// <returns>
     /// The deserialized month.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Month FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Month FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Month : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct Month : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Month other);
+    partial void OnReadXml(Month value);
 
     /// <summary>Writes the month to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct Month : IXmlSerializable
 
 public partial struct Month
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
     /// <param name="s">
     /// A string containing the month to convert.
@@ -258,35 +217,10 @@ public partial struct Month
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Month result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
-    /// <param name="s">
-    /// A string containing the month to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed month.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Month Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionMonth);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
-    /// <param name="s">
-    /// A string containing the month to convert.
-    /// </param>
-    /// <returns>
-    /// The month if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Month? TryParse(string s) => TryParse(s, out Month val) ? val : default(Month?);
-#endif
 }
 
 public partial struct Month
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid month.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct Month
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid month.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -6,37 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-
 namespace Qowaiv;
 
 public partial struct MonthSpan
 {
-#if !NotField
     private MonthSpan(int value) => m_Value = value;
 
     /// <summary>The inner value of the month span.</summary>
     private int m_Value;
-#endif
 
-#if !NotIsEmpty
-    /// <summary>Returns true if the  month span is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  month span is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  month span is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct MonthSpan : IEquatable<MonthSpan>
@@ -45,18 +23,15 @@ public partial struct MonthSpan : IEquatable<MonthSpan>
     [Pure]
     public override bool Equals(object obj) => obj is MonthSpan other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other month span are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="MonthSpan" /> to compare with.</param>
     [Pure]
     public bool Equals(MonthSpan other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -78,12 +53,9 @@ public partial struct MonthSpan : IComparable, IComparable<MonthSpan>
         else if (obj is MonthSpan other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(MonthSpan other) => Comparer<int>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(MonthSpan l, MonthSpan r) => l.CompareTo(r) < 0;
 
@@ -95,7 +67,6 @@ public partial struct MonthSpan : IComparable, IComparable<MonthSpan>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(MonthSpan l, MonthSpan r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct MonthSpan : IFormattable
@@ -146,13 +117,8 @@ public partial struct MonthSpan
     /// <returns>
     /// The deserialized month span.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static MonthSpan FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static MonthSpan FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct MonthSpan : IXmlSerializable
@@ -170,17 +136,11 @@ public partial struct MonthSpan : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(MonthSpan other);
+    partial void OnReadXml(MonthSpan value);
 
     /// <summary>Writes the month span to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -193,7 +153,6 @@ public partial struct MonthSpan : IXmlSerializable
 
 public partial struct MonthSpan
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
     /// <param name="s">
     /// A string containing the month span to convert.
@@ -260,35 +219,10 @@ public partial struct MonthSpan
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out MonthSpan result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
-    /// <param name="s">
-    /// A string containing the month span to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed month span.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static MonthSpan Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionMonthSpan);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
-    /// <param name="s">
-    /// A string containing the month span to convert.
-    /// </param>
-    /// <returns>
-    /// The month span if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static MonthSpan? TryParse(string s) => TryParse(s, out MonthSpan val) ? val : default(MonthSpan?);
-#endif
 }
 
 public partial struct MonthSpan
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid month span.</summary>
     /// <param name="val">
@@ -308,15 +242,5 @@ public partial struct MonthSpan
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid month span.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -6,37 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-
 namespace Qowaiv;
 
 public partial struct Percentage
 {
-#if !NotField
     private Percentage(decimal value) => m_Value = value;
 
     /// <summary>The inner value of the percentage.</summary>
     private decimal m_Value;
-#endif
 
-#if !NotIsEmpty
-    /// <summary>Returns true if the  percentage is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  percentage is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  percentage is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Percentage : IEquatable<Percentage>
@@ -45,18 +23,15 @@ public partial struct Percentage : IEquatable<Percentage>
     [Pure]
     public override bool Equals(object obj) => obj is Percentage other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other percentage are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Percentage" /> to compare with.</param>
     [Pure]
     public bool Equals(Percentage other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -78,12 +53,9 @@ public partial struct Percentage : IComparable, IComparable<Percentage>
         else if (obj is Percentage other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Percentage other) => Comparer<decimal>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(Percentage l, Percentage r) => l.CompareTo(r) < 0;
 
@@ -95,7 +67,6 @@ public partial struct Percentage : IComparable, IComparable<Percentage>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(Percentage l, Percentage r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Percentage : IFormattable
@@ -146,13 +117,8 @@ public partial struct Percentage
     /// <returns>
     /// The deserialized percentage.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Percentage FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Percentage FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Percentage : IXmlSerializable
@@ -170,17 +136,11 @@ public partial struct Percentage : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Percentage other);
+    partial void OnReadXml(Percentage value);
 
     /// <summary>Writes the percentage to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -193,7 +153,6 @@ public partial struct Percentage : IXmlSerializable
 
 public partial struct Percentage
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
     /// <param name="s">
     /// A string containing the percentage to convert.
@@ -260,35 +219,10 @@ public partial struct Percentage
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Percentage result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
-    /// <param name="s">
-    /// A string containing the percentage to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed percentage.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Percentage Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionPercentage);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
-    /// <param name="s">
-    /// A string containing the percentage to convert.
-    /// </param>
-    /// <returns>
-    /// The percentage if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Percentage? TryParse(string s) => TryParse(s, out Percentage val) ? val : default(Percentage?);
-#endif
 }
 
 public partial struct Percentage
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid percentage.</summary>
     /// <param name="val">
@@ -308,15 +242,5 @@ public partial struct Percentage
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid percentage.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv;
 
 public partial struct PostalCode
 {
-#if !NotField
     private PostalCode(string value) => m_Value = value;
 
     /// <summary>The inner value of the postal code.</summary>
     private string m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  postal code is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  postal code is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  postal code is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct PostalCode : IEquatable<PostalCode>
@@ -43,18 +32,15 @@ public partial struct PostalCode : IEquatable<PostalCode>
     [Pure]
     public override bool Equals(object obj) => obj is PostalCode other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other postal code are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="PostalCode" /> to compare with.</param>
     [Pure]
     public bool Equals(PostalCode other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct PostalCode : IComparable, IComparable<PostalCode>
         else if (obj is PostalCode other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(PostalCode other) => Comparer<string>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(PostalCode l, PostalCode r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(PostalCode l, PostalCode r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(PostalCode l, PostalCode r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(PostalCode l, PostalCode r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct PostalCode : IFormattable
@@ -144,13 +115,8 @@ public partial struct PostalCode
     /// <returns>
     /// The deserialized postal code.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static PostalCode FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static PostalCode FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct PostalCode : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct PostalCode : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(PostalCode other);
+    partial void OnReadXml(PostalCode value);
 
     /// <summary>Writes the postal code to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct PostalCode : IXmlSerializable
 
 public partial struct PostalCode
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
     /// <param name="s">
     /// A string containing the postal code to convert.
@@ -258,35 +217,10 @@ public partial struct PostalCode
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out PostalCode result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
-    /// <param name="s">
-    /// A string containing the postal code to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed postal code.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static PostalCode Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionPostalCode);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
-    /// <param name="s">
-    /// A string containing the postal code to convert.
-    /// </param>
-    /// <returns>
-    /// The postal code if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static PostalCode? TryParse(string s) => TryParse(s, out PostalCode val) ? val : default(PostalCode?);
-#endif
 }
 
 public partial struct PostalCode
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid postal code.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct PostalCode
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid postal code.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv;
 
 public partial struct Sex
 {
-#if !NotField
     private Sex(byte value) => m_Value = value;
 
     /// <summary>The inner value of the sex.</summary>
     private byte m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  sex is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  sex is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  sex is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Sex : IEquatable<Sex>
@@ -43,18 +32,15 @@ public partial struct Sex : IEquatable<Sex>
     [Pure]
     public override bool Equals(object obj) => obj is Sex other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other sex are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Sex" /> to compare with.</param>
     [Pure]
     public bool Equals(Sex other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct Sex : IComparable, IComparable<Sex>
         else if (obj is Sex other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Sex other) => Comparer<byte>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(Sex l, Sex r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(Sex l, Sex r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(Sex l, Sex r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(Sex l, Sex r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Sex : IFormattable
@@ -144,13 +115,8 @@ public partial struct Sex
     /// <returns>
     /// The deserialized sex.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Sex FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Sex FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Sex : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct Sex : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Sex other);
+    partial void OnReadXml(Sex value);
 
     /// <summary>Writes the sex to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct Sex : IXmlSerializable
 
 public partial struct Sex
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.</summary>
     /// <param name="s">
     /// A string containing the sex to convert.
@@ -258,35 +217,10 @@ public partial struct Sex
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Sex result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.</summary>
-    /// <param name="s">
-    /// A string containing the sex to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed sex.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Sex Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionSex);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.</summary>
-    /// <param name="s">
-    /// A string containing the sex to convert.
-    /// </param>
-    /// <returns>
-    /// The sex if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Sex? TryParse(string s) => TryParse(s, out Sex val) ? val : default(Sex?);
-#endif
 }
 
 public partial struct Sex
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid sex.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct Sex
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid sex.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -6,37 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-
 namespace Qowaiv.Statistics;
 
 public partial struct Elo
 {
-#if !NotField
     private Elo(double value) => m_Value = value;
 
     /// <summary>The inner value of the elo.</summary>
     private double m_Value;
-#endif
 
-#if !NotIsEmpty
-    /// <summary>Returns true if the  elo is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  elo is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  elo is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Elo : IEquatable<Elo>
@@ -45,18 +23,15 @@ public partial struct Elo : IEquatable<Elo>
     [Pure]
     public override bool Equals(object obj) => obj is Elo other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other elo are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Elo" /> to compare with.</param>
     [Pure]
     public bool Equals(Elo other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -78,12 +53,9 @@ public partial struct Elo : IComparable, IComparable<Elo>
         else if (obj is Elo other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Elo other) => Comparer<double>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(Elo l, Elo r) => l.CompareTo(r) < 0;
 
@@ -95,7 +67,6 @@ public partial struct Elo : IComparable, IComparable<Elo>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(Elo l, Elo r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Elo : IFormattable
@@ -146,13 +117,8 @@ public partial struct Elo
     /// <returns>
     /// The deserialized elo.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Elo FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Elo FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Elo : IXmlSerializable
@@ -170,17 +136,11 @@ public partial struct Elo : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Elo other);
+    partial void OnReadXml(Elo value);
 
     /// <summary>Writes the elo to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -193,7 +153,6 @@ public partial struct Elo : IXmlSerializable
 
 public partial struct Elo
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
     /// <param name="s">
     /// A string containing the elo to convert.
@@ -260,35 +219,10 @@ public partial struct Elo
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Elo result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
-    /// <param name="s">
-    /// A string containing the elo to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed elo.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Elo Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionElo);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
-    /// <param name="s">
-    /// A string containing the elo to convert.
-    /// </param>
-    /// <returns>
-    /// The elo if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Elo? TryParse(string s) => TryParse(s, out Elo val) ? val : default(Elo?);
-#endif
 }
 
 public partial struct Elo
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid elo.</summary>
     /// <param name="val">
@@ -308,15 +242,5 @@ public partial struct Elo
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid elo.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -6,38 +6,18 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotCultureDependent
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-#define NoComparisonOperators
-
 namespace Qowaiv;
 
 public partial struct Uuid
 {
-#if !NotField
     private Uuid(Guid value) => m_Value = value;
 
     /// <summary>The inner value of the UUID.</summary>
     private Guid m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  UUID is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  UUID is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  UUID is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Uuid : IEquatable<Uuid>
@@ -46,18 +26,15 @@ public partial struct Uuid : IEquatable<Uuid>
     [Pure]
     public override bool Equals(object obj) => obj is Uuid other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other UUID are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Uuid" /> to compare with.</param>
     [Pure]
     public bool Equals(Uuid other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -79,24 +56,9 @@ public partial struct Uuid : IComparable, IComparable<Uuid>
         else if (obj is Uuid other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Uuid other) => Comparer<Guid>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(Uuid l, Uuid r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(Uuid l, Uuid r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(Uuid l, Uuid r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(Uuid l, Uuid r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Uuid : IFormattable
@@ -147,13 +109,8 @@ public partial struct Uuid
     /// <returns>
     /// The deserialized UUID.
     /// </returns>
-#if !NotCultureDependent
-    [Pure]
-    public static Uuid FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
     [Pure]
     public static Uuid FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Uuid : IXmlSerializable
@@ -171,17 +128,11 @@ public partial struct Uuid : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
-        var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
         var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Uuid other);
+    partial void OnReadXml(Uuid value);
 
     /// <summary>Writes the UUID to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -194,74 +145,6 @@ public partial struct Uuid : IXmlSerializable
 
 public partial struct Uuid
 {
-#if !NotCultureDependent
-    /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
-    /// <param name="s">
-    /// A string containing the UUID to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed UUID.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Uuid Parse(string s) => Parse(s, null);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
-    /// <param name="s">
-    /// A string containing the UUID to convert.
-    /// </param>
-    /// <param name="formatProvider">
-    /// The specified format provider.
-    /// </param>
-    /// <returns>
-    /// The parsed UUID.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Uuid Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionUuid);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
-    /// <param name="s">
-    /// A string containing the UUID to convert.
-    /// </param>
-    /// <returns>
-    /// The UUID if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Uuid? TryParse(string s) => TryParse(s, null);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
-    /// <param name="s">
-    /// A string containing the UUID to convert.
-    /// </param>
-    /// <param name="formatProvider">
-    /// The specified format provider.
-    /// </param>
-    /// <returns>
-    /// The UUID if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Uuid? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out Uuid val) ? val : default(Uuid?);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.
-    /// A return value indicates whether the conversion succeeded.
-    /// </summary>
-    /// <param name="s">
-    /// A string containing the UUID to convert.
-    /// </param>
-    /// <param name="result">
-    /// The result of the parsing.
-    /// </param>
-    /// <returns>
-    /// True if the string was converted successfully, otherwise false.
-    /// </returns>
-    [Pure]
-    public static bool TryParse(string s, out Uuid result) => TryParse(s, null, out result);
-#else
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
     /// <param name="s">
     /// A string containing the UUID to convert.
@@ -284,32 +167,10 @@ public partial struct Uuid
     /// </returns>
     [Pure]
     public static Uuid? TryParse(string s) => TryParse(s, out Uuid val) ? val : default(Uuid?);
-#endif
 }
 
 public partial struct Uuid
 {
-#if !NotCultureDependent
-
-    /// <summary>Returns true if the value represents a valid UUID.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val) => IsValid(val, (IFormatProvider)null);
-
-    /// <summary>Returns true if the value represents a valid UUID.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    /// <param name="formatProvider">
-    /// The <see cref="IFormatProvider"/> to interpret the <see cref="string"/> value with.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val, IFormatProvider formatProvider)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, formatProvider, out _);
-#else
     /// <summary>Returns true if the value represents a valid UUID.</summary>
     /// <param name="val">
     /// The <see cref="string"/> to validate.
@@ -318,6 +179,5 @@ public partial struct Uuid
     public static bool IsValid(string val)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -6,36 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotCultureDependent
-#define NoComparisonOperators
-
 namespace Qowaiv.Web;
 
 public partial struct InternetMediaType
 {
-#if !NotField
     private InternetMediaType(string value) => m_Value = value;
 
     /// <summary>The inner value of the Internet media type.</summary>
     private string m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  Internet media type is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  Internet media type is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  Internet media type is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct InternetMediaType : IEquatable<InternetMediaType>
@@ -44,18 +32,15 @@ public partial struct InternetMediaType : IEquatable<InternetMediaType>
     [Pure]
     public override bool Equals(object obj) => obj is InternetMediaType other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other Internet media type are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="InternetMediaType" /> to compare with.</param>
     [Pure]
     public bool Equals(InternetMediaType other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -77,24 +62,9 @@ public partial struct InternetMediaType : IComparable, IComparable<InternetMedia
         else if (obj is InternetMediaType other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(InternetMediaType other) => Comparer<string>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(InternetMediaType l, InternetMediaType r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(InternetMediaType l, InternetMediaType r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(InternetMediaType l, InternetMediaType r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(InternetMediaType l, InternetMediaType r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct InternetMediaType : IFormattable
@@ -145,13 +115,8 @@ public partial struct InternetMediaType
     /// <returns>
     /// The deserialized Internet media type.
     /// </returns>
-#if !NotCultureDependent
-    [Pure]
-    public static InternetMediaType FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
     [Pure]
     public static InternetMediaType FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct InternetMediaType : IXmlSerializable
@@ -169,17 +134,11 @@ public partial struct InternetMediaType : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
-        var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
         var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(InternetMediaType other);
+    partial void OnReadXml(InternetMediaType value);
 
     /// <summary>Writes the Internet media type to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -192,74 +151,6 @@ public partial struct InternetMediaType : IXmlSerializable
 
 public partial struct InternetMediaType
 {
-#if !NotCultureDependent
-    /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
-    /// <param name="s">
-    /// A string containing the Internet media type to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed Internet media type.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static InternetMediaType Parse(string s) => Parse(s, null);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
-    /// <param name="s">
-    /// A string containing the Internet media type to convert.
-    /// </param>
-    /// <param name="formatProvider">
-    /// The specified format provider.
-    /// </param>
-    /// <returns>
-    /// The parsed Internet media type.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static InternetMediaType Parse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionInternetMediaType);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
-    /// <param name="s">
-    /// A string containing the Internet media type to convert.
-    /// </param>
-    /// <returns>
-    /// The Internet media type if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static InternetMediaType? TryParse(string s) => TryParse(s, null);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
-    /// <param name="s">
-    /// A string containing the Internet media type to convert.
-    /// </param>
-    /// <param name="formatProvider">
-    /// The specified format provider.
-    /// </param>
-    /// <returns>
-    /// The Internet media type if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static InternetMediaType? TryParse(string s, IFormatProvider formatProvider) => TryParse(s, formatProvider, out InternetMediaType val) ? val : default(InternetMediaType?);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.
-    /// A return value indicates whether the conversion succeeded.
-    /// </summary>
-    /// <param name="s">
-    /// A string containing the Internet media type to convert.
-    /// </param>
-    /// <param name="result">
-    /// The result of the parsing.
-    /// </param>
-    /// <returns>
-    /// True if the string was converted successfully, otherwise false.
-    /// </returns>
-    [Pure]
-    public static bool TryParse(string s, out InternetMediaType result) => TryParse(s, null, out result);
-#else
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
     /// <param name="s">
     /// A string containing the Internet media type to convert.
@@ -282,32 +173,10 @@ public partial struct InternetMediaType
     /// </returns>
     [Pure]
     public static InternetMediaType? TryParse(string s) => TryParse(s, out InternetMediaType val) ? val : default(InternetMediaType?);
-#endif
 }
 
 public partial struct InternetMediaType
 {
-#if !NotCultureDependent
-
-    /// <summary>Returns true if the value represents a valid Internet media type.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val) => IsValid(val, (IFormatProvider)null);
-
-    /// <summary>Returns true if the value represents a valid Internet media type.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    /// <param name="formatProvider">
-    /// The <see cref="IFormatProvider"/> to interpret the <see cref="string"/> value with.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val, IFormatProvider formatProvider)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, formatProvider, out _);
-#else
     /// <summary>Returns true if the value represents a valid Internet media type.</summary>
     /// <param name="val">
     /// The <see cref="string"/> to validate.
@@ -316,6 +185,5 @@ public partial struct InternetMediaType
     public static bool IsValid(string val)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -6,38 +6,11 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NotField
-#define NotIsEmpty
-#define NotIsUnknown
-#define NotIsEmptyOrUnknown
-
 namespace Qowaiv;
 
 public partial struct WeekDate
 {
-#if !NotField
-    private WeekDate(Qowaiv.Date value) => m_Value = value;
 
-    /// <summary>The inner value of the week date.</summary>
-    private Qowaiv.Date m_Value;
-#endif
-
-#if !NotIsEmpty
-    /// <summary>Returns true if the  week date is empty, otherwise false.</summary>
-    [Pure]
-    public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
-    /// <summary>Returns true if the  week date is unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
-    /// <summary>Returns true if the  week date is empty or unknown, otherwise false.</summary>
-    [Pure]
-    public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct WeekDate : IEquatable<WeekDate>
@@ -46,18 +19,15 @@ public partial struct WeekDate : IEquatable<WeekDate>
     [Pure]
     public override bool Equals(object obj) => obj is WeekDate other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other week date are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="WeekDate" /> to compare with.</param>
     [Pure]
     public bool Equals(WeekDate other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -79,12 +49,9 @@ public partial struct WeekDate : IComparable, IComparable<WeekDate>
         else if (obj is WeekDate other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(WeekDate other) => Comparer<Qowaiv.Date>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(WeekDate l, WeekDate r) => l.CompareTo(r) < 0;
 
@@ -96,7 +63,6 @@ public partial struct WeekDate : IComparable, IComparable<WeekDate>
 
     /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
     public static bool operator >=(WeekDate l, WeekDate r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct WeekDate : IFormattable
@@ -120,7 +86,6 @@ public partial struct WeekDate : IFormattable
     public string ToString(IFormatProvider provider) => ToString(null, provider);
 }
 
-
 public partial struct WeekDate
 {
     /// <summary>Creates the week date from a JSON string.</summary>
@@ -130,13 +95,8 @@ public partial struct WeekDate
     /// <returns>
     /// The deserialized week date.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static WeekDate FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static WeekDate FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct WeekDate : IXmlSerializable
@@ -154,17 +114,10 @@ public partial struct WeekDate : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
-        m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(WeekDate other);
+    partial void OnReadXml(WeekDate value);
 
     /// <summary>Writes the week date to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -177,7 +130,6 @@ public partial struct WeekDate : IXmlSerializable
 
 public partial struct WeekDate
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
     /// <param name="s">
     /// A string containing the week date to convert.
@@ -244,35 +196,10 @@ public partial struct WeekDate
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out WeekDate result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
-    /// <param name="s">
-    /// A string containing the week date to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed week date.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static WeekDate Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionWeekDate);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
-    /// <param name="s">
-    /// A string containing the week date to convert.
-    /// </param>
-    /// <returns>
-    /// The week date if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static WeekDate? TryParse(string s) => TryParse(s, out WeekDate val) ? val : default(WeekDate?);
-#endif
 }
 
 public partial struct WeekDate
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid week date.</summary>
     /// <param name="val">
@@ -292,15 +219,5 @@ public partial struct WeekDate
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid week date.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv;
 
 public partial struct Year
 {
-#if !NotField
     private Year(short value) => m_Value = value;
 
     /// <summary>The inner value of the year.</summary>
     private short m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  year is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  year is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  year is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct Year : IEquatable<Year>
@@ -43,18 +32,15 @@ public partial struct Year : IEquatable<Year>
     [Pure]
     public override bool Equals(object obj) => obj is Year other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other year are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Year" /> to compare with.</param>
     [Pure]
     public bool Equals(Year other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct Year : IComparable, IComparable<Year>
         else if (obj is Year other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(Year other) => Comparer<short>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(Year l, Year r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(Year l, Year r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(Year l, Year r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(Year l, Year r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct Year : IFormattable
@@ -144,13 +115,8 @@ public partial struct Year
     /// <returns>
     /// The deserialized year.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static Year FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static Year FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct Year : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct Year : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(Year other);
+    partial void OnReadXml(Year value);
 
     /// <summary>Writes the year to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct Year : IXmlSerializable
 
 public partial struct Year
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
     /// <param name="s">
     /// A string containing the year to convert.
@@ -258,35 +217,10 @@ public partial struct Year
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out Year result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
-    /// <param name="s">
-    /// A string containing the year to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed year.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static Year Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionYear);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
-    /// <param name="s">
-    /// A string containing the year to convert.
-    /// </param>
-    /// <returns>
-    /// The year if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static Year? TryParse(string s) => TryParse(s, out Year val) ? val : default(Year?);
-#endif
 }
 
 public partial struct Year
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid year.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct Year
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid year.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -6,35 +6,24 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-
-#define NoComparisonOperators
-
 namespace Qowaiv;
 
 public partial struct YesNo
 {
-#if !NotField
     private YesNo(byte value) => m_Value = value;
 
     /// <summary>The inner value of the yes-no.</summary>
     private byte m_Value;
-#endif
 
-#if !NotIsEmpty
     /// <summary>Returns true if the  yes-no is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
-#endif
-#if !NotIsUnknown
     /// <summary>Returns true if the  yes-no is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
-#endif
-#if !NotIsEmptyOrUnknown
     /// <summary>Returns true if the  yes-no is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
-#endif
 }
 
 public partial struct YesNo : IEquatable<YesNo>
@@ -43,18 +32,15 @@ public partial struct YesNo : IEquatable<YesNo>
     [Pure]
     public override bool Equals(object obj) => obj is YesNo other && Equals(other);
 
-#if !NotEqualsSvo
     /// <summary>Returns true if this instance and the other yes-no are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="YesNo" /> to compare with.</param>
     [Pure]
     public bool Equals(YesNo other) => m_Value == other.m_Value;
 
-#if !NotGetHashCode
     /// <inheritdoc />
     [Pure]
     public override int GetHashCode() => Hash.Code(m_Value);
-#endif
-#endif
+
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand</param>
@@ -76,24 +62,9 @@ public partial struct YesNo : IComparable, IComparable<YesNo>
         else if (obj is YesNo other) { return CompareTo(other); }
         else { throw new ArgumentException($"Argument must be {GetType().Name}.", nameof(obj)); }
     }
-#if !NotEqualsSvo
     /// <inheritdoc />
     [Pure]
     public int CompareTo(YesNo other) => Comparer<byte>.Default.Compare(m_Value, other.m_Value);
-#endif
-#if !NoComparisonOperators
-    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
-    public static bool operator <(YesNo l, YesNo r) => l.CompareTo(r) < 0;
-
-    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
-    public static bool operator >(YesNo l, YesNo r) => l.CompareTo(r) > 0;
-
-    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
-    public static bool operator <=(YesNo l, YesNo r) => l.CompareTo(r) <= 0;
-
-    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
-    public static bool operator >=(YesNo l, YesNo r) => l.CompareTo(r) >= 0;
-#endif
 }
 
 public partial struct YesNo : IFormattable
@@ -144,13 +115,8 @@ public partial struct YesNo
     /// <returns>
     /// The deserialized yes-no.
     /// </returns>
-#if !NotCultureDependent
     [Pure]
     public static YesNo FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
-#else
-    [Pure]
-    public static YesNo FromJson(string json) => Parse(json);
-#endif
 }
 
 public partial struct YesNo : IXmlSerializable
@@ -168,17 +134,11 @@ public partial struct YesNo : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-#if !NotCultureDependent
         var val = Parse(xml, CultureInfo.InvariantCulture);
-#else
-        var val = Parse(xml);
-#endif
-#if !NotField
         m_Value = val.m_Value;
-#endif
         OnReadXml(val);
     }
-    partial void OnReadXml(YesNo other);
+    partial void OnReadXml(YesNo value);
 
     /// <summary>Writes the yes-no to an <see href="XmlWriter" />.</summary>
     /// <remarks>
@@ -191,7 +151,6 @@ public partial struct YesNo : IXmlSerializable
 
 public partial struct YesNo
 {
-#if !NotCultureDependent
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
     /// <param name="s">
     /// A string containing the yes-no to convert.
@@ -258,35 +217,10 @@ public partial struct YesNo
     /// </returns>
     [Pure]
     public static bool TryParse(string s, out YesNo result) => TryParse(s, null, out result);
-#else
-    /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
-    /// <param name="s">
-    /// A string containing the yes-no to convert.
-    /// </param>
-    /// <returns>
-    /// The parsed yes-no.
-    /// </returns>
-    /// <exception cref="FormatException">
-    /// <paramref name="s"/> is not in the correct format.
-    /// </exception>
-    [Pure]
-    public static YesNo Parse(string s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionYesNo);
-
-    /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
-    /// <param name="s">
-    /// A string containing the yes-no to convert.
-    /// </param>
-    /// <returns>
-    /// The yes-no if the string was converted successfully, otherwise default.
-    /// </returns>
-    [Pure]
-    public static YesNo? TryParse(string s) => TryParse(s, out YesNo val) ? val : default(YesNo?);
-#endif
 }
 
 public partial struct YesNo
 {
-#if !NotCultureDependent
 
     /// <summary>Returns true if the value represents a valid yes-no.</summary>
     /// <param name="val">
@@ -306,15 +240,5 @@ public partial struct YesNo
     public static bool IsValid(string val, IFormatProvider formatProvider)
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
-#else
-    /// <summary>Returns true if the value represents a valid yes-no.</summary>
-    /// <param name="val">
-    /// The <see cref="string"/> to validate.
-    /// </param>
-    [Pure]
-    public static bool IsValid(string val)
-        => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
-#endif
 }
 


### PR DESCRIPTION
Previously `#if`, `#else`, `#endif`, and `#define` statements (which are used to enable/disable parts of the generated code) where visible in the generated code itself. To reduce complexity, this not longer in the file.