### PR TITLE
Extend Open API to support Id<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | version                                                                       | package                                                                     |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-|![v](https://img.shields.io/badge/version-6.0.1-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
+|![v](https://img.shields.io/badge/version-6.0.2-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
 |![v](https://img.shields.io/badge/version-6.0.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Data.SqlCient](https://www.nuget.org/packages/Qowaiv.Data.SqlClient/)|
 |![v](https://img.shields.io/badge/version-6.0.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)         |
 

--- a/README.md
+++ b/README.md
@@ -685,14 +685,6 @@ and if the data type is nullable, all when applicable.
     "format": "email-collection",
     "nullabe": true
   },
-  "Gender": {
-    "description": "Gender as specified by ISO/IEC 5218.",
-    "example": "female",
-    "type": "string",
-    "format": "gender",
-    "nullabe": true,
-    "enum": ["NotKnown", "Male", "Female", "NotApplicable"]
-  },
   "HouseNumber": {
     "description": "House number notation.",
     "example": "13",
@@ -737,6 +729,14 @@ and if the data type is nullable, all when applicable.
     "type": "string",
     "format": "postal-code",
     "nullabe": true
+  },
+  "Sex": {
+    "description": "Sex as specified by ISO/IEC 5218.",
+    "example": "female",
+    "type": "string",
+    "format": "sex",
+    "nullabe": true,
+    "enum": ["NotKnown", "Male", "Female", "NotApplicable"]
   },
   "Uuid": {
     "description": "Universally unique identifier, Base64 encoded.",
@@ -810,15 +810,44 @@ and if the data type is nullable, all when applicable.
     "format": "country",
     "nullabe": true
   },
-  "Identifiers.Id<TIdentifier>": {
-    "description": "identifier",
+  "Identifiers.GuidBehavior": {
+    "description": "GUID based identifier",
     "example": "8a1a8c42-d2ff-e254-e26e-b6abcbf19420",
-    "type": "any",
-    "nullabe": false
+    "type": "string",
+    "format": "guid",
+    "nullabe": true
+  },
+  "Identifiers.Int32IdBehavior": {
+    "description": "Int32 based identifier",
+    "example": 17,
+    "type": "integer",
+    "format": "identifier",
+    "nullabe": true
+  },
+  "Identifiers.Int64IdBehavior": {
+    "description": "Int64 based identifier",
+    "example": 17,
+    "type": "integer",
+    "format": "identifier",
+    "nullabe": true
+  },
+  "Identifiers.StringIdBehavior": {
+    "description": "String based identifier",
+    "example": "lmZO_haEOTCwGsCcbIZFFg",
+    "type": "string",
+    "format": "identifier",
+    "nullabe": true
+  },
+  "Identifiers.UuidBehavior": {
+    "description": "UUID based identifier",
+    "example": "lmZO_haEOTCwGsCcbIZFFg",
+    "type": "string",
+    "format": "uuid-base64",
+    "nullabe": true
   },
   "IO.StreamSize": {
     "description": "Stream size notation (in byte).",
-    "example": 1024",
+    "example": 1024,
     "type": "integer",
     "format": "stream-size",
     "nullabe": false
@@ -833,7 +862,7 @@ and if the data type is nullable, all when applicable.
   },
   "Statistics.Elo": {
     "description": "Elo rating system notation.",
-    "example": 1600,
+    "example": 1600.0,
     "type": "number",
     "format": "elo",
     "nullabe": false
@@ -858,25 +887,26 @@ public static class SwaggerGenOptionsSvoExtensions
     /// <summary>Maps Qowaiv SVO's.</summary>
     public static SwaggerGenOptions MapSingleValueObjects(this SwaggerGenOptions options)
     {
-        var attributes = OpenApiDataTypeAttribute.From(typeof(Date).Assembly);
-        foreach (var attr in attributes)
+        var infos = OpenApiDataTypes.FromAssemblies(typeof(Date).Assembly);
+        foreach (var info in infos)
         {
-            options.MapType(attr.DataType, () => new OpenApiSchema
+            options.MapType(info.DataType, () => new OpenApiSchema
             {
-                Type = attr.Type,
-                Example = attr.Example(),
-                Format = attr.Format,
-                Pattern = attr.Pattern,
-                Nullable = attr.Nullable,
+                Type = info.Type,
+                Example = info.Example(),
+                Format = info.Format,
+                Pattern = info.Pattern,
+                Nullable = info.Nullable,
             });
         }
+        return options;
     }
 
-    private static IOpenApiAny Example(this OpenApiDataTypeAttribute attr)
-        => attr.Type switch
+    private static IOpenApiAny Example(this OpenApiDataType info)
+        => info.Example switch
         {
-            "integer" => new OpenApiInteger((int)attr.Example),
-            "number" => new OpenApiDouble((double)attr.Example),
+            int integer => new OpenApiInteger(integer),
+            double floating => new OpenApiDouble(floating),
             _ => new OpenApiString(attr.Example.ToString()),
         };
 }

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ and if the data type is nullable, all when applicable.
   },
   "Identifiers.StringIdBehavior": {
     "description": "String based identifier",
-    "example": "lmZO_haEOTCwGsCcbIZFFg",
+    "example": "Order-UK-2022-215",
     "type": "string",
     "format": "identifier",
     "nullabe": true

--- a/README.md
+++ b/README.md
@@ -877,9 +877,9 @@ and if the data type is nullable, all when applicable.
 }
 ```
   
-#### OpenApi using Swagger 
-When using [Swagger](https://swagger.io/resources/open-api/) to implement
-OpenApi this could be done like below:
+#### Open API using Swagger 
+When using [Swagger](https://swagger.io/resources/open-api/) to communicate
+an Open API definition, this could be done like below:
 ``` C#
 /// <summary>Extensions on <see cref="SwaggerGenOptions"/>.</summary>
 public static class SwaggerGenOptionsSvoExtensions

--- a/props/common.props
+++ b/props/common.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.36.1.44192">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.38.0.46746">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/specs/Qowaiv.Specs/DateSpan_specs.cs
+++ b/specs/Qowaiv.Specs/DateSpan_specs.cs
@@ -24,3 +24,17 @@ public class Supports_type_conversion
         }
     }
 }
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+       => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(DateSpan))
+       .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+           dataType: typeof(DateSpan),
+           description: "Date span, specified in years, months and days.",
+           example: "1Y+10M+16D",
+           type: "string",
+           format: "date-span",
+           pattern: @"[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D"));
+}

--- a/specs/Qowaiv.Specs/Date_specs.cs
+++ b/specs/Qowaiv.Specs/Date_specs.cs
@@ -120,6 +120,19 @@ public class Supports_type_conversion
         => Converting.To<WeekDate>().From(Svo.Date).Should().Be(new WeekDate(2017, 23, 7));
 }
 
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+       => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Date))
+       .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+           dataType: typeof(Date),
+           description: "Full-date notation as defined by RFC 3339, section 5.6.",
+           example: "2017-06-10",
+           type: "string",
+           format: "date"));
+}
+
 public class Casts_with_dotnet_6_0
 {
     [Test]

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -444,6 +444,17 @@ public class Supports_XML_serialization
 
 public class Is_Open_API_data_type
 {
+    [Test]
+    public void with_info()
+       => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(EmailAddress))
+       .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+           dataType: typeof(EmailAddress),
+           description: "Email notation as defined by RFC 5322.",
+           type: "string",
+           example: "svo@qowaiv.org",
+           format: "email",
+           nullable: true));
+
     internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(EmailAddress)).FirstOrDefault();
 
     [Test]

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -454,23 +454,6 @@ public class Is_Open_API_data_type
            example: "svo@qowaiv.org",
            format: "email",
            nullable: true));
-
-    internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(EmailAddress)).FirstOrDefault();
-
-    [Test]
-    public void with_description() => Attribute.Description.Should().Be("Email notation as defined by RFC 5322.");
-
-    [Test]
-    public void with_example() => Attribute.Example.Should().Be("svo@qowaiv.org");
-
-    [Test]
-    public void has_type() => Attribute.Type.Should().Be("string");
-
-    [Test]
-    public void has_format() => Attribute.Format.Should().Be("email");
-
-    [Test]
-    public void pattern_is_null() => Attribute.Pattern.Should().BeNull();
 }
 
 public class Supports_binary_serialization

