### PR TITLE
Drop usage of partial functions in generated code

### DIFF
--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -138,9 +138,7 @@ public partial struct Timestamp : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Timestamp value);
 
     /// <summary>Writes the timestamp to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -407,17 +407,11 @@ public partial struct Date : ISerializable, IXmlSerializable, IFormattable, IEqu
     public string ToString(string format, IFormatProvider formatProvider)
     {
         // We don't want to see hh:mm pop up.
-        var f = string.IsNullOrEmpty(format) ? "d" : format;
-
-        if (StringFormatter.TryApplyCustomFormatter(f, this, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        return m_Value.ToString(f, formatProvider);
+        format = format.WithDefault("d");
+        return StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted)
+            ? formatted 
+            : m_Value.ToString(format, formatProvider);
     }
-
-    /// <summary>Bind XML value.</summary>
-    partial void OnReadXml(Date value) => m_Value = value.m_Value;
 
     /// <summary>Gets an XML string representation of the @FullName.</summary>
     [Pure]

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -415,7 +415,7 @@ public partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEq
     }
 
     /// <remarks>Sets the currency.</remarks>
-    partial void OnReadXml(Money value)
+    private void OnReadXml(Money value)
     {
         m_Value = value.m_Value;
         m_Currency = value.m_Currency;
@@ -466,8 +466,11 @@ public partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEq
         {
             return formatted;
         }
-        var numberFormatInfo = Currency.GetNumberFormatInfo(formatProvider);
-        return m_Value.ToString(string.IsNullOrEmpty(format) ? "C" : format, numberFormatInfo);
+        else
+        {
+            var numberFormatInfo = Currency.GetNumberFormatInfo(formatProvider);
+            return m_Value.ToString(string.IsNullOrEmpty(format) ? "C" : format, numberFormatInfo);
+        }
     }
 
     /// <summary>Gets an XML string representation of the money.</summary>
@@ -499,14 +502,9 @@ public partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEq
     /// </returns>
     [Pure]
     public int CompareTo(Money other)
-    {
-        var compare = m_Currency.CompareTo(other.m_Currency);
-        if (compare == 0)
-        {
-            compare = m_Value.CompareTo(other.m_Value);
-        }
-        return compare;
-    }
+        => m_Currency.CompareTo(other.m_Currency) is var compare && compare == 0
+        ? m_Value.CompareTo(other.m_Value)
+        : compare;
 
     #region (Explicit) casting
 

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -8,11 +8,6 @@
 // ------------------------------------------------------------------------------
 namespace Qowaiv;
 
-public partial struct Date
-{
-
-}
-
 public partial struct Date : IEquatable<Date>
 {
     /// <inheritdoc />
@@ -133,9 +128,8 @@ public partial struct Date : IXmlSerializable
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
-        OnReadXml(val);
+        m_Value = val.m_Value;
     }
-    partial void OnReadXml(Date value);
 
     /// <summary>Writes the date to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -126,9 +126,7 @@ public partial struct DateSpan : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(DateSpan value);
 
     /// <summary>Writes the date span to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -136,9 +136,7 @@ public partial struct EmailAddress : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(EmailAddress value);
 
     /// <summary>Writes the email address to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -138,9 +138,7 @@ public partial struct Amount : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Amount value);
 
     /// <summary>Writes the amount to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -136,9 +136,7 @@ public partial struct BusinessIdentifierCode : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(BusinessIdentifierCode value);
 
     /// <summary>Writes the BIC to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -136,9 +136,7 @@ public partial struct Currency : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Currency value);
 
     /// <summary>Writes the currency to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -136,9 +136,7 @@ public partial struct InternationalBankAccountNumber : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(InternationalBankAccountNumber value);
 
     /// <summary>Writes the IBAN to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -8,11 +8,6 @@
 // ------------------------------------------------------------------------------
 namespace Qowaiv.Financial;
 
-public partial struct Money
-{
-
-}
-
 public partial struct Money : IEquatable<Money>
 {
     /// <inheritdoc />
@@ -105,7 +100,6 @@ public partial struct Money : IXmlSerializable
         var val = Parse(xml, CultureInfo.InvariantCulture);
         OnReadXml(val);
     }
-    partial void OnReadXml(Money value);
 
     /// <summary>Writes the money to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -136,9 +136,7 @@ public partial struct Gender : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Gender value);
 
     /// <summary>Writes the gender to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -136,9 +136,7 @@ public partial struct Country : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Country value);
 
     /// <summary>Writes the country to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -147,9 +147,7 @@ public partial struct HouseNumber : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(HouseNumber value);
 
     /// <summary>Writes the house number to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -8,11 +8,6 @@
 // ------------------------------------------------------------------------------
 namespace Qowaiv.IO;
 
-public partial struct StreamSize
-{
-
-}
-
 public partial struct StreamSize : IEquatable<StreamSize>
 {
     /// <inheritdoc />
@@ -112,9 +107,8 @@ public partial struct StreamSize : IXmlSerializable
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
-        OnReadXml(val);
+        m_Value = val.m_Value;
     }
-    partial void OnReadXml(StreamSize value);
 
     /// <summary>Writes the stream size to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -8,11 +8,6 @@
 // ------------------------------------------------------------------------------
 namespace Qowaiv;
 
