### PR TITLE
Percentage.MaxValue should be able to be represented as a string

### DIFF
--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -310,6 +310,18 @@ public class Has_custom_formatting
             Assert.AreEqual("1751‱", Svo.Percentage.ToString("PT"));
         }
     }
+
+    [TestCase("0.##%", "792281625142643375935439503.35%")]
+    [TestCase("0.#‰", "7922816251426433759354395033.5‰")]
+    [TestCase("0‱", "79228162514264337593543950335‱")]
+    public void for_max_value(string format, string formatted)
+        => Percentage.MaxValue.ToString(format, CultureInfo.InvariantCulture).Should().Be(formatted);
+
+    [TestCase("0.##%", "-792281625142643375935439503.35%")]
+    [TestCase("0.#‰", "-7922816251426433759354395033.5‰")]
+    [TestCase("0‱", "-79228162514264337593543950335‱")]
+    public void for_min_value(string format, string formatted)
+        => Percentage.MinValue.ToString(format, CultureInfo.InvariantCulture).Should().Be(formatted);
 }
 
 public class Formatting_is_invalid

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -28,10 +28,10 @@ public partial struct Percentage : ISerializable, IXmlSerializable, IFormattable
     public static readonly Percentage Hundred = 100.Percent();
 
     /// <summary>Gets the minimum value of a percentage.</summary>
-    public static readonly Percentage MinValue = new(decimal.MinValue);
+    public static readonly Percentage MinValue = new(decimal.MinValue / 10_000);
 
     /// <summary>Gets the maximum value of a percentage.</summary>
-    public static readonly Percentage MaxValue = new(decimal.MaxValue);
+    public static readonly Percentage MaxValue = new(decimal.MaxValue / 10_000);
 
     #region Percentage manipulation
 
@@ -656,7 +656,7 @@ public partial struct Percentage : ISerializable, IXmlSerializable, IFormattable
     {
         result = Zero;
 
-        if (s is { Length: > 0} 
+        if (s is { Length: > 0 }
             && FormatInfo.TryParse(s, formatProvider, out var info)
             && decimal.TryParse(info.Format, NumberStyles.Number, info.Provider, out var dec))
         {


### PR DESCRIPTION
To represent a percentage as a string its internal `decimal` value must support a multiplication with 10,000 (when using the per ten thousand symbol). Therefor, the `Percentage.MaxValue` and the `Percentage.MinValue` should be reduced by the same factor.