--- a/specs/Qowaiv.Specs/HouseNumber_specs.cs
+++ b/specs/Qowaiv.Specs/HouseNumber_specs.cs
@@ -95,3 +95,17 @@ public class Supports_type_conversion
     public void to_long()
         => Converting.To<long>().From(Svo.HouseNumber).Should().Be(123456789L);
 }
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+       => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(HouseNumber))
+       .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+           dataType: typeof(HouseNumber),
+           description: "House number notation.",
+           example: "13",
+           type: "string",
+           format: "house-number",
+           nullable: true));
+}

--- a/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
+++ b/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
@@ -218,3 +218,16 @@ public class Supports_type_conversion
     public void to_long()
         => Converting.To<long>().From(Svo.StreamSize).Should().Be(123456789);
 }
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(StreamSize))
+        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(StreamSize),
+            description: "Stream size notation (in byte).",
+            example: 1024,
+            type: "integer",
+            format: "stream-size"));
+}

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -60,3 +60,15 @@ public class Supports_type_conversion
         => Converting.To<Uuid>().From(Svo.CustomGuid).Should().Be(Svo.Uuid);
 }
 
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(ForGuid))
+        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(CustomGuid),
+            description: "GUID based identifier",
+            example: "8a1a8c42-d2ff-e254-e26e-b6abcbf19420",
+            type: "string",
+            format: "guid"));
+}

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -70,5 +70,6 @@ public class Is_Open_API_data_type
             description: "GUID based identifier",
             example: "8a1a8c42-d2ff-e254-e26e-b6abcbf19420",
             type: "string",
-            format: "guid"));
+            format: "guid",
+            nullable: true));
 }

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
@@ -51,3 +51,16 @@ public class Supports_type_conversion
         => Converting.To<int>().From(Svo.Int32Id).Should().Be(17);
 }
 
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(ForInt32))
+        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(Int32Id),
+            description: "Int32 based identifier",
+            example: 17,
+            type: "integer",
+            format: "identifier",
+            nullable: true));
+}

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -77,3 +77,17 @@ public class Supports_type_conversion
             .WithMessage("Cast from long to Qowaiv.Identifiers.Id<Qowaiv.TestTools.ForInt64> is not valid.");
     }
 }
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(ForInt64))
+        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(Int64Id),
+            description: "Int64 based identifier",
+            example: 17,
+            type: "integer",
+            format: "identifier",
+            nullable: true));
+}

--- a/specs/Qowaiv.Specs/Json/Open_API_specs.cs
+++ b/specs/Qowaiv.Specs/Json/Open_API_specs.cs
@@ -5,49 +5,5 @@ public class SVOs : SvoTypeTest
     [TestCaseSource(nameof(JsonSerializable))]
     public void Has_OpenApiDataType_attribute(Type svo)
         => svo.Should().BeDecoratedWith<OpenApiDataTypeAttribute>();
-
-    [Test]
-    public void For_README_md()
-    {
-        var attributes = OpenApiDataTypeAttribute.From(typeof(Date).Assembly)
-            .OrderBy(attr => attr.DataType.Namespace)
-            .ThenBy(attr => attr.DataType.Name);
-
-        var all = new Dictionary<string, OpenApiDataType>();
-
-        foreach (var attribute in attributes)
-        {
-            var name = $"{attribute.DataType.Namespace}.{attribute.DataType.Name}".Replace("Qowaiv.", "", StringComparison.InvariantCulture);
-
-            all[name] = new OpenApiDataType
-            {
-                description = attribute.Description,
-                example = attribute.Example,
-                type = attribute.Type,
-                format = attribute.Format,
-                pattern = attribute.Pattern,
-                nullabe = attribute.Nullable,
-                @enum = attribute.Enum,
-            };
-        }
-
-        Console.WriteLine(JsonConvert.SerializeObject(all, Newtonsoft.Json.Formatting.Indented, new JsonSerializerSettings
-        {
-            NullValueHandling = NullValueHandling.Ignore,
-        }));
-
-        all.Should().NotBeEmpty();
-    }
-
-    private class OpenApiDataType
-    {
-        public string description { get; set; }
-        public object example { get; set; }
-        public string type { get; set; }
-        public string format { get; set; }
-        public string pattern { get; set; }
-        public bool nullabe { get; set; }
-        public string[] @enum { get; set; }
-    }
 }
 

--- a/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
+++ b/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
@@ -182,3 +182,17 @@ public class Supports_type_conversion
         }
     }
 }
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Fraction))
+        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(Fraction),
+            description: "Faction",
+            type: "string",
+            format: "faction",
+            pattern: "-?[0-9]+(/[0-9]+)?",
+            example: "13/42"));
+}

--- a/specs/Qowaiv.Specs/MonthSpan_specs.cs
+++ b/specs/Qowaiv.Specs/MonthSpan_specs.cs
@@ -95,3 +95,17 @@ public class Supports_type_conversion
     public void to_int()
         => Converting.To<int>().From(Svo.MonthSpan).Should().Be(69);
 }
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+       => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(MonthSpan))
+       .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+           dataType: typeof(MonthSpan),
+           description: "Month span, specified in years and months.",
+           example: "1Y+10M",
+           type: "string",
+           format: "month-span",
+           pattern: @"[+-]?[0-9]+Y[+-][0-9]+M"));
+}

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -567,7 +567,20 @@ public class Supports_XML_serialization
 
 public class Is_Open_API_data_type
 {
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Month))
+        .Should().BeEquivalentTo(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(Month),
+            description: "Month(-only) notation.",
+            type: "string",
+            example: "Jun",
+            format: "month",
+            @enum: new[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "?" },
+            nullable: true));
+
     internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Month)).FirstOrDefault();
+    
     [Test]
     public void with_description()
     {

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -578,32 +578,6 @@ public class Is_Open_API_data_type
             format: "month",
             @enum: new[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "?" },
             nullable: true));
-
-    internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Month)).FirstOrDefault();
-    
-    [Test]
-    public void with_description()
-    {
-        Assert.AreEqual("Month(-only) notation.", Attribute.Description);
-    }
-
-    [Test]
-    public void has_type()
-    {
-        Assert.AreEqual("string", Attribute.Type);
-    }
-
-    [Test]
-    public void has_format()
-    {
-        Assert.AreEqual("month", Attribute.Format);
-    }
-
-    [Test]
-    public void pattern_is_null()
-    {
-        Assert.IsNull(Attribute.Pattern);
-    }
 }
 
 public class Supports_binary_serialization

