### PR TITLE
Int64 based id should serialize to a JSON string by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | version                                                                       | package                                                                     |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-|![v](https://img.shields.io/badge/version-6.0.0-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
+|![v](https://img.shields.io/badge/version-6.0.1-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
 |![v](https://img.shields.io/badge/version-6.0.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Data.SqlCient](https://www.nuget.org/packages/Qowaiv.Data.SqlClient/)|
 |![v](https://img.shields.io/badge/version-6.0.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)         |
 

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -1,5 +1,20 @@
 ﻿namespace Identifiers.Id_for_Int64_specs;
 
+public class Supports_JSON_serialization
+{
+    [TestCase(0, null)]
+    [TestCase(123456789L, "123456789")]
+    public void convention_based_deserialization(Int64Id svo, object json)
+        => JsonTester.Read<Int64Id>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase(null, 0)]
+    [TestCase("123456789", 123456789L)]
+    [TestCase("123456789", "123456789")]
+    public void convention_based_serialization(object json, Int64Id svo)
+        => JsonTester.Write(svo).Should().Be(json);
+}
+
 public class Supports_type_conversion
 {
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
@@ -338,23 +338,6 @@ namespace Qowaiv.UnitTests.Identifiers
             Assert.Catch<FormatException>(() => JsonTester.Read<Id<ForInt64>>(json));
         }
 
-        [TestCase("123456789", "123456789")]
-        [TestCase("12345678", 12345678L)]
-        [TestCase("", "")]
-        [TestCase("", 0L)]
-        public void FromJson(Id<ForInt64> expected, object json)
-        {
-            var actual = JsonTester.Read<Id<ForInt64>>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ToJson_TestStruct_LongValue()
-        {
-            var json = TestStruct.ToJson();
-            Assert.AreEqual(123456789L, json);
-        }
-
         [Test]
         public void ToString_Empty_StringEmpty()
         {

--- a/src/Qowaiv/Identifiers/Int64IdBehavior.cs
+++ b/src/Qowaiv/Identifiers/Int64IdBehavior.cs
@@ -49,7 +49,7 @@ public class Int64IdBehavior : IdentifierBehavior
 
     /// <inheritdoc/>
     [Pure]
-    public override object? ToJson(object? obj) => Id(obj);
+    public override object? ToJson(object? obj)=> Id(obj).ToString();
 
     /// <inheritdoc/>
     public override bool TryParse(string? str, out object? id)

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,8 +5,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.0.0</Version>
+    <Version>6.0.1</Version>
     <PackageReleaseNotes>
+v6.0.1
+- Int64 based id serializes to a JSON string #236 
+- Percentage.MaxValue representable as a string #235
 v6.0.0
 - Added .NET 6.0 version to the package. #216
 - Sex as replacement Gender (ISO 5218). #214


### PR DESCRIPTION
In JavaScript, int64's are not guaranteed represented correctly as some number implementations are 32-bit. Therefore, the should be serialized as JSON strings instead.