### PR TITLE
Mark the Binary formatting helper as obsolete

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -96,6 +96,9 @@ dotnet_diagnostic.S107.severity = warning
 # S134: Control flow statements "if", "switch", "for", "foreach", "while", "do" and "try" should not be nested too deeply
 dotnet_diagnostic.S134.severity = warning
 
+# S138: Functions should not have too many lines of code
+dotnet_diagnostic.S138.severity = warning
+
 # S1067: Expressions should not be too complex
 dotnet_diagnostic.S1067.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -93,6 +93,9 @@ dotnet_diagnostic.S101.severity = none
 # S107: Methods should not have too many parameters
 dotnet_diagnostic.S107.severity = warning
 
+# S127: Methods should not have too many parameters
+dotnet_diagnostic.S127.severity = warning
+
 # S134: Control flow statements "if", "switch", "for", "foreach", "while", "do" and "try" should not be nested too deeply
 dotnet_diagnostic.S134.severity = warning
 

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -465,6 +465,7 @@ public class Is_Open_API_data_type
 public class Supports_binary_serialization
 {
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.EmailAddress);

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -596,6 +596,7 @@ public class Is_Open_API_data_type
 public class Supports_binary_serialization
 {
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Month);

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -1222,6 +1222,7 @@ public class Is_Open_API_data_type
 public class Supports_binary_serialization
 {
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Percentage);

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -539,6 +539,7 @@ public class Is_Open_API_data_type
 public class Supports_binary_serialization
 {
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.PostalCode);

--- a/specs/Qowaiv.Specs/Sex_specs.cs
+++ b/specs/Qowaiv.Specs/Sex_specs.cs
@@ -509,6 +509,7 @@ public class Is_Open_API_data_type
 public class Supports_binary_serialization
 {
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Sex);