--- a/specs/Qowaiv.Specs/OpenApi/Open_API_specs.cs
+++ b/specs/Qowaiv.Specs/OpenApi/Open_API_specs.cs
@@ -1,0 +1,83 @@
+﻿using Qowaiv.OpenApi;
+using OpenApiDataTypeAttribute = Qowaiv.OpenApi.OpenApiDataTypeAttribute;
+
+namespace Open_API_specs;
+
+public class OpenApiDataType_attributes : SvoTypeTest
+{
+    public static IEnumerable<Type> Decoratable
+        => JsonSerializable.Where(tp => !tp.IsGenericType);
+
+    [TestCaseSource(nameof(Decoratable))]
+    public void Decorates(Type svo)
+        => svo.Should().BeDecoratedWith<OpenApiDataTypeAttribute>();
+}
+
+public class Open_API_data_type
+{
+    [Test]
+    public void Resolved_by_base_if_not_decorated()
+        => OpenApiDataType.FromType(typeof(ForUuid))
+        .Should().Be(new OpenApiDataType(
+            dataType: typeof(CustomUuid),
+            description: "UUID based identifier",
+            type: "string",
+            example: "lmZO_haEOTCwGsCcbIZFFg",
+            format: "uuid-base64"));
+
+    [Test]
+    public void IIDentifierBehavior_is_resolved_as_Id_type()
+        => OpenApiDataType.FromType(typeof(DecoratedId))
+        .Should().Be(new OpenApiDataType(
+            dataType: typeof(Id<DecoratedId>),
+            description: "Custom description",
+            type: "string",
+            example: "custom example",
+            format: "custom-uuid"));
+
+
+    [OpenApiDataType(description: "Custom description", example: "custom example", type: "string", format: "custom-uuid")]
+    internal sealed class DecoratedId : UuidBehavior { }
+}
+
+public class README_md
+{
+    [Test]
+    public void Describes()
+    {
+        var all = OpenApiDataTypes.FromAssemblies(typeof(Date).Assembly)
+            .OrderBy(attr => attr.DataType.Namespace)
+            .ThenBy(attr => attr.DataType.Name)
+            .ToDictionary(
+                info => $"{info.DataType.Namespace}.{info.DataType.Name}".Replace("Qowaiv.", "", StringComparison.InvariantCulture),
+                info => new OpenApiDataTypeInfo
+                {
+                    description = info.Description,
+                    example = info.Example,
+                    type = info.Type,
+                    format = info.Format,
+                    pattern = info.Pattern,
+                    nullabe = info.Nullable,
+                    @enum = info.Enum?.ToArray(),
+                });
+
+        Console.WriteLine(JsonConvert.SerializeObject(all, Formatting.Indented, new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+        }));
+
+        all.Should().NotBeEmpty();
+    }
+
+    private sealed record OpenApiDataTypeInfo
+    {
+        public string description { get; init; }
+        public object example { get; init; }
+        public string type { get; init; }
+        public string format { get; init; }
+        public string pattern { get; init; }
+        public bool nullabe { get; init; }
+        public string[] @enum { get; init; }
+    }
+}
+

--- a/specs/Qowaiv.Specs/OpenApi/Open_API_specs.cs
+++ b/specs/Qowaiv.Specs/OpenApi/Open_API_specs.cs
@@ -23,7 +23,8 @@ public class Open_API_data_type
             description: "UUID based identifier",
             type: "string",
             example: "lmZO_haEOTCwGsCcbIZFFg",
-            format: "uuid-base64"));
+            format: "uuid-base64",
+            nullable: true));
 
     [Test]
     public void IIDentifierBehavior_is_resolved_as_Id_type()

--- a/specs/Qowaiv.Specs/OpenApi/Open_API_specs.cs
+++ b/specs/Qowaiv.Specs/OpenApi/Open_API_specs.cs
@@ -36,6 +36,16 @@ public class Open_API_data_type
             example: "custom example",
             format: "custom-uuid"));
 
+    [Test]
+        public void has_custom_debug_display()
+            => new OpenApiDataType(
+            dataType: typeof(Date),
+            description: "Custom description",
+            type: "string",
+            example: "custom example",
+            format: "custom-uuid",
+            pattern: "[0-9]{4}-[0-9]{2}-[0-9]{2}")
+        .Should().HaveDebuggerDisplay("{ type: string, desc: Custom description, example: custom example, format: custom-uuid, pattern: [0-9]{4}-[0-9]{2}-[0-9]{2} }");
 
     [OpenApiDataType(description: "Custom description", example: "custom example", type: "string", format: "custom-uuid")]
     internal sealed class DecoratedId : UuidBehavior { }

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -1221,25 +1221,12 @@ public class Is_Open_API_data_type
              format: "percentage",
              pattern: @"-?[0-9]+(\.[0-9]+)?%"));
 
-    internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Percentage)).FirstOrDefault();
-
-    [Test]
-    public void with_description() => Attribute.Description.Should().Be("Ratio expressed as a fraction of 100 denoted using the percent sign '%'.");
-
-    [Test]
-    public void with_example() => Attribute.Example.Should().Be("13.76%");
-
-    [Test]
-    public void has_type() => Attribute.Type.Should().Be("string");
-
-    [Test]
-    public void has_format() => Attribute.Format.Should().Be("percentage");
-
     [TestCase("17.51%")]
     [TestCase("-4.1%")]
     [TestCase("-0.1%")]
     [TestCase("31%")]
-    public void pattern_matches(string input) => Regex.IsMatch(input, Attribute.Pattern).Should().BeTrue();
+    public void pattern_matches(string input) 
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Percentage)).Matches(input).Should().BeTrue();
 }
 
 public class Supports_binary_serialization

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -1210,6 +1210,17 @@ public class Supports_XML_serialization
 
 public class Is_Open_API_data_type
 {
+    [Test]
+    public void with_info()
+         => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Percentage))
+         .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+             dataType: typeof(Percentage),
+             description: "Ratio expressed as a fraction of 100 denoted using the percent sign '%'.",
+             type: "string",
+             example: "13.76%",
+             format: "percentage",
+             pattern: @"-?[0-9]+(\.[0-9]+)?%"));
+
     internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Percentage)).FirstOrDefault();
 
     [Test]

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -507,6 +507,17 @@ public class Supports_XML_serialization
 
 public class Is_Open_API_data_type
 {
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(PostalCode))
+        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(PostalCode),
+            description: "Postal code notation.",
+            type: "string",
+            example: "2624DP",
+            format: "postal-code",
+            nullable: true));
+
     internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(PostalCode)).FirstOrDefault();
 
     [Test]

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -517,34 +517,6 @@ public class Is_Open_API_data_type
             example: "2624DP",
             format: "postal-code",
             nullable: true));
-
-    internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(PostalCode)).FirstOrDefault();
-
-    [Test]
-    public void with_description()
-    {
-        Assert.AreEqual(
-            "Postal code notation.",
-            Attribute.Description);
-    }
-
-    [Test]
-    public void has_type()
-    {
-        Assert.AreEqual("string", Attribute.Type);
-    }
-
-    [Test]
-    public void has_format()
-    {
-        Assert.AreEqual("postal-code", Attribute.Format);
-    }
-
-    [Test]
-    public void pattern_is_null()
-    {
-        Assert.IsNull(Attribute.Pattern);
-    }
 }
 
 public class Supports_binary_serialization

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -19,8 +19,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.16.0">
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/specs/Qowaiv.Specs/Sex_specs.cs
+++ b/specs/Qowaiv.Specs/Sex_specs.cs
@@ -474,7 +474,20 @@ public class Supports_XML_serialization
 
 public class Is_Open_API_data_type
 {
+    [Test]
+    public void with_info()
+       => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Sex))
+       .Should().BeEquivalentTo(new Qowaiv.OpenApi.OpenApiDataType(
+           dataType: typeof(Sex),
+           description: "Sex as specified by ISO/IEC 5218.",
+           type: "string",
+           example: "female",
+           format: "sex",
+           @enum: new[] { "NotKnown", "Male", "Female", "NotApplicable" },
+           nullable: true));
+
     internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Sex)).FirstOrDefault();
+    
     [Test]
     public void with_description()
     {

--- a/specs/Qowaiv.Specs/Sex_specs.cs
+++ b/specs/Qowaiv.Specs/Sex_specs.cs
@@ -485,38 +485,6 @@ public class Is_Open_API_data_type
            format: "sex",
            @enum: new[] { "NotKnown", "Male", "Female", "NotApplicable" },
            nullable: true));
-
-    internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Sex)).FirstOrDefault();
-    
-    [Test]
-    public void with_description()
-    {
-        Assert.AreEqual("Sex as specified by ISO/IEC 5218.", Attribute.Description);
-    }
-
-    [Test]
-    public void has_type()
-    {
-        Assert.AreEqual("string", Attribute.Type);
-    }
-
-    [Test]
-    public void has_format()
-    {
-        Assert.AreEqual("sex", Attribute.Format);
-    }
-
-    [Test]
-    public void has_enum()
-    {
-        Assert.AreEqual(new[] { "NotKnown", "Male", "Female", "NotApplicable" }, Attribute.Enum);
-    }
-
-    [Test]
-    public void pattern_is_null()
-    {
-        Assert.IsNull(Attribute.Pattern);
-    }
 }
 
 public class Supports_binary_serialization

--- a/specs/Qowaiv.Specs/Sql/Timestamp_specs.cs
+++ b/specs/Qowaiv.Specs/Sql/Timestamp_specs.cs
@@ -44,3 +44,17 @@ public class Is_equal_by_value
         }
     }
 }
