### PR TITLE
Percentage can not be initialized on environments lacking French or Iranian culture

### DIFF
--- a/src/Qowaiv/Percentage.Formatting.cs
+++ b/src/Qowaiv/Percentage.Formatting.cs
@@ -48,7 +48,7 @@ namespace Qowaiv
         {
             if (string.IsNullOrEmpty(format))
             {
-                return DefaultFormats.TryGetValue(formatProvider, out format)
+                return formatProvider is CultureInfo culture && DefaultFormats.TryGetValue(culture.Name, out format)
                     ? format
                     : PercentFormat;
             }
@@ -64,10 +64,10 @@ namespace Qowaiv
         }
 
         /// <summary>Gets the default format for different countries.</summary>
-        private static readonly Dictionary<IFormatProvider, string> DefaultFormats = new Dictionary<IFormatProvider, string>
+        private static readonly Dictionary<string, string> DefaultFormats = new Dictionary<string, string>
         {
-            { new CultureInfo("fr-FR"), "%0.############################" },
-            { new CultureInfo("fa-IR"), "%0.############################" },
+            { "fr-FR", "%0.############################" },
+            { "fa-IR", "%0.############################" },
         };
     }
 }

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,14 +5,16 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>5.1.4</Version>
+    <Version>5.1.5</Version>
     <PackageReleaseNotes>
-v5.1.4
-- ConvertFrom(object) should not use fallback when TryCreate() fails. #194
-v5.1.3
-- ConvertFrom(object) should use Behavior.TryCreate(). #189
-v5.1.2
-- Extend Open API documentation with explicit example. #188
+      v5.1.5
+      - Percentage can not be initialized on environments lacking French or Iranian culture. #226
+      v5.1.4
+      - ConvertFrom(object) should not use fallback when TryCreate() fails. #194
+      v5.1.3
+      - ConvertFrom(object) should use Behavior.TryCreate(). #189
+      v5.1.2
+      - Extend Open API documentation with explicit example. #188
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -7,14 +7,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>5.1.5</Version>
     <PackageReleaseNotes>
-      v5.1.5
-      - Percentage can not be initialized on environments lacking French or Iranian culture. #226
-      v5.1.4
-      - ConvertFrom(object) should not use fallback when TryCreate() fails. #194
-      v5.1.3
-      - ConvertFrom(object) should use Behavior.TryCreate(). #189
-      v5.1.2
-      - Extend Open API documentation with explicit example. #188
+v5.1.5
+- Percentage can not be initialized on environments lacking French or Iranian culture. #226
+v5.1.4
+- ConvertFrom(object) should not use fallback when TryCreate() fails. #194
+v5.1.3
+- ConvertFrom(object) should use Behavior.TryCreate(). #189
+v5.1.2
+- Extend Open API documentation with explicit example. #188
     </PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
As reported #226 

By selection the name of the culture provided (if any), this issue can easily be resolved.