-public partial struct LocalDateTime
-{
-
-}
-
 public partial struct LocalDateTime : IEquatable<LocalDateTime>
 {
     /// <inheritdoc />
@@ -133,9 +128,8 @@ public partial struct LocalDateTime : IXmlSerializable
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
-        OnReadXml(val);
+        m_Value = val.m_Value;
     }
-    partial void OnReadXml(LocalDateTime value);
 
     /// <summary>Writes the local date time to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -8,11 +8,6 @@
 // ------------------------------------------------------------------------------
 namespace Qowaiv.Mathematics;
 
-public partial struct Fraction
-{
-
-}
-
 public partial struct Fraction : IEquatable<Fraction>
 {
     /// <inheritdoc />
@@ -105,7 +100,6 @@ public partial struct Fraction : IXmlSerializable
         var val = Parse(xml, CultureInfo.InvariantCulture);
         OnReadXml(val);
     }
-    partial void OnReadXml(Fraction value);
 
     /// <summary>Writes the fraction to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -136,9 +136,7 @@ public partial struct Month : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Month value);
 
     /// <summary>Writes the month to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -138,9 +138,7 @@ public partial struct MonthSpan : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(MonthSpan value);
 
     /// <summary>Writes the month span to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -138,9 +138,7 @@ public partial struct Percentage : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Percentage value);
 
     /// <summary>Writes the percentage to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -136,9 +136,7 @@ public partial struct PostalCode : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(PostalCode value);
 
     /// <summary>Writes the postal code to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -136,9 +136,7 @@ public partial struct Sex : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Sex value);
 
     /// <summary>Writes the sex to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -138,9 +138,7 @@ public partial struct Elo : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Elo value);
 
     /// <summary>Writes the elo to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -130,9 +130,7 @@ public partial struct Uuid : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Uuid value);
 
     /// <summary>Writes the UUID to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -136,9 +136,7 @@ public partial struct InternetMediaType : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(InternetMediaType value);
 
     /// <summary>Writes the Internet media type to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -8,11 +8,6 @@
 // ------------------------------------------------------------------------------
 namespace Qowaiv;
 
-public partial struct WeekDate
-{
-
-}
-
 public partial struct WeekDate : IEquatable<WeekDate>
 {
     /// <inheritdoc />
@@ -115,9 +110,8 @@ public partial struct WeekDate : IXmlSerializable
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
-        OnReadXml(val);
+        m_Value = val.m_Value;
     }
-    partial void OnReadXml(WeekDate value);
 
     /// <summary>Writes the week date to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -136,9 +136,7 @@ public partial struct Year : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(Year value);
 
     /// <summary>Writes the year to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -136,9 +136,7 @@ public partial struct YesNo : IXmlSerializable
         var xml = reader.ReadElementString();
         var val = Parse(xml, CultureInfo.InvariantCulture);
         m_Value = val.m_Value;
-        OnReadXml(val);
     }
-    partial void OnReadXml(YesNo value);
 
     /// <summary>Writes the yes-no to an <see href="XmlWriter" />.</summary>
     /// <remarks>

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -477,9 +477,6 @@ public partial struct StreamSize : ISerializable, IXmlSerializable, IFormattable
     [Pure]
     private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-    /// <summary>Bind XML value.</summary>
-    partial void OnReadXml(StreamSize value) => m_Value = value.m_Value;
-
     [Pure]
     private string ToFormattedString(IFormatProvider formatProvider, Match match)
     {

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -514,20 +514,13 @@ public partial struct LocalDateTime : ISerializable, IXmlSerializable, IFormatta
     /// </param>
     [Pure]
     public string ToString(string format, IFormatProvider formatProvider)
-    {
-        if (StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        return m_Value.ToString(format, formatProvider);
-    }
+        => StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted)
+        ? formatted
+        : m_Value.ToString(format, formatProvider);
 
     /// <summary>Gets an XML string representation of the @FullName.</summary>
     [Pure]
     private string ToXmlString() => ToString(SerializableFormat, CultureInfo.InvariantCulture);
-
-    /// <summary>Bind XML value.</summary>
-    partial void OnReadXml(LocalDateTime value) => m_Value = value.m_Value;
 
     #region (Explicit) casting
 

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -524,7 +524,7 @@ public partial struct Fraction : ISerializable, IXmlSerializable, IFormattable, 
     }
 
     /// <remarks>Sets the currency.</remarks>
-    partial void OnReadXml(Fraction other)
+    private void OnReadXml(Fraction other)
     {
         numerator = other.numerator;
         denominator = other.denominator;

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -221,9 +221,6 @@ public partial struct WeekDate : ISerializable, IXmlSerializable, IFormattable, 
     [Pure]
     private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
 
-    /// <summary>Bind XML value.</summary>
-    partial void OnReadXml(WeekDate value) => m_Value = value.m_Value;
-
     /// <summary>Casts a week date to a date time.</summary>
     public static implicit operator DateTime(WeekDate val) => val.m_Value;
 


### PR DESCRIPTION
The `partial void OnReadXml`  started giving warnings due to (non existing) differences in signatures, when supporting .NET 6.0. Is was hardly used in the first place, so got rid of it.