+
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Timestamp))
+        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(Timestamp),
+            description: "SQL Server timestamp notation.",
+            example: "0x00000000000007D9",
+            type: "string",
+            format: "timestamp"));
+}

--- a/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
+++ b/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
@@ -104,3 +104,16 @@ public class Supports_type_conversion
         }
     }
 }
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Elo))
+        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(Elo),
+            description: "Elo rating system notation.",
+            example: 1600d,
+            type: "number",
+            format: "elo"));
+}

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -622,6 +622,17 @@ public class Supports_XML_serialization
 
 public class Is_Open_API_data_type
 {
+    [Test]
+    public void with_info()
+       => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Uuid))
+       .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+           dataType: typeof(Uuid),
+           description: "Universally unique identifier, Base64 encoded.",
+           example: "lmZO_haEOTCwGsCcbIZFFg",
+           type: "string",
+           format: "uuid-base64",
+           nullable: true));
+
     internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Uuid)).FirstOrDefault();
 
     [Test]

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -632,23 +632,6 @@ public class Is_Open_API_data_type
            type: "string",
            format: "uuid-base64",
            nullable: true));
-
-    internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Uuid)).FirstOrDefault();
-
-    [Test]
-    public void with_description() => Attribute.Description.Should().Be("Universally unique identifier, Base64 encoded.");
-
-    [Test]
-    public void with_example() => Attribute.Example.Should().Be("lmZO_haEOTCwGsCcbIZFFg");
-
-    [Test]
-    public void has_type() => Attribute.Type.Should().Be("string");
-
-    [Test]
-    public void has_format() => Attribute.Format.Should().Be("uuid-base64");
-
-    [Test]
-    public void pattern_is_null() => Attribute.Pattern.Should().BeNull();
 }
 
 public class Supports_binary_serialization

--- a/specs/Qowaiv.Specs/Web/InternetMediaType_specs.cs
+++ b/specs/Qowaiv.Specs/Web/InternetMediaType_specs.cs
@@ -42,3 +42,17 @@ public class Supports_type_conversion
         }
     }
 }
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(InternetMediaType))
+        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(InternetMediaType),
+            description: "Media type notation as defined by RFC 6838.",
+            example: "text/html",
+            type: "string",
+            format: "internet-media-type",
+            nullable: true));
+}

--- a/specs/Qowaiv.Specs/WeekDate_specs.cs
+++ b/specs/Qowaiv.Specs/WeekDate_specs.cs
@@ -65,3 +65,16 @@ public class Supports_type_conversion
     public void to_LocalDateTime()
         => Converting.To<LocalDateTime>().From(Svo.WeekDate).Should().Be(new LocalDateTime(2017, 06, 11));
 }
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+       => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(WeekDate))
+       .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+           dataType: typeof(WeekDate),
+           description: "Full-date notation as defined by ISO 8601.",
+           example: "1997-W14-6",
+           type: "string",
+           format: "date-weekbased"));
+}

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -545,34 +545,6 @@ public class Is_Open_API_data_type
           type: "integer",
           format: "year",
           nullable: true));
-
-    internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Year)).FirstOrDefault();
-
-    [Test]
-    public void with_description()
-    {
-        Assert.AreEqual(
-            "Year(-only) notation.",
-            Attribute.Description);
-    }
-
-    [Test]
-    public void has_type()
-    {
-        Assert.AreEqual("integer", Attribute.Type);
-    }
-
-    [Test]
-    public void has_format()
-    {
-        Assert.AreEqual("year", Attribute.Format);
-    }
-
-    [Test]
-    public void pattern_is_null()
-    {
-        Assert.IsNull(Attribute.Pattern);
-    }
 }
 
 public class Supports_binary_serialization

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -535,6 +535,17 @@ public class Supports_XML_serialization
 
 public class Is_Open_API_data_type
 {
+    [Test]
+    public void with_info()
+      => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Year))
+      .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+          dataType: typeof(Year),
+          description: "Year(-only) notation.",
+          example: 1983, 
+          type: "integer",
+          format: "year",
+          nullable: true));
+
     internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(Year)).FirstOrDefault();
 
     [Test]

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -545,6 +545,18 @@ public class Supports_XML_serialization
 
 public class Is_Open_API_data_type
 {
+    [Test]
+    public void with_info()
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(YesNo))
+        .Should().BeEquivalentTo(new Qowaiv.OpenApi.OpenApiDataType(
+            dataType: typeof(YesNo),
+            description: "Yes-No notation.",
+            example: "yes",
+            type: "string",
+            format: "yes-no",
+            @enum: new[] { "yes", "no", "?" },
+            nullable: true));
+
     internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(YesNo)).FirstOrDefault();
 
     [Test]

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -556,34 +556,6 @@ public class Is_Open_API_data_type
             format: "yes-no",
             @enum: new[] { "yes", "no", "?" },
             nullable: true));
-
-    internal static readonly OpenApiDataTypeAttribute Attribute = OpenApiDataTypeAttribute.From(typeof(YesNo)).FirstOrDefault();
-
-    [Test]
-    public void with_description()
-    {
-        Assert.AreEqual(
-            "Yes-No notation.",
-            Attribute.Description);
-    }
-
-    [Test]
-    public void has_type()
-    {
-        Assert.AreEqual("string", Attribute.Type);
-    }
-
-    [Test]
-    public void has_format()
-    {
-        Assert.AreEqual("yes-no", Attribute.Format);
-    }
-
-    [Test]
-    public void pattern_is_null()
-    {
-        Assert.IsNull(Attribute.Pattern);
-    }
 }
 
 public class Supports_binary_serialization

--- a/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
+++ b/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
@@ -4,6 +4,7 @@
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(ulong))]
 [OpenApiDataType(description: "SQL Server timestamp notation.", example: "0x00000000000007D9", type: "string", format: "timestamp")]
+[OpenApi.OpenApiDataType(description: "SQL Server timestamp notation.", example: "0x00000000000007D9", type: "string", format: "timestamp")]
 [TypeConverter(typeof(Conversion.Sql.TimestampTypeConverter))]
 public partial struct Timestamp : ISerializable, IXmlSerializable, IFormattable, IEquatable<Timestamp>, IComparable, IComparable<Timestamp>
 {

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -22,7 +22,7 @@ v6.0.0
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -4,6 +4,7 @@
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All ^ SingleValueStaticOptions.HasEmptyValue ^ SingleValueStaticOptions.HasUnknownValue, typeof(DateTime))]
 [OpenApiDataType(description: "Full-date notation as defined by RFC 3339, section 5.6.", example: "2017-06-10", type: "string", format: "date")]
+[OpenApi.OpenApiDataType(description: "Full-date notation as defined by RFC 3339, section 5.6.", example: "2017-06-10", type: "string", format: "date")]
 [TypeConverter(typeof(DateTypeConverter))]
 public partial struct Date : ISerializable, IXmlSerializable, IFormattable, IEquatable<Date>, IComparable, IComparable<Date>
 {

--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -4,6 +4,7 @@ namespace Qowaiv;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(ulong))]
 [OpenApiDataType(description: "Date span, specified in years, months and days.", example: "1Y+10M+16D", type: "string", format: "date-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D")]