--- a/specs/Qowaiv.Specs/Text/CharBuffer_specs.cs
+++ b/specs/Qowaiv.Specs/Text/CharBuffer_specs.cs
@@ -36,15 +36,6 @@ public class Add
 
 public class Remove
 {
-    [TestCase("Test", "this is a Test!", "this is a !")]
-    [TestCase("x", "What a fxckin' xwxsxmx feature.", "What a fckin' wsm feature.")]
-    [TestCase("%", "-3%", "-3")]
-    public void string_values_from_buffer(string remove, string input, string expected)
-    {
-        var buffer = input.Buffer();
-        Assert.AreEqual(expected, buffer.Remove(remove).ToString());
-    }
-
     [Test]
     public void FromStart_removes_characters_from_the_start()
     {

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -643,6 +643,7 @@ public class Is_Open_API_data_type
 public class Supports_binary_serialization
 {
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Uuid);

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
@@ -116,6 +116,7 @@ public class DateSpanTest
     }
 
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
     {
         var input = TestStruct;
@@ -141,6 +142,7 @@ public class DateSpanTest
     }
 
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_DateSpanSerializeObject_AreEqual()
     {
         var input = new DateSpanSerializeObject
@@ -202,6 +204,7 @@ public class DateSpanTest
     }
 
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
     {
         var input = new DateSpanSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
@@ -101,6 +101,7 @@ public class DateTest
     }
 
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
     {
         var input = TestStruct;
@@ -132,8 +133,8 @@ public class DateTest
         Assert.AreEqual(TestStruct, act);
     }
 
-
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_DateSerializeObject_AreEqual()
     {
         var input = new DateSerializeObject
@@ -195,6 +196,7 @@ public class DateTest
     }
 
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_MinValue_AreEqual()
     {
         var input = new DateSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
@@ -26,6 +26,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = GetTestInstance();
@@ -59,6 +60,7 @@ namespace Qowaiv.UnitTests
 
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_EmailAddressSerializeObject_AreEqual()
         {
             var input = new EmailAddressCollectionSerializeObject
@@ -120,6 +122,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Empty_AreEqual()
         {
             var input = new EmailAddressCollectionSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
@@ -123,6 +123,7 @@ namespace Qowaiv.Financial.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -156,6 +157,7 @@ namespace Qowaiv.Financial.UnitTests
 
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_AmountSerializeObject_AreEqual()
         {
             var input = new AmountSerializeObject
@@ -217,6 +219,7 @@ namespace Qowaiv.Financial.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new AmountSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
@@ -194,6 +194,7 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -225,8 +226,8 @@ namespace Qowaiv.UnitTests.Financial
             Assert.AreEqual(TestStruct, act);
         }
 
-
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
         {
             var input = new BusinessIdentifierCodeSerializeObject
@@ -288,6 +289,7 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Empty_AreEqual()
         {
             var input = new BusinessIdentifierCodeSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
@@ -238,6 +238,7 @@ public class CurrencyTest
     }
 
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
     {
         var input = CurrencyTest.TestStruct;
@@ -270,6 +271,7 @@ public class CurrencyTest
     }
 
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_CurrencySerializeObject_AreEqual()
     {
         var input = new CurrencySerializeObject
@@ -331,6 +333,7 @@ public class CurrencyTest
     }
 
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Empty_AreEqual()
     {
         var input = new CurrencySerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
@@ -130,6 +130,7 @@ namespace Qowaiv.UnitTests.Financial
         #region (XML) (De)serialization tests
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = InternationalBankAccountNumberTest.TestStruct;
@@ -161,8 +162,8 @@ namespace Qowaiv.UnitTests.Financial
             Assert.AreEqual(TestStruct, act);
         }
 
-
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()
         {
             var input = new InternationalBankAccountNumberSerializeObject
@@ -224,6 +225,7 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Empty_AreEqual()
         {
             var input = new InternationalBankAccountNumberSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
@@ -122,6 +122,7 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -154,6 +155,7 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_MoneySerializeObject_AreEqual()
         {
             var input = new MoneySerializeObject
@@ -215,6 +217,7 @@ namespace Qowaiv.UnitTests.Financial
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new MoneySerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsTest.cs
@@ -85,6 +85,7 @@ namespace Qowaiv.UnitTests.Formatting
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new FormattableArgumentsSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -265,6 +265,7 @@ namespace Qowaiv.UnitTests.Globalization
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = CountryTest.TestStruct;
@@ -298,6 +299,7 @@ namespace Qowaiv.UnitTests.Globalization
 
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_CountrySerializeObject_AreEqual()
         {
             var input = new CountrySerializeObject
@@ -359,6 +361,7 @@ namespace Qowaiv.UnitTests.Globalization
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Empty_AreEqual()
         {
             var input = new CountrySerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
@@ -245,6 +245,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -276,8 +277,8 @@ namespace Qowaiv.UnitTests
             Assert.AreEqual(TestStruct, act);
         }
 
-
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_HouseNumberSerializeObject_AreEqual()
         {
             var input = new HouseNumberSerializeObject
@@ -339,6 +340,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Empty_AreEqual()
         {
             var input = new HouseNumberSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
@@ -115,6 +115,7 @@ namespace Qowaiv.UnitTests.IO
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -147,6 +148,7 @@ namespace Qowaiv.UnitTests.IO
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_StreamSizeSerializeObject_AreEqual()
         {
             var input = new StreamSizeSerializeObject
@@ -208,6 +210,7 @@ namespace Qowaiv.UnitTests.IO
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new StreamSizeSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
@@ -170,6 +170,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -203,6 +204,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_IdForGuidSerializeObject_AreEqual()
         {
             var input = new IdForGuidSerializeObject
@@ -278,6 +280,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new IdForGuidSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
@@ -165,6 +165,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -198,6 +199,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_IdForInt32SerializeObject_AreEqual()
         {
             var input = new IdForInt32SerializeObject
@@ -273,6 +275,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new IdForInt32SerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
@@ -165,6 +165,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -198,6 +199,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_IdForInt64SerializeObject_AreEqual()
         {
             var input = new IdForInt64SerializeObject
@@ -273,6 +275,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new IdForInt64SerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
@@ -124,6 +124,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -157,6 +158,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_IdForStringSerializeObject_AreEqual()
         {
             var input = new IdForStringSerializeObject
@@ -232,6 +234,7 @@ namespace Qowaiv.UnitTests.Identifiers
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new IdForStringSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
@@ -115,6 +115,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = LocalDateTimeTest.TestStructNoMilliseconds;
@@ -146,8 +147,8 @@ namespace Qowaiv.UnitTests
             Assert.AreEqual(TestStruct, act);
         }
 
-
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
         {
             var input = new LocalDateTimeSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
@@ -100,6 +100,7 @@ namespace Qowaiv.UnitTests.Mathematics
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -133,6 +134,7 @@ namespace Qowaiv.UnitTests.Mathematics
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_FractionSerializeObject_AreEqual()
         {
             var input = new FractionSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
@@ -166,6 +168,7 @@ namespace Qowaiv.UnitTests.Mathematics
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new FractionSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -128,6 +128,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -161,6 +162,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_MonthSpanSerializeObject_AreEqual()
         {
             var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
@@ -194,6 +196,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
@@ -150,6 +150,7 @@ namespace Qowaiv.UnitTests.Sql
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
             =>  SerializeDeserialize.Binary(TestStruct).Should().Be(TestStruct);
 
@@ -173,6 +174,7 @@ namespace Qowaiv.UnitTests.Sql
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TimestampSerializeObject_AreEqual()
         {
             var input = new TimestampSerializeObject
@@ -234,6 +236,7 @@ namespace Qowaiv.UnitTests.Sql
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Default_AreEqual()
         {
             var input = new TimestampSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
@@ -146,6 +146,7 @@ namespace Qowaiv.UnitTests.Statistics
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = EloTest.TestStruct;
@@ -178,6 +179,7 @@ namespace Qowaiv.UnitTests.Statistics
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_EloSerializeObject_AreEqual()
         {
             var input = new EloSerializeObject
@@ -239,6 +241,7 @@ namespace Qowaiv.UnitTests.Statistics
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Zero_AreEqual()
         {
             var input = new EloSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
@@ -118,6 +118,7 @@ namespace Qowaiv.UnitTests.Text
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var act = SerializeDeserialize.Binary(TestPattern);

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
@@ -255,6 +255,7 @@ namespace Qowaiv.UnitTests.Web
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -287,6 +288,7 @@ namespace Qowaiv.UnitTests.Web
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_InternetMediaTypeSerializeObject_AreEqual()
         {
             var input = new InternetMediaTypeSerializeObject
@@ -348,6 +350,7 @@ namespace Qowaiv.UnitTests.Web
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Empty_AreEqual()
         {
             var input = new InternetMediaTypeSerializeObject

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
@@ -197,6 +197,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
         {
             var input = TestStruct;
@@ -229,6 +230,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_WeekDateSerializeObject_AreEqual()
         {
             var input = new WeekDateSerializeObject
@@ -290,6 +292,7 @@ namespace Qowaiv.UnitTests
         }
 
         [Test]
+        [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_MinValue_AreEqual()
         {
             var input = new WeekDateSerializeObject

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -567,6 +567,7 @@ public class Is_Open_API_data_type
 public class Supports_binary_serialization
 {
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Year);

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -577,6 +577,7 @@ public class Is_Open_API_data_type
 public class Supports_binary_serialization
 {
     [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.YesNo);

--- a/src/Qowaiv.TestTools/SerializeDeserialize.cs
+++ b/src/Qowaiv.TestTools/SerializeDeserialize.cs
@@ -1,65 +1,65 @@
 ﻿#pragma warning disable S5773 // Types allowed to be deserialized should be restricted
-// Test code, os no risk
+// Test code, so no risk
 
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
-namespace Qowaiv.TestTools
+namespace Qowaiv.TestTools;
+
+/// <summary>Helps with testing serialization code.</summary>
+public static class SerializeDeserialize
 {
-    /// <summary>Helps with testing serialization code.</summary>
-    public static class SerializeDeserialize
+    /// <summary>Serializes and deserializes an instance using <see cref="BinaryFormatter"/>.</summary>
+    /// <typeparam name="T">
+    /// Type of the instance.
+    /// </typeparam>
+    /// <param name="instance">
+    /// The instance to serialize and deserialize.
+    /// </param>
+    [Pure]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public static T Binary<T>(T instance)
     {
-        /// <summary>Serializes and deserializes an instance using <see cref="BinaryFormatter"/>.</summary>
-        /// <typeparam name="T">
-        /// Type of the instance.
-        /// </typeparam>
-        /// <param name="instance">
-        /// The instance to serialize and deserialize.
-        /// </param>
-        [Pure]
-        public static T Binary<T>(T instance)
-        {
-            using var buffer = new MemoryStream();
-            var formatter = new BinaryFormatter();
-            formatter.Serialize(buffer, instance ?? throw new ArgumentNullException(nameof(instance)));
-            buffer.Position = 0;
-            return Not.Null((T?)formatter.Deserialize(buffer));
-        }
+        using var buffer = new MemoryStream();
+        var formatter = new BinaryFormatter();
+        formatter.Serialize(buffer, instance ?? throw new ArgumentNullException(nameof(instance)));
+        buffer.Position = 0;
+        return Not.Null((T?)formatter.Deserialize(buffer));
+    }
 
-        /// <summary>Serializes and deserializes an instance using a <see cref="DataContractSerializer"/>.</summary>
-        /// <typeparam name="T">
-        /// Type of the instance.
-        /// </typeparam>
-        /// <param name="instance">
-        /// The instance to (XML) serialize and (XML) deserialize.
-        /// </param>
-        [Pure]
-        public static T DataContract<T>(T instance)
-        {
-            using var stream = new MemoryStream();
+    /// <summary>Serializes and deserializes an instance using a <see cref="DataContractSerializer"/>.</summary>
+    /// <typeparam name="T">
+    /// Type of the instance.
+    /// </typeparam>
+    /// <param name="instance">
+    /// The instance to (XML) serialize and (XML) deserialize.
+    /// </param>
+    [Pure]
+    public static T DataContract<T>(T instance)
+    {
+        using var stream = new MemoryStream();
 
-            var serializer = new DataContractSerializer(typeof(T));
-            serializer.WriteObject(stream, instance);
-            stream.Position = 0;
-            return Not.Null((T?)serializer.ReadObject(stream));
-        }
+        var serializer = new DataContractSerializer(typeof(T));
+        serializer.WriteObject(stream, instance);
+        stream.Position = 0;
+        return Not.Null((T?)serializer.ReadObject(stream));
+    }
 
-        /// <summary>Serializes and deserializes an instance using an <see cref="XmlSerializer"/>.</summary>
-        /// <typeparam name="T">
-        /// Type of the instance.
-        /// </typeparam>
-        /// <param name="instance">
-        /// The instance to (XML) serialize and (XML) deserialize.
-        /// </param>
-        [Pure]
-        public static T Xml<T>(T instance)
-        {
-            using var stream = new MemoryStream();
-            var writer = new XmlTextWriter(stream, Encoding.UTF8);
-            var serializer = new XmlSerializer(typeof(T));
-            serializer.Serialize(writer, instance);
-            stream.Position = 0;
-            return Not.Null((T?)serializer.Deserialize(stream));
-        }
+    /// <summary>Serializes and deserializes an instance using an <see cref="XmlSerializer"/>.</summary>
+    /// <typeparam name="T">
+    /// Type of the instance.
+    /// </typeparam>
+    /// <param name="instance">
+    /// The instance to (XML) serialize and (XML) deserialize.
+    /// </param>
+    [Pure]
+    public static T Xml<T>(T instance)
+    {
+        using var stream = new MemoryStream();
+        var writer = new XmlTextWriter(stream, Encoding.UTF8);
+        var serializer = new XmlSerializer(typeof(T));
+        serializer.Serialize(writer, instance);
+        stream.Position = 0;
+        return Not.Null((T?)serializer.Deserialize(stream));
     }
 }

--- a/src/Qowaiv/Formatting/FormattingArgumentsCollection.cs
+++ b/src/Qowaiv/Formatting/FormattingArgumentsCollection.cs
@@ -93,6 +93,7 @@ public class FormattingArgumentsCollection : IEnumerable<KeyValuePair<Type, Form
 #nullable disable
 #pragma warning disable S125 // Sections of code should not be "commented out"
 #pragma warning disable S134 // Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+#pragma warning disable S138 // Functions should not have too many lines of code
 #pragma warning disable S1227 // break statements should not be used except for switch cases
 #pragma warning disable S1541 // Methods and properties should not be too complex
 #pragma warning disable S1854 // Dead stores should be removed
@@ -276,8 +277,9 @@ public class FormattingArgumentsCollection : IEnumerable<KeyValuePair<Type, Form
 #pragma warning restore S1854 // Dead stores should be removed
 #pragma warning restore S1541 // Methods and properties should not be too complex
 #pragma warning restore S1227 // break statements should not be used except for switch cases
-#pragma warning restore S125 // Sections of code should not be "commented out"
+#pragma warning restore S138 // Functions should not have too many lines of code
 #pragma warning restore S134 // Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+#pragma warning restore S125 // Sections of code should not be "commented out"
 #pragma warning restore IDE0059 // Unnecessary assignment of a value
 #nullable enable
 

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -322,7 +322,7 @@ public partial struct Id<TIdentifier> : ISerializable, IXmlSerializable, IFormat
     public static Id<TIdentifier> Create(object obj)
         => TryCreate(obj, out var id)
         ? id
-        : throw Exceptions.InvalidCast(obj.GetType(), typeof(Id<TIdentifier>));
+        : throw Exceptions.InvalidCast(Not.Null(obj?.GetType()), typeof(Id<TIdentifier>));
 
     /// <summary>Tries to create an identifier from an <see cref="object"/>.</summary>
     /// <param name="obj">

--- a/src/Qowaiv/Text/CharBuffer.Transform.cs
+++ b/src/Qowaiv/Text/CharBuffer.Transform.cs
@@ -48,32 +48,6 @@ internal partial class CharBuffer
         return this;
     }
 
-    /// <summary>Removes all instances of <param name="str"/> from the buffer.</summary>
-    [FluentSyntax]
-    public CharBuffer Remove(string str)
-    {
-        var match = 0;
-        for (var i = 0; i < Length; i++)
-        {
-            if (str[match] == this[i])
-            {
-                match++;
-
-                if (match == str.Length)
-                {
-                    i -= match - 1;
-                    RemoveRange(i, match);
-                    match = 0;
-                }
-            }
-            else
-            {
-                match = 0;
-            }
-        }
-        return this;
-    }
-
     /// <summary>Removes a specified length from the start of the buffer.</summary>
     [FluentSyntax]
     public CharBuffer RemoveFromStart(int length)


### PR DESCRIPTION
The `BinaryFormatter` has been deprecated by Microsoft, as it is considered harmful, and beyond repair. Therefor, `DeserializeSerialize.Binary` should also be marked as depricated/obsolete.