### PR TITLE
Prevent implicit casting by introducing obsolete operator overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | version                                                                       | package                                                                     |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-|![v](https://img.shields.io/badge/version-6.2.0-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
+|![v](https://img.shields.io/badge/version-6.2.1-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
 |![v](https://img.shields.io/badge/version-6.1.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Data.SqlCient](https://www.nuget.org/packages/Qowaiv.Data.SqlClient/)|
 |![v](https://img.shields.io/badge/version-6.0.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)         |
 

--- a/specs/Qowaiv.Specs/Obsolete_code.cs
+++ b/specs/Qowaiv.Specs/Obsolete_code.cs
@@ -13,13 +13,13 @@ public class Will_be_dropped
     public void Date_Tomorrow() => Date.Tomorrow.Should().Be(Clock.Tomorrow());
 
     [Test]
-    public void Amount_Addition_with_implicit_cast() => (50.Amount() + 49m).Should().Be(99.Amount());
+    public void Amount_Addition_with_decimal() => (50.Amount() + 49m).Should().Be(99.Amount());
 
     [Test]
-    public void Amount_Subtraction_with_implicit_cast() => (90.Amount() - 20m).Should().Be(70.Amount());
+    public void Amount_Subtraction_with_decimal() => (90.Amount() - 20m).Should().Be(70.Amount());
 
     [Test]
-    public void Amount_Implictly_from_decimal()
+    public void Percentage_Implicit_cast_from_decimal()
     {
         Percentage casted = 0.1751m;
         casted.Should().Be(Svo.Percentage);

--- a/specs/Qowaiv.Specs/Obsolete_code.cs
+++ b/specs/Qowaiv.Specs/Obsolete_code.cs
@@ -11,6 +11,19 @@ public class Will_be_dropped
 
     [Test]
     public void Date_Tomorrow() => Date.Tomorrow.Should().Be(Clock.Tomorrow());
+
+    [Test]
+    public void Amount_Addition_with_implicit_cast() => (50.Amount() + 49m).Should().Be(99.Amount());
+
+    [Test]
+    public void Amount_Subtraction_with_implicit_cast() => (90.Amount() - 20m).Should().Be(70.Amount());
+
+    [Test]
+    public void Amount_Implictly_from_decimal()
+    {
+        Percentage casted = 0.1751m;
+        casted.Should().Be(Svo.Percentage);
+    }
 }
 
 [Obsolete("Will become private when the next major version is released.")]

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -404,13 +404,6 @@ public class Casts
     }
    
     [Test]
-    public void immplictly_from_decimal()
-    {
-        Percentage casted = 0.1751m;
-        Assert.AreEqual(Svo.Percentage, casted);
-    }
-
-    [Test]
     public void explicitly_to_decimal()
     {
         var casted = (decimal)Svo.Percentage;

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -255,7 +255,7 @@ public class Has_custom_formatting
     [Test]
     public void unknown_value_is_represented_as_unknown()
     {
-        Assert.AreEqual("unknown", YesNo.Unknown.ToString());
+        Assert.AreEqual("unknown", YesNo.Unknown.ToString(CultureInfo.InvariantCulture));
     }
 
     [Test]

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -412,16 +412,16 @@ public readonly partial struct Amount : ISerializable, IXmlSerializable, IFormat
     [Pure]
     public static Amount FromJson(long json) => new(json);
 
-    /// <summary>Casts a decimal an </summary>
+    /// <summary>Casts a decimal to an amount.</summary>
     public static explicit operator Amount(decimal val) => Create(val);
 
-    /// <summary>Casts a decimal an </summary>
+    /// <summary>Casts a decimal to an amount.</summary>
     public static explicit operator Amount(double val) => Create(val);
 
-    /// <summary>Casts a long an </summary>
+    /// <summary>Casts a long to an amount.</summary>
     public static explicit operator Amount(long val) => Create((decimal)val);
 
-    /// <summary>Casts a int an </summary>
+    /// <summary>Casts a int to an amount.</summary>
     public static explicit operator Amount(int val) => Create((decimal)val);
 
     /// <summary>Casts an Amount to a decimal.</summary>
@@ -430,8 +430,16 @@ public readonly partial struct Amount : ISerializable, IXmlSerializable, IFormat
     public static explicit operator double(Amount val) => (double)val.m_Value;
     /// <summary>Casts an Amount to a long.</summary>
     public static explicit operator long(Amount val) => (long)val.m_Value;
-    /// <summary>Casts an Amount to a int.</summary>
+    /// <summary>Casts an Amount to an int.</summary>
     public static explicit operator int(Amount val) => (int)val.m_Value;
+
+    /// <summary>Adds the left and the right amount.</summary>
+    [Obsolete("Explicitly convert the added value to Percentage or Amount.", false)]
+    public static Amount operator +(Amount amount, decimal other) => amount + other.Amount();
+
+    /// <summary>Subtracts the left and the right amount.</summary>
+    [Obsolete("Explicitly convert the subtracted value to Percentage or Amount.", false)]
+    public static Amount operator -(Amount amount, decimal other) => amount - other.Amount();
 
     /// <summary>Converts the string to an 
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -624,10 +624,10 @@ public readonly partial struct Percentage : ISerializable, IXmlSerializable, IFo
 
     #region (Explicit) casting
 
-    /// <summary>Casts a decimal a Percentage.</summary>
+    /// <summary>Casts a decimal to a Percentage.</summary>
     public static implicit operator Percentage(decimal val) => new(val);
 
-    /// <summary>Casts a decimal a Percentage.</summary>
+    /// <summary>Casts a decimal to a Percentage.</summary>
     public static explicit operator Percentage(double val) => Create(val);
 
     /// <summary>Casts a Percentage to a decimal.</summary>

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,8 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.2.0</Version>
+    <Version>6.2.1</Version>
     <PackageReleaseNotes>
+v6.2.1
+- Prevent implicit casting by introducing obsolete operator overloads. #257 (fix)
 v6.2.0
 -  Introduction of Svo&lt;SvoBehavior&gt; as a generic for string based SVO's. #248 
 v6.1.2


### PR DESCRIPTION
As described in #256, the implicit cast to a `Percentage` by the compiler to resolve `Amount + decimal` and `Amount - decimal` can be solved by providing defined overloads. By doing so, with an obsolete warning the developer is notified that his code need changes.

With the next breaking change release (not decided yet) the implicit cast to percentage should be dropped, together with these operator overloads.