+[OpenApi.OpenApiDataType(description: "Date span, specified in years, months and days.", example: "1Y+10M+16D", type: "string", format: "date-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D")]
 [TypeConverter(typeof(DateSpanTypeConverter))]
 public partial struct DateSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<DateSpan>, IComparable, IComparable<DateSpan>
 {

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -10,6 +10,7 @@ namespace Qowaiv;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
 [OpenApiDataType(description: "Email notation as defined by RFC 5322.", example: "svo@qowaiv.org", type: "string", format: "email", nullable: true)]
+[OpenApi.OpenApiDataType(description: "Email notation as defined by RFC 5322.", example: "svo@qowaiv.org", type: "string", format: "email", nullable: true)]
 [TypeConverter(typeof(EmailAddressTypeConverter))]
 public partial struct EmailAddress : ISerializable, IXmlSerializable, IFormattable, IEquatable<EmailAddress>, IComparable, IComparable<EmailAddress>
 {

--- a/src/Qowaiv/EmailAddressCollection.cs
+++ b/src/Qowaiv/EmailAddressCollection.cs
@@ -6,6 +6,7 @@
 /// </remarks>
 [Serializable]
 [OpenApiDataType(description: "Comma separated list of email addresses defined by RFC 5322.", example: "info@qowaiv.org,test@test.com", type: "string", format: "email-collection", nullable: true)]
+[OpenApi.OpenApiDataType(description: "Comma separated list of email addresses defined by RFC 5322.", example: "info@qowaiv.org,test@test.com", type: "string", format: "email-collection", nullable: true)]
 public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSerializable, IFormattable
 {
     /// <summary>The email address separator is a comma.</summary>

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -6,6 +6,7 @@ namespace Qowaiv.Financial;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(decimal))]
 [OpenApiDataType(description: "Decimal representation of a currency amount.", example: 15.95, type: "number", format: "amount")]
+[OpenApi.OpenApiDataType(description: "Decimal representation of a currency amount.", example: 15.95, type: "number", format: "amount")]
 [TypeConverter(typeof(AmountTypeConverter))]
 public partial struct Amount : ISerializable, IXmlSerializable, IFormattable, IEquatable<Amount>, IComparable, IComparable<Amount>
 {

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -24,6 +24,7 @@ namespace Qowaiv.Financial;
 [Serializable]
 [SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
 [OpenApiDataType(description: "Business Identifier Code, as defined by ISO 9362.", example: "DEUTDEFF", type: "string", format: "bic", nullable: true)]
+[OpenApi.OpenApiDataType(description: "Business Identifier Code, as defined by ISO 9362.", example: "DEUTDEFF", type: "string", format: "bic", nullable: true)]
 [TypeConverter(typeof(BusinessIdentifierCodeTypeConverter))]
 public partial struct BusinessIdentifierCode : ISerializable, IXmlSerializable, IFormattable, IEquatable<BusinessIdentifierCode>, IComparable, IComparable<BusinessIdentifierCode>
 {

--- a/src/Qowaiv/Financial/Currency.cs
+++ b/src/Qowaiv/Financial/Currency.cs
@@ -23,6 +23,7 @@ namespace Qowaiv.Financial;
 [Serializable]
 [SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
 [OpenApiDataType(description: "Currency notation as defined by ISO 4217.", example: "EUR", type: "string", format: "currency", nullable: true)]
+[OpenApi.OpenApiDataType(description: "Currency notation as defined by ISO 4217.", example: "EUR", type: "string", format: "currency", nullable: true)]
 [TypeConverter(typeof(CurrencyTypeConverter))]
 public partial struct Currency : ISerializable, IXmlSerializable, IFormattable, IFormatProvider, IEquatable<Currency>, IComparable, IComparable<Currency>
 {

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -19,6 +19,7 @@ namespace Qowaiv.Financial;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
 [OpenApiDataType(description: "International Bank Account Number notation as defined by ISO 13616:2007.", example: "BE71096123456769.", type: "string", format: "iban", nullable: true)]
+[OpenApi.OpenApiDataType(description: "International Bank Account Number notation as defined by ISO 13616:2007.", example: "BE71096123456769.", type: "string", format: "iban", nullable: true)]
 [TypeConverter(typeof(InternationalBankAccountNumberTypeConverter))]
 public partial struct InternationalBankAccountNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<InternationalBankAccountNumber>, IComparable, IComparable<InternationalBankAccountNumber>
 {

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -7,6 +7,7 @@ namespace Qowaiv.Financial;
 [Serializable]
 [SingleValueObject(SingleValueStaticOptions.Continuous, typeof(decimal))]
 [OpenApiDataType(description: "Combined currency and amount notation as defined by ISO 4217.", example: "EUR12.47", type: "string", format: "money", pattern: @"[A-Z]{3} -?[0-9]+(\.[0-9]+)?")]
+[OpenApi.OpenApiDataType(description: "Combined currency and amount notation as defined by ISO 4217.", example: "EUR12.47", type: "string", format: "money", pattern: @"[A-Z]{3} -?[0-9]+(\.[0-9]+)?")]
 [TypeConverter(typeof(MoneyTypeConverter))]
 public partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEquatable<Money>, IComparable, IComparable<Money>
 {

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -14,6 +14,7 @@ namespace Qowaiv.Globalization;
 [Serializable]
 [SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
 [OpenApiDataType(description: "Country notation as defined by ISO 3166-1 alpha-2.", example: "NL", type: "string", format: "country", nullable: true)]
+[OpenApi.OpenApiDataType(description: "Country notation as defined by ISO 3166-1 alpha-2.", example: "NL", type: "string", format: "country", nullable: true)]
 [TypeConverter(typeof(CountryTypeConverter))]
 public partial struct Country : ISerializable, IXmlSerializable, IFormattable, IEquatable<Country>, IComparable, IComparable<Country>
 {

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -4,6 +4,7 @@
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(int))]
 [OpenApiDataType(description: "House number notation.", example: "13", type: "string", format: "house-number", nullable: true)]
+[OpenApi.OpenApiDataType(description: "House number notation.", example: "13", type: "string", format: "house-number", nullable: true)]
 [TypeConverter(typeof(HouseNumberTypeConverter))]
 public partial struct HouseNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<HouseNumber>, IComparable, IComparable<HouseNumber>
 {

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -15,6 +15,7 @@ namespace Qowaiv.IO;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(long))]
 [OpenApiDataType(description: "Stream size notation (in byte).", example: 1024, type: "integer", format: "stream-size")]
+[OpenApi.OpenApiDataType(description: "Stream size notation (in byte).", example: 1024, type: "integer", format: "stream-size")]
 [TypeConverter(typeof(StreamSizeTypeConverter))]
 public partial struct StreamSize : ISerializable, IXmlSerializable, IFormattable, IEquatable<StreamSize>, IComparable, IComparable<StreamSize>
 {

--- a/src/Qowaiv/Identifiers/GuidBehavior.cs
+++ b/src/Qowaiv/Identifiers/GuidBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Identifiers;
 
 /// <summary>Implements <see cref="IIdentifierBehavior"/> for an identifier based on <see cref="Guid"/>.</summary>
+[OpenApi.OpenApiDataType(description: "GUID based identifier", example: "8a1a8c42-d2ff-e254-e26e-b6abcbf19420", type: "string", format: "guid", nullable: true)]
 public class GuidBehavior : IdentifierBehavior
 {
     internal static readonly GuidBehavior Instance = new();

--- a/src/Qowaiv/Identifiers/Int32IdBehavior.cs
+++ b/src/Qowaiv/Identifiers/Int32IdBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Identifiers;
 
 /// <summary>Implements <see cref="IIdentifierBehavior"/> for an identifier based on <see cref="int"/>.</summary>
+[OpenApi.OpenApiDataType(description: "Int32 based identifier", example: 17, type: "integer", format: "identifier", nullable: true)]
 public class Int32IdBehavior : IdentifierBehavior
 {
     /// <summary>Creates a new instance of the <see cref="Int32IdBehavior"/> class.</summary>

--- a/src/Qowaiv/Identifiers/Int64IdBehavior.cs
+++ b/src/Qowaiv/Identifiers/Int64IdBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Identifiers;
 
 /// <summary>Implements <see cref="IIdentifierBehavior"/> for an identifier based on <see cref="long"/>.</summary>
+[OpenApi.OpenApiDataType(description: "Int64 based identifier", example: 17, type: "integer", format: "identifier", nullable: true)]
 public class Int64IdBehavior : IdentifierBehavior
 {
     /// <summary>Creates a new instance of the <see cref="Int64IdBehavior"/> class.</summary>

--- a/src/Qowaiv/Identifiers/StringIdBehavior.cs
+++ b/src/Qowaiv/Identifiers/StringIdBehavior.cs
@@ -1,7 +1,7 @@
 ﻿namespace Qowaiv.Identifiers;
 
 /// <summary>Implements <see cref="IIdentifierBehavior"/> for an identifier based on <see cref="string"/>.</summary>
-[OpenApi.OpenApiDataType(description: "String based identifier", example: "lmZO_haEOTCwGsCcbIZFFg", type: "string", format: "identifier", nullable: true)]
+[OpenApi.OpenApiDataType(description: "String based identifier", example: "Order-UK-2022-215", type: "string", format: "identifier", nullable: true)]
 public class StringIdBehavior : IdentifierBehavior
 {
     /// <summary>Creates a new instance of the <see cref="StringIdBehavior"/> class.</summary>

--- a/src/Qowaiv/Identifiers/StringIdBehavior.cs
+++ b/src/Qowaiv/Identifiers/StringIdBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Identifiers;
 
 /// <summary>Implements <see cref="IIdentifierBehavior"/> for an identifier based on <see cref="string"/>.</summary>
+[OpenApi.OpenApiDataType(description: "String based identifier", example: "lmZO_haEOTCwGsCcbIZFFg", type: "string", format: "identifier", nullable: true)]
 public class StringIdBehavior : IdentifierBehavior
 {
     /// <summary>Creates a new instance of the <see cref="StringIdBehavior"/> class.</summary>

--- a/src/Qowaiv/Identifiers/UuidBehavior.cs
+++ b/src/Qowaiv/Identifiers/UuidBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Identifiers;
 
 /// <summary>Implements <see cref="IIdentifierBehavior"/> for an identifier based on <see cref="Uuid"/>.</summary>
+[OpenApi.OpenApiDataType(description: "UUID based identifier", example: "lmZO_haEOTCwGsCcbIZFFg", type: "string", format: "uuid-base64", nullable: true)]
 public class UuidBehavior : GuidBehavior
 {
     internal new static readonly UuidBehavior Instance = new();

--- a/src/Qowaiv/Json/OpenApiDataTypeAttribute.cs
+++ b/src/Qowaiv/Json/OpenApiDataTypeAttribute.cs
@@ -83,7 +83,9 @@ public sealed class OpenApiDataTypeAttribute : Attribute
     }
 
     /// <summary>Gets all <see cref="OpenApiDataTypeAttribute"/>s specified in the assemblies.</summary>
+    [ExcludeFromCodeCoverage]
     [Pure]
+    [Obsolete("Use Qowaiv.OpenApi.OpenApiDataTypes.FromAssemblies() instead.")]
     public static IEnumerable<OpenApiDataTypeAttribute> From(params Assembly[] assemblies)
         => From(Guard.NotNull(assemblies, nameof(assemblies))
             .SelectMany(assembly => assembly.GetTypes()));
@@ -93,13 +95,16 @@ public sealed class OpenApiDataTypeAttribute : Attribute
     /// </summary>
     [ExcludeFromCodeCoverage]
     [Pure]
+    [Obsolete("Use Qowaiv.OpenApi.OpenApiDataTypes.FromTypes() instead.")]
     public static IEnumerable<OpenApiDataTypeAttribute> From(params Type[] types)
         => From(types?.AsEnumerable() ?? Array.Empty<Type>());
 
     /// <summary>Gets all <see cref="OpenApiDataTypeAttribute"/>s of the
     /// specified types that are decorated as such.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     [Pure]
+    [Obsolete("Use Qowaiv.OpenApi.OpenApiDataTypes.FromTypes() instead.")]
     public static IEnumerable<OpenApiDataTypeAttribute> From(IEnumerable<Type> types)
         => Guard.NotNull(types, nameof(types))
         .Where(type => type is not null && type.GetCustomAttributes<OpenApiDataTypeAttribute>().Any())

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -4,6 +4,7 @@
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.Continuous, typeof(DateTime))]
 [OpenApiDataType(description: "Date-time notation as defined by RFC 3339, without time zone information.", example: "2017-06-10 15:00", type: "string", format: "local-date-time")]
+[OpenApi.OpenApiDataType(description: "Date-time notation as defined by RFC 3339, without time zone information.", example: "2017-06-10 15:00", type: "string", format: "local-date-time")]
 [TypeConverter(typeof(LocalDateTimeTypeConverter))]
 public partial struct LocalDateTime : ISerializable, IXmlSerializable, IFormattable, IEquatable<LocalDateTime>, IComparable, IComparable<LocalDateTime>
 {

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -8,6 +8,7 @@ namespace Qowaiv.Mathematics;
 [Serializable]
 [SingleValueObject(SingleValueStaticOptions.Continuous, typeof(Tuple<long, long>))]
 [OpenApiDataType(description: "Faction", type: "string", format: "faction", pattern: "-?[0-9]+(/[0-9]+)?", example: "13/42")]
+[OpenApi.OpenApiDataType(description: "Faction", type: "string", format: "faction", pattern: "-?[0-9]+(/[0-9]+)?", example: "13/42")]
 [TypeConverter(typeof(FractionTypeConverter))]
 [StructLayout(LayoutKind.Sequential)]
 public partial struct Fraction : ISerializable, IXmlSerializable, IFormattable, IEquatable<Fraction>, IComparable, IComparable<Fraction>

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -6,6 +6,7 @@ namespace Qowaiv;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(byte))]
 [OpenApiDataType(description: "Month(-only) notation.", example: "Jun", type: "string", format: "month", nullable: true, @enum: "Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec,?")]
+[OpenApi.OpenApiDataType(description: "Month(-only) notation.", example: "Jun", type: "string", format: "month", nullable: true, @enum: "Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec,?")]
 [TypeConverter(typeof(MonthTypeConverter))]
 public partial struct Month : ISerializable, IXmlSerializable, IFormattable, IEquatable<Month>, IComparable, IComparable<Month>
 {

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -5,7 +5,8 @@
 [Serializable]
 [SingleValueObject(SingleValueStaticOptions.Continuous, underlyingType: typeof(int))]
 [OpenApiDataType(description: "Month span, specified in years and months.", example: "1Y+10M", type: "string", format: "month-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M")]
-[TypeConverter(typeof(Conversion.MonthSpanTypeConverter))]
+[OpenApi.OpenApiDataType(description: "Month span, specified in years and months.", example: "1Y+10M", type: "string", format: "month-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M")]
+[TypeConverter(typeof(MonthSpanTypeConverter))]
 public partial struct MonthSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<MonthSpan>, IComparable, IComparable<MonthSpan>
 {
     /// <summary>Represents a month span with a zero duration.</summary>

--- a/src/Qowaiv/OpenApi/OpenApiDataType.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataType.cs
@@ -91,36 +91,18 @@ public sealed record OpenApiDataType
     /// The type to create an <see cref="OpenApiDataType" /> for.
     /// </param>
     [Pure]
-    public static OpenApiDataType? FromType(Type type)
-    {
-        Guard.NotNull(type, nameof(type));
-
-        if (type.GetCustomAttributes<OpenApiDataTypeAttribute>().FirstOrDefault() is { } attr)
-        {
-            return new(
-                dataType: AsDataType(type),
-                description: attr.Description,
-                type: attr.Type,
-                example: attr.Example,
-                format: attr.Format,
-                nullable: attr.Nullable,
-                pattern: attr.Pattern,
-                @enum: attr.Enum);
-        }
-        else if (type.GetCustomAttributes<Json.OpenApiDataTypeAttribute>().FirstOrDefault() is { } obsolete)
-        {
-            return new(
-                dataType: AsDataType(type),
-                description: obsolete.Description,
-                type: obsolete.Type,
-                example: obsolete.Example,
-                format: obsolete.Format,
-                nullable: obsolete.Nullable,
-                pattern: obsolete.Pattern,
-                @enum: obsolete.Enum);
-        }
-        else return null;
-    }
+    public static OpenApiDataType? FromType(Type type) 
+        => Guard.NotNull(type, nameof(type)).GetCustomAttributes<OpenApiDataTypeAttribute>().FirstOrDefault() is { } attr
+        ? new(
+            dataType: AsDataType(type),
+            description: attr.Description,
+            type: attr.Type,
+            example: attr.Example,
+            format: attr.Format,
+            nullable: attr.Nullable,
+            pattern: attr.Pattern,
+            @enum: attr.Enum)
+        : null;
 
     [Pure]
     private static Type AsDataType(Type type)

--- a/src/Qowaiv/OpenApi/OpenApiDataType.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataType.cs
@@ -83,6 +83,11 @@ public sealed record OpenApiDataType
         }
     }
 
+    /// <summary>Returns true if the pattern matches the input, or the is no pattern restriction.</summary>
+    [Pure]
+    public bool Matches(string? str)
+        => Pattern is null || Regex.IsMatch(str!, Pattern);
+
     /// <summary>
     /// Creates an <see cref="OpenApiDataType"/> based on a type, null if not
     /// decorated with a <see cref="OpenApiDataTypeAttribute"/>.

--- a/src/Qowaiv/OpenApi/OpenApiDataType.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataType.cs
@@ -1,0 +1,132 @@
+﻿using Qowaiv.Identifiers;
+using System.Reflection;
+
+namespace Qowaiv.OpenApi;
+
+/// <summary>Represents an Open API data type.</summary>
+[DebuggerDisplay("{DebuggerDisplay}")]
+public sealed record OpenApiDataType
+{
+    /// <summary>Creates a new instance of the <see cref="OpenApiDataType"/> class.</summary>
+#pragma warning disable S107 // Methods should not have too many parameters
+    // To overcome the lack of the init key word in netstandard2.0.
+    public OpenApiDataType(Type dataType,
+       string description,
+       string type,
+       object? example,
+       string? format = null,
+       bool nullable = false,
+       string? pattern = null,
+       IReadOnlyCollection<string>? @enum = null)
+#pragma warning restore S107 // Methods should not have too many parameters
+    {
+        DataType = Guard.NotNull(dataType, nameof(dataType));
+        Description = Guard.NotNullOrEmpty(description, nameof(description));
+        Type = Guard.NotNullOrEmpty(type, nameof(type));
+        Example = example;
+        Format = format;
+        Nullable = nullable;
+        Pattern = pattern;
+        Enum = @enum;
+    }
+
+    /// <summary>Gets the bound .NET type of the OpenAPI Data Type.</summary>
+    /// <remarks>
+    /// Only set when received via one of the <c>From()</c> factory methods.
+    /// </remarks>
+    public Type DataType { get; }
+
+    /// <summary>Gets the description of the OpenAPI Data Type.</summary>
+    public string Description { get; }
+
+    /// <summary>Gets the type of the OpenAPI Data Type.</summary>
+    public string Type { get; }
+
+    /// <summary>Gets the example of the OpenAPI Data Type.</summary>
+    public object? Example { get; }
+
+    /// <summary>Gets the format of the OpenAPI Data Type.</summary>
+    public string? Format { get; }
+
+    /// <summary>Gets if the OpenAPI Data Type is nullable or not.</summary>
+    public bool Nullable { get; }
+
+    /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>
+    public string? Pattern { get; }
+
+    /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>
+    public IReadOnlyCollection<string>? Enum { get; }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay
+    {
+        get
+        {
+            var sb = new StringBuilder();
+            sb.Append($@"{{ type: {Type}, desc: {Description}, example: {Example}");
+
+            if (!string.IsNullOrEmpty(Format))
+            {
+                sb.Append($@", format: {Format}");
+            }
+            if (!string.IsNullOrEmpty(Pattern))
+            {
+                sb.Append($@", pattern: {Pattern}");
+            }
+            if (Nullable)
+            {
+                sb.Append($", nullable: true");
+            }
+            sb.Append(" }");
+
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Creates an <see cref="OpenApiDataType"/> based on a type, null if not
+    /// decorated with a <see cref="OpenApiDataTypeAttribute"/>.
+    /// </summary>
+    /// <param name="type">
+    /// The type to create an <see cref="OpenApiDataType" /> for.
+    /// </param>
+    [Pure]
+    public static OpenApiDataType? FromType(Type type)
+    {
+        Guard.NotNull(type, nameof(type));
+
+        if (type.GetCustomAttributes<OpenApiDataTypeAttribute>().FirstOrDefault() is { } attr)
+        {
+            return new(
+                dataType: AsDataType(type),
+                description: attr.Description,
+                type: attr.Type,
+                example: attr.Example,
+                format: attr.Format,
+                nullable: attr.Nullable,
+                pattern: attr.Pattern,
+                @enum: attr.Enum);
+        }
+        else if (type.GetCustomAttributes<Json.OpenApiDataTypeAttribute>().FirstOrDefault() is { } obsolete)
+        {
+            return new(
+                dataType: AsDataType(type),
+                description: obsolete.Description,
+                type: obsolete.Type,
+                example: obsolete.Example,
+                format: obsolete.Format,
+                nullable: obsolete.Nullable,
+                pattern: obsolete.Pattern,
+                @enum: obsolete.Enum);
+        }
+        else return null;
+    }
+
+    [Pure]
+    private static Type AsDataType(Type type)
+        => !type.IsAbstract 
+        && type.GetInterfaces().Contains(typeof(IIdentifierBehavior))
+        && type.GetConstructors().Any(ctor => !ctor.GetParameters().Any())
+        ? typeof(Id<>).MakeGenericType(type)
+        : type;
+}

--- a/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
@@ -47,30 +47,4 @@ public sealed class OpenApiDataTypeAttribute : Attribute
 
     /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>
     public string[]? Enum { get; }
-
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private string DebuggerDisplay
-    {
-        get
-        {
-            var sb = new StringBuilder();
-            sb.Append($@"{{ type: {Type}, desc: {Description}, example: {Example}");
-
-            if (!string.IsNullOrEmpty(Format))
-            {
-                sb.Append($@", format: {Format}");
-            }
-            if (!string.IsNullOrEmpty(Pattern))
-            {
-                sb.Append($@", pattern: {Pattern}");
-            }
-            if (Nullable)
-            {
-                sb.Append($", nullable: true");
-            }
-            sb.Append(" }");
-
-            return sb.ToString();
-        }
-    }
 }

--- a/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
@@ -1,0 +1,76 @@
+﻿namespace Qowaiv.OpenApi;
+
+/// <summary>Describes how a type should be described as OpenAPI Data Type.</summary>
+/// <remarks>
+/// See: https://swagger.io/docs/specification/data-models/data-types/
+/// </remarks>
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+[DebuggerDisplay("{DebuggerDisplay}")]
+public sealed class OpenApiDataTypeAttribute : Attribute
+{
+    /// <summary>Creates a new instance of a <see cref="OpenApiDataTypeAttribute"/>.</summary>
+    public OpenApiDataTypeAttribute(
+        string description,
+        string type,
+        object example,
+        string? format = null,
+        bool nullable = false,
+        string? pattern = null,
+        string? @enum = null)
+    {
+        Description = Guard.NotNullOrEmpty(description, nameof(description));
+        Type = Guard.NotNullOrEmpty(type, nameof(type));
+        Example = Guard.NotNull(example, nameof(example));
+        Format = format;
+        Nullable = nullable;
+        Pattern = pattern;
+        Enum = @enum?.Split(',');
+    }
+
+    /// <summary>Gets the description of the OpenAPI Data Type.</summary>
+    public string Description { get; }
+
+    /// <summary>Gets the type of the OpenAPI Data Type.</summary>
+    public string Type { get; }
+
+    /// <summary>Gets the example of the OpenAPI Data Type.</summary>
+    public object Example { get; }
+
+    /// <summary>Gets the format of the OpenAPI Data Type.</summary>
+    public string? Format { get; }
+
+    /// <summary>Gets if the OpenAPI Data Type is nullable or not.</summary>
+    public bool Nullable { get; }
+
+    /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>
+    public string? Pattern { get; }
+
+    /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>
+    public string[]? Enum { get; }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay
+    {
+        get
+        {
+            var sb = new StringBuilder();
+            sb.Append($@"{{ type: {Type}, desc: {Description}, example: {Example}");
+
+            if (!string.IsNullOrEmpty(Format))
+            {
+                sb.Append($@", format: {Format}");
+            }
+            if (!string.IsNullOrEmpty(Pattern))
+            {
+                sb.Append($@", pattern: {Pattern}");
+            }
+            if (Nullable)
+            {
+                sb.Append($", nullable: true");
+            }
+            sb.Append(" }");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Qowaiv/OpenApi/OpenApiDataTypes.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataTypes.cs
@@ -1,0 +1,30 @@
+﻿using System.Reflection;
+
+namespace Qowaiv.OpenApi;
+
+/// <summary>Creates <see cref="OpenApiDataType"/>s.</summary>
+public static class OpenApiDataTypes
+{
+    /// <summary>Gets all <see cref="OpenApiDataTypeAttribute"/>s specified in the assemblies.</summary>
+    [Pure]
+    public static IEnumerable<OpenApiDataType> FromAssemblies(params Assembly[] assemblies)
+        => FromTypes(Guard.NotNull(assemblies, nameof(assemblies))
+        .SelectMany(assembly => assembly.GetExportedTypes()));
+
+    /// <summary>Gets all <see cref="OpenApiDataTypeAttribute"/>s of the
+    /// specified types that are decorated as such.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [Pure]
+    public static IEnumerable<OpenApiDataType> FromTypes(params Type[] types)
+        => FromTypes(types?.AsEnumerable() ?? Array.Empty<Type>());
+
+    /// <summary>Gets all <see cref="OpenApiDataTypeAttribute"/>s of the
+    /// specified types that are decorated as such.
+    /// </summary>
+    [Pure]
+    public static IEnumerable<OpenApiDataType> FromTypes(IEnumerable<Type> types)
+        => Guard.NotNull(types, nameof(types))
+        .Select(OpenApiDataType.FromType)
+        .Where(data => data is { })!;
+}

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -4,6 +4,7 @@
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All ^ SingleValueStaticOptions.HasEmptyValue ^ SingleValueStaticOptions.HasUnknownValue, typeof(decimal))]
 [OpenApiDataType(description: "Ratio expressed as a fraction of 100 denoted using the percent sign '%'.", example: "13.76%", type: "string", format: "percentage", pattern: @"-?[0-9]+(\.[0-9]+)?%")]
+[OpenApi.OpenApiDataType(description: "Ratio expressed as a fraction of 100 denoted using the percent sign '%'.", example: "13.76%", type: "string", format: "percentage", pattern: @"-?[0-9]+(\.[0-9]+)?%")]
 [TypeConverter(typeof(PercentageTypeConverter))]
 public partial struct Percentage : ISerializable, IXmlSerializable, IFormattable, IEquatable<Percentage>, IComparable, IComparable<Percentage>
 {

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -10,6 +10,7 @@ namespace Qowaiv;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
 [OpenApiDataType(description: "Postal code notation.", example: "2624DP", type: "string", format: "postal-code", nullable: true)]
+[OpenApi.OpenApiDataType(description: "Postal code notation.", example: "2624DP", type: "string", format: "postal-code", nullable: true)]
 [TypeConverter(typeof(PostalCodeTypeConverter))]
 public partial struct PostalCode : ISerializable, IXmlSerializable, IFormattable, IEquatable<PostalCode>, IComparable, IComparable<PostalCode>
 {

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,8 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.0.1</Version>
+    <Version>6.0.2</Version>
     <PackageReleaseNotes>
+v6.0.2
+- Extend Open API support for ID&lt;T&gt;. #239
 v6.0.1
 - Int64 based id serializes to a JSON string #236 
 - Percentage.MaxValue representable as a string #235

--- a/src/Qowaiv/Sex.cs
+++ b/src/Qowaiv/Sex.cs
@@ -25,6 +25,7 @@ namespace Qowaiv;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(byte))]
 [OpenApiDataType(description: "Sex as specified by ISO/IEC 5218.", example: "female", type: "string", format: "sex", nullable: true, @enum: "NotKnown,Male,Female,NotApplicable")]
+[OpenApi.OpenApiDataType(description: "Sex as specified by ISO/IEC 5218.", example: "female", type: "string", format: "sex", nullable: true, @enum: "NotKnown,Male,Female,NotApplicable")]
 [TypeConverter(typeof(SexTypeConverter))]
 public partial struct Sex : ISerializable, IXmlSerializable, IFormattable, IEquatable<Sex>, IComparable, IComparable<Sex>
 {

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -17,6 +17,7 @@ namespace Qowaiv.Statistics;
 [Serializable]
 [SingleValueObject(SingleValueStaticOptions.Continuous, typeof(double))]
 [OpenApiDataType(description: "Elo rating system notation.", example: 1600, type: "number", format: "elo")]
+[OpenApi.OpenApiDataType(description: "Elo rating system notation.", example: 1600d, type: "number", format: "elo")]
 [TypeConverter(typeof(EloTypeConverter))]
 public partial struct Elo : ISerializable, IXmlSerializable, IFormattable, IEquatable<Elo>, IComparable, IComparable<Elo>
 {

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -20,6 +20,7 @@ namespace Qowaiv;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.AllExcludingCulture ^ SingleValueStaticOptions.HasUnknownValue, typeof(Guid))]
 [OpenApiDataType(description: "Universally unique identifier, Base64 encoded.", example: "lmZO_haEOTCwGsCcbIZFFg", type: "string", format: "uuid-base64", nullable: true)]
+[OpenApi.OpenApiDataType(description: "Universally unique identifier, Base64 encoded.", example: "lmZO_haEOTCwGsCcbIZFFg", type: "string", format: "uuid-base64", nullable: true)]
 [TypeConverter(typeof(UuidTypeConverter))]
 public partial struct Uuid : ISerializable, IXmlSerializable, IFormattable, IEquatable<Uuid>, IComparable, IComparable<Uuid>
 {

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -39,6 +39,7 @@ namespace Qowaiv.Web;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.AllExcludingCulture, typeof(string))]
 [OpenApiDataType(description: "Media type notation as defined by RFC 6838.", example: "text/html", type: "string", format: "internet-media-type", nullable: true)]
+[OpenApi.OpenApiDataType(description: "Media type notation as defined by RFC 6838.", example: "text/html", type: "string", format: "internet-media-type", nullable: true)]
 [TypeConverter(typeof(InternetMediaTypeTypeConverter))]
 public partial struct InternetMediaType : ISerializable, IXmlSerializable, IFormattable, IEquatable<InternetMediaType>, IComparable, IComparable<InternetMediaType>
 {

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -30,6 +30,7 @@
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All ^ SingleValueStaticOptions.HasEmptyValue ^ SingleValueStaticOptions.HasUnknownValue, typeof(Date))]
 [OpenApiDataType(description: "Full-date notation as defined by ISO 8601.", example: "1997-W14-6", type: "string", format: "date-weekbased")]
+[OpenApi.OpenApiDataType(description: "Full-date notation as defined by ISO 8601.", example: "1997-W14-6", type: "string", format: "date-weekbased")]
 [TypeConverter(typeof(WeekDateTypeConverter))]
 public partial struct WeekDate : ISerializable, IXmlSerializable, IFormattable, IEquatable<WeekDate>, IComparable, IComparable<WeekDate>
 {

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -4,6 +4,7 @@
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(short))]
 [OpenApiDataType(description: "Year(-only) notation.", example: 1983, type: "integer", format: "year", nullable: true)]
+[OpenApi.OpenApiDataType(description: "Year(-only) notation.", example: 1983, type: "integer", format: "year", nullable: true)]
 [TypeConverter(typeof(YearTypeConverter))]
 public partial struct Year : ISerializable, IXmlSerializable, IFormattable, IEquatable<Year>, IComparable, IComparable<Year>
 {

--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -16,6 +16,7 @@ namespace Qowaiv;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(byte))]
 [OpenApiDataType(description: "Yes-No notation.", example: "yes", type: "string", format: "yes-no", nullable: true, @enum: "yes,no,?")]
+[OpenApi.OpenApiDataType(description: "Yes-No notation.", example: "yes", type: "string", format: "yes-no", nullable: true, @enum: "yes,no,?")]
 [TypeConverter(typeof(YesNoTypeConverter))]
 public partial struct YesNo : ISerializable, IXmlSerializable, IFormattable, IEquatable<YesNo>, IComparable, IComparable<YesNo>
 {


### PR DESCRIPTION
When resolving Open API data types, currently, resolving `Id<T>`s are not included. This is solved. As a part of this PR, the updated code is provided in a different namespace.