### PR TITLE
Support System.Text.Json.Serialization out of the box for .NET 5.0 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | version                                                                       | package                                                                     |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-|![v](https://img.shields.io/badge/version-6.2.2-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
+|![v](https://img.shields.io/badge/version-6.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
 |![v](https://img.shields.io/badge/version-6.1.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Data.SqlCient](https://www.nuget.org/packages/Qowaiv.Data.SqlClient/)|
 |![v](https://img.shields.io/badge/version-6.0.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)         |
 
@@ -659,11 +659,16 @@ public struct Svo
     public object /* or string, bool, int, long, double, decimal */ ToJson();
 }
 ```
+
 #### Implementations
-There are two _out-of-the-box_ implementations that that support this convention
+There are two _out-of-the-box_ implementations that support this convention
 based contract.
 * [Qowaiv.Json.Newtonsoft](https://www.nuget.org/packages/Qowaiv.Json.Newtonsoft/)  
 * [Qowaiv.Text.Json.Serialization](https://www.nuget.org/packages/Qowaiv.Text.Json.Serialization/)  
+
+For the .NET 5.0, and higher versions of the package, when using `System.Text.Json`,
+no custom serialization registration is required for Qowaiv SVO's: all have been
+decorated with the `[JsonConverter]` attribute.
 
 #### OpenAPI Specification
 The [OpenAPI Specification](https://swagger.io/docs/specification/about/)

--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ based convention:
 ``` C#
 public struct Svo
 {
-    public static Svo FromJson(string json);
+    public static Svo FromJson(string? json);
 
     // When appropriate for the SVO. Example: `Percentage`.
     public static Svo FromJson(double json);

--- a/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
+++ b/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
@@ -89,7 +89,7 @@ public class Has_constant
 {
     [Test]
     public void Empty_represent_default_value()
-        => CasRegistryNumber.Empty.Should().Be(default(CasRegistryNumber));
+        => CasRegistryNumber.Empty.Should().Be(default);
 }
 
 public class Is_equal_by_value
@@ -381,24 +381,24 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("?", "unknown")]
-    [TestCase("10028-14-5", 10028_14_5L)]
-    public void System_Text_JSON_deserialization(CasRegistryNumber svo, object json)
+    [TestCase("?", "?")]
+    [TestCase(10028_14_5L, "10028-14-5")]
+    public void System_Text_JSON_deserialization(object json, CasRegistryNumber svo)
       => JsonTester.Read_System_Text_JSON<CasRegistryNumber>(json).Should().Be(svo);
+    
+    [TestCase("?", "?")]
+    [TestCase(10028_14_5L, "10028-14-5")]
+    public void convention_based_deserialization(object json, CasRegistryNumber svo)
+       => JsonTester.Read<CasRegistryNumber>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
+    [TestCase(null, null)]
     [TestCase("10028-14-5", "10028-14-5")]
-    public void System_Text_JSON_serialization(object json, CasRegistryNumber svo)
+    public void System_Text_JSON_serialization(CasRegistryNumber svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase("?", "unknown")]
-    [TestCase("10028-14-5", 10028_14_5L)]
-    public void convention_based_deserialization(CasRegistryNumber svo, object json)
-        => JsonTester.Read<CasRegistryNumber>(json).Should().Be(svo);
-
-    [TestCase(null, "")]
+    [TestCase(null, null)]
     [TestCase("10028-14-5", "10028-14-5")]
-    public void convention_based_serialization(object json, CasRegistryNumber svo)
+    public void convention_based_serialization(CasRegistryNumber svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
+++ b/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
@@ -383,6 +383,16 @@ public class Supports_JSON_serialization
 {
     [TestCase("?", "unknown")]
     [TestCase("10028-14-5", 10028_14_5L)]
+    public void System_Text_JSON_deserialization(CasRegistryNumber svo, object json)
+      => JsonTester.Read_System_Text_JSON<CasRegistryNumber>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("10028-14-5", "10028-14-5")]
+    public void System_Text_JSON_serialization(object json, CasRegistryNumber svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("?", "unknown")]
+    [TestCase("10028-14-5", 10028_14_5L)]
     public void convention_based_deserialization(CasRegistryNumber svo, object json)
         => JsonTester.Read<CasRegistryNumber>(json).Should().Be(svo);
 

--- a/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
@@ -360,6 +360,16 @@ public class Supports_JSON_serialization
 {
     [TestCase("?", "?")]
     [TestCase("QOWAIV", "QOWAIV")]
+    public void System_Text_JSON_deserialization(CustomSvo svo, object json)
+        => JsonTester.Read_System_Text_JSON<CustomSvo>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("QOWAIV", "QOWAIV")]
+    public void System_Text_JSON__serialization(object json, CustomSvo svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("?", "?")]
+    [TestCase("QOWAIV", "QOWAIV")]
     public void convention_based_deserialization(CustomSvo svo, object json)
         => JsonTester.Read<CustomSvo>(json).Should().Be(svo);
 

--- a/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
@@ -360,22 +360,22 @@ public class Supports_JSON_serialization
 {
     [TestCase("?", "?")]
     [TestCase("QOWAIV", "QOWAIV")]
-    public void System_Text_JSON_deserialization(CustomSvo svo, object json)
+    public void System_Text_JSON_deserialization(object json, CustomSvo svo)
         => JsonTester.Read_System_Text_JSON<CustomSvo>(json).Should().Be(svo);
-
-    [TestCase(null, "")]
-    [TestCase("QOWAIV", "QOWAIV")]
-    public void System_Text_JSON__serialization(object json, CustomSvo svo)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
     [TestCase("?", "?")]
     [TestCase("QOWAIV", "QOWAIV")]
-    public void convention_based_deserialization(CustomSvo svo, object json)
-        => JsonTester.Read<CustomSvo>(json).Should().Be(svo);
+    public void convention_based_deserialization(object json, CustomSvo svo)
+       => JsonTester.Read<CustomSvo>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
+    [TestCase(null, null)]
     [TestCase("QOWAIV", "QOWAIV")]
-    public void convention_based_serialization(object json, CustomSvo svo)
+    public void System_Text_JSON__serialization(CustomSvo svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(null, null)]
+    [TestCase("QOWAIV", "QOWAIV")]
+    public void convention_based_serialization(CustomSvo svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input!", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
@@ -358,6 +358,7 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
+    [TestCase(null, null)]
     [TestCase("?", "?")]
     [TestCase("QOWAIV", "QOWAIV")]
     public void System_Text_JSON_deserialization(object json, CustomSvo svo)
@@ -371,7 +372,7 @@ public class Supports_JSON_serialization
     [TestCase(null, null)]
     [TestCase("QOWAIV", "QOWAIV")]
     public void System_Text_JSON__serialization(CustomSvo svo, object json)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+      => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
     [TestCase(null, null)]
     [TestCase("QOWAIV", "QOWAIV")]

--- a/specs/Qowaiv.Specs/DateSpan_specs.cs
+++ b/specs/Qowaiv.Specs/DateSpan_specs.cs
@@ -25,6 +25,39 @@ public class Supports_type_conversion
     }
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase("0Y+0M+0D", null)]
+    [TestCase("0Y+0M+0D", 0L)]
+    [TestCase("0Y+0M+0D", "0Y+0M+0D")]
+    [TestCase("1Y+8M+3D", "1Y+8M+3D")]
+    public void System_Text_JSON_deserialization(DateSpan svo, object json)
+        => JsonTester.Read_System_Text_JSON<DateSpan>(json).Should().Be(svo);
+
+    [TestCase("1Y+8M+3D", "1Y+8M+3D")]
+    public void System_Text_JSON_serialization(object json, DateSpan svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("0Y+0M+0D", 0L)]
+    [TestCase("0Y+0M+0D", "0Y+0M+0D")]
+    [TestCase("1Y+8M+3D", "1Y+8M+3D")]
+    public void convention_based_deserialization(DateSpan svo, object json)
+        => JsonTester.Read<DateSpan>(json).Should().Be(svo);
+
+    [TestCase("1Y+8M+3D", "1Y+8M+3D")]
+    public void convention_based_serialization(object json, DateSpan svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<DateSpan>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/DateSpan_specs.cs
+++ b/specs/Qowaiv.Specs/DateSpan_specs.cs
@@ -27,25 +27,25 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("0Y+0M+0D", null)]
-    [TestCase("0Y+0M+0D", 0L)]
+    [TestCase(null, "0Y+0M+0D")]
+    [TestCase(0L, "0Y+0M+0D")]
     [TestCase("0Y+0M+0D", "0Y+0M+0D")]
     [TestCase("1Y+8M+3D", "1Y+8M+3D")]
-    public void System_Text_JSON_deserialization(DateSpan svo, object json)
+    public void System_Text_JSON_deserialization(object json, DateSpan svo)
         => JsonTester.Read_System_Text_JSON<DateSpan>(json).Should().Be(svo);
 
     [TestCase("1Y+8M+3D", "1Y+8M+3D")]
-    public void System_Text_JSON_serialization(object json, DateSpan svo)
+    public void System_Text_JSON_serialization(DateSpan svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase("0Y+0M+0D", 0L)]
+    [TestCase(0L, "0Y+0M+0D")]
     [TestCase("0Y+0M+0D", "0Y+0M+0D")]
     [TestCase("1Y+8M+3D", "1Y+8M+3D")]
-    public void convention_based_deserialization(DateSpan svo, object json)
+    public void convention_based_deserialization(object json, DateSpan svo)
         => JsonTester.Read<DateSpan>(json).Should().Be(svo);
 
     [TestCase("1Y+8M+3D", "1Y+8M+3D")]
-    public void convention_based_serialization(object json, DateSpan svo)
+    public void convention_based_serialization(DateSpan svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/DateSpan_specs.cs
+++ b/specs/Qowaiv.Specs/DateSpan_specs.cs
@@ -34,15 +34,15 @@ public class Supports_JSON_serialization
     public void System_Text_JSON_deserialization(object json, DateSpan svo)
         => JsonTester.Read_System_Text_JSON<DateSpan>(json).Should().Be(svo);
 
-    [TestCase("1Y+8M+3D", "1Y+8M+3D")]
-    public void System_Text_JSON_serialization(DateSpan svo, object json)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
     [TestCase(0L, "0Y+0M+0D")]
     [TestCase("0Y+0M+0D", "0Y+0M+0D")]
     [TestCase("1Y+8M+3D", "1Y+8M+3D")]
     public void convention_based_deserialization(object json, DateSpan svo)
         => JsonTester.Read<DateSpan>(json).Should().Be(svo);
+
+    [TestCase("1Y+8M+3D", "1Y+8M+3D")]
+    public void System_Text_JSON_serialization(DateSpan svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
     [TestCase("1Y+8M+3D", "1Y+8M+3D")]
     public void convention_based_serialization(DateSpan svo, object json)

--- a/specs/Qowaiv.Specs/Date_specs.cs
+++ b/specs/Qowaiv.Specs/Date_specs.cs
@@ -123,23 +123,23 @@ public class Supports_type_conversion
 public class Supports_JSON_serialization
 {
     [TestCase("2012-04-23", "2012-04-23")]
-    [TestCase("2012-04-23", "2012-04-23T18:25:43.511Z")]
-    [TestCase("2012-04-23", "2012-04-23T10:25:43-05:00")]
-    public void System_Text_JSON_deserialization(Date svo, object json)
+    [TestCase("2012-04-23T18:25:43.511Z", "2012-04-23")]
+    [TestCase("2012-04-23T10:25:43-05:00", "2012-04-23")]
+    public void System_Text_JSON_deserialization(object json, Date svo)
         => JsonTester.Read_System_Text_JSON<Date>(json).Should().Be(svo);
 
     [TestCase("2012-04-23", "2012-04-23")]
-    public void System_Text_JSON_serialization(object json, Date svo)
+    public void System_Text_JSON_serialization(Date svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
     [TestCase("2012-04-23", "2012-04-23")]
-    [TestCase("2012-04-23", "2012-04-23T18:25:43.511Z")]
-    [TestCase("2012-04-23", "2012-04-23T10:25:43-05:00")]
-    public void convention_based_deserialization(Date svo, object json)
+    [TestCase("2012-04-23T18:25:43.511Z", "2012-04-23")]
+    [TestCase("2012-04-23T10:25:43-05:00", "2012-04-23")]
+    public void convention_based_deserialization(object json, Date svo)
         => JsonTester.Read<Date>(json).Should().Be(svo);
 
     [TestCase("2012-04-23", "2012-04-23")]
-    public void convention_based_serialization(object json, Date svo)
+    public void convention_based_serialization(Date svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Date_specs.cs
+++ b/specs/Qowaiv.Specs/Date_specs.cs
@@ -129,15 +129,15 @@ public class Supports_JSON_serialization
         => JsonTester.Read_System_Text_JSON<Date>(json).Should().Be(svo);
 
     [TestCase("2012-04-23", "2012-04-23")]
-    public void System_Text_JSON_serialization(Date svo, object json)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
-    [TestCase("2012-04-23", "2012-04-23")]
     [TestCase("2012-04-23T18:25:43.511Z", "2012-04-23")]
     [TestCase("2012-04-23T10:25:43-05:00", "2012-04-23")]
     public void convention_based_deserialization(object json, Date svo)
-        => JsonTester.Read<Date>(json).Should().Be(svo);
+      => JsonTester.Read<Date>(json).Should().Be(svo);
 
+    [TestCase("2012-04-23", "2012-04-23")]
+    public void System_Text_JSON_serialization(Date svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+      
     [TestCase("2012-04-23", "2012-04-23")]
     public void convention_based_serialization(Date svo, object json)
         => JsonTester.Write(svo).Should().Be(json);

--- a/specs/Qowaiv.Specs/Date_specs.cs
+++ b/specs/Qowaiv.Specs/Date_specs.cs
@@ -120,6 +120,38 @@ public class Supports_type_conversion
         => Converting.To<WeekDate>().From(Svo.Date).Should().Be(new WeekDate(2017, 23, 7));
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase("2012-04-23", "2012-04-23")]
+    [TestCase("2012-04-23", "2012-04-23T18:25:43.511Z")]
+    [TestCase("2012-04-23", "2012-04-23T10:25:43-05:00")]
+    public void System_Text_JSON_deserialization(Date svo, object json)
+        => JsonTester.Read_System_Text_JSON<Date>(json).Should().Be(svo);
+
+    [TestCase("2012-04-23", "2012-04-23")]
+    public void System_Text_JSON_serialization(object json, Date svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("2012-04-23", "2012-04-23")]
+    [TestCase("2012-04-23", "2012-04-23T18:25:43.511Z")]
+    [TestCase("2012-04-23", "2012-04-23T10:25:43-05:00")]
+    public void convention_based_deserialization(Date svo, object json)
+        => JsonTester.Read<Date>(json).Should().Be(svo);
+
+    [TestCase("2012-04-23", "2012-04-23")]
+    public void convention_based_serialization(object json, Date svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("yyyy-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<Date>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -380,6 +380,17 @@ public class Supports_type_conversion
 public class Supports_JSON_serialization
 {
     [TestCase("?", "unknown")]
+    [TestCase("info@qowaiv.org", "info@qowaiv.org")]
+    public void System_Text_JSON_deserialization(EmailAddress svo, object json)
+        => JsonTester.Read_System_Text_JSON<EmailAddress>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("info@qowaiv.org", "info@qowaiv.org")]
+    public void System_Text_JSON_serialization(object json, EmailAddress svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("?", "unknown")]
+    [TestCase("info@qowaiv.org", "info@qowaiv.org")]
     public void convention_based_deserialization(EmailAddress expected, object json)
     {
         var actual = JsonTester.Read<EmailAddress>(json);

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -379,31 +379,25 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("?", "unknown")]
+    [TestCase("?", "?")]
     [TestCase("info@qowaiv.org", "info@qowaiv.org")]
-    public void System_Text_JSON_deserialization(EmailAddress svo, object json)
+    public void System_Text_JSON_deserialization(object json, EmailAddress svo)
         => JsonTester.Read_System_Text_JSON<EmailAddress>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
+    [TestCase("?", "?")]
+    [TestCase("info@qowaiv.org", "info@qowaiv.org")]
+    public void convention_based_deserialization(object json, EmailAddress svo)
+        => JsonTester.Read<EmailAddress>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
     [TestCase("info@qowaiv.org", "info@qowaiv.org")]
     public void System_Text_JSON_serialization(object json, EmailAddress svo)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase("?", "unknown")]
+    [TestCase(null, null)]
     [TestCase("info@qowaiv.org", "info@qowaiv.org")]
-    public void convention_based_deserialization(EmailAddress expected, object json)
-    {
-        var actual = JsonTester.Read<EmailAddress>(json);
-        Assert.AreEqual(expected, actual);
-    }
-
-    [TestCase(null, "")]
-    [TestCase("info@qowaiv.org", "info@qowaiv.org")]
-    public void convention_based_serialization(object expected, EmailAddress svo)
-    {
-        var serialized = JsonTester.Write(svo);
-        Assert.AreEqual(expected, serialized);
-    }
+    public void convention_based_serialization(object json, EmailAddress svo)
+        => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]
     [TestCase("2017-06-11", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Financial/Amount_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Amount_specs.cs
@@ -52,26 +52,24 @@ public class Supports_type_conversion
 
     public class Supports_JSON_serialization
     {
-        [TestCase("1234.56", "1234.56")]
+        [TestCase("1234.56", 1234.56)]
         [TestCase(1234.56, 1234.56)]
-        [TestCase(1234.00, 1234L)]
-        public void System_Text_JSON_deserialization(Amount svo, object json)
+        [TestCase(1234L, 1234.00)]
+        public void System_Text_JSON_deserialization(object json, Amount svo)
             => JsonTester.Read_System_Text_JSON<Amount>(json).Should().Be(svo);
 
-        [TestCase(1234.56, "1234.56")]
+        [TestCase("1234.56", 1234.56)]
         [TestCase(1234.56, 1234.56)]
-        public void System_Text_JSON_serialization(object json, Amount svo)
+        [TestCase(1234L, 1234.00)]
+        public void convention_based_deserialization(object json, Amount svo)
+          => JsonTester.Read<Amount>(json).Should().Be(svo);
+
+        [TestCase(1234.56, 1234.56)]
+        public void System_Text_JSON_serialization(Amount svo, object json)
             => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-        [TestCase("1234.56", "1234.56")]
         [TestCase(1234.56, 1234.56)]
-        [TestCase(1234.00, 1234L)]
-        public void convention_based_deserialization(Amount svo, object json)
-            => JsonTester.Read<Amount>(json).Should().Be(svo);
-
-        [TestCase(1234.56, "1234.56")]
-        [TestCase(1234.56, 1234.56)]
-        public void convention_based_serialization(object json, Amount svo)
+        public void convention_based_serialization(Amount svo, object json)
             => JsonTester.Write(svo).Should().Be(json);
 
         [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Financial/Amount_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Amount_specs.cs
@@ -49,6 +49,40 @@ public class Supports_type_conversion
     public void to_double()
         => Converting.To<double>().From(Svo.Amount).Should().Be(42.17);
 
+
+    public class Supports_JSON_serialization
+    {
+        [TestCase("1234.56", "1234.56")]
+        [TestCase(1234.56, 1234.56)]
+        [TestCase(1234.00, 1234L)]
+        public void System_Text_JSON_deserialization(Amount svo, object json)
+            => JsonTester.Read_System_Text_JSON<Amount>(json).Should().Be(svo);
+
+        [TestCase(1234.56, "1234.56")]
+        [TestCase(1234.56, 1234.56)]
+        public void System_Text_JSON_serialization(object json, Amount svo)
+            => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+        [TestCase("1234.56", "1234.56")]
+        [TestCase(1234.56, 1234.56)]
+        [TestCase(1234.00, 1234L)]
+        public void convention_based_deserialization(Amount svo, object json)
+            => JsonTester.Read<Amount>(json).Should().Be(svo);
+
+        [TestCase(1234.56, "1234.56")]
+        [TestCase(1234.56, 1234.56)]
+        public void convention_based_serialization(object json, Amount svo)
+            => JsonTester.Write(svo).Should().Be(json);
+
+        [TestCase("Invalid input", typeof(FormatException))]
+        [TestCase("2017-06-11", typeof(FormatException))]
+        public void throws_for_invalid_json(object json, Type exceptionType)
+        {
+            var exception = Assert.Catch(() => JsonTester.Read<Amount>(json));
+            Assert.IsInstanceOf(exceptionType, exception);
+        }
+    }
+
     public class Has_operators
     {
         [Test]

--- a/specs/Qowaiv.Specs/Financial/BIC_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/BIC_specs.cs
@@ -42,3 +42,34 @@ public class Supports_type_conversion
         }
     }
 }
+
+public class Supports_JSON_serialization
+{
+    [TestCase("", null)]
+    [TestCase("AEGONL2UXXX", "AEGONL2UXXX")]
+    public void System_Text_JSON_deserialization(BusinessIdentifierCode svo, object json)
+        => JsonTester.Read_System_Text_JSON<BusinessIdentifierCode>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("AEGONL2UXXX", "AEGONL2UXXX")]
+    public void System_Text_JSON_serialization(object json, BusinessIdentifierCode svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("AEGONL2UXXX", "AEGONL2UXXX")]
+    public void convention_based_deserialization(BusinessIdentifierCode svo, object json)
+        => JsonTester.Read<BusinessIdentifierCode>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("AEGONL2UXXX", "AEGONL2UXXX")]
+    public void convention_based_serialization(object json, BusinessIdentifierCode svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<BusinessIdentifierCode>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}

--- a/specs/Qowaiv.Specs/Financial/BIC_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/BIC_specs.cs
@@ -45,23 +45,23 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("", null)]
+    [TestCase(null, null)]
     [TestCase("AEGONL2UXXX", "AEGONL2UXXX")]
-    public void System_Text_JSON_deserialization(BusinessIdentifierCode svo, object json)
+    public void System_Text_JSON_deserialization(object json, BusinessIdentifierCode svo)
         => JsonTester.Read_System_Text_JSON<BusinessIdentifierCode>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
     [TestCase("AEGONL2UXXX", "AEGONL2UXXX")]
-    public void System_Text_JSON_serialization(object json, BusinessIdentifierCode svo)
+    public void convention_based_deserialization(object json, BusinessIdentifierCode svo)
+    => JsonTester.Read<BusinessIdentifierCode>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase("AEGONL2UXXX", "AEGONL2UXXX")]
+    public void System_Text_JSON_serialization(BusinessIdentifierCode svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
+    [TestCase(null, null)]
     [TestCase("AEGONL2UXXX", "AEGONL2UXXX")]
-    public void convention_based_deserialization(BusinessIdentifierCode svo, object json)
-        => JsonTester.Read<BusinessIdentifierCode>(json).Should().Be(svo);
-
-    [TestCase(null, "")]
-    [TestCase("AEGONL2UXXX", "AEGONL2UXXX")]
-    public void convention_based_serialization(object json, BusinessIdentifierCode svo)
+    public void convention_based_serialization(BusinessIdentifierCode svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Financial/Currency_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Currency_specs.cs
@@ -42,3 +42,36 @@ public class Supports_type_conversion
         }
     }
 }
+
+public class Supports_JSON_serialization
+{
+    [TestCase(null, null)]
+    [TestCase("EUR", 978L)]
+    [TestCase("EUR", 978.0)]
+    [TestCase("EUR", "EUR")]
+    public void System_Text_JSON_deserialization(Currency svo, object json)
+        => JsonTester.Read_System_Text_JSON<Currency>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase("EUR", "EUR")]
+    public void System_Text_JSON_serialization(object json, Currency svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("EUR", "EUR")]
+    public void convention_based_deserialization(Currency svo, object json)
+        => JsonTester.Read<Currency>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase("EUR", "EUR")]
+    public void convention_based_serialization(object json, Currency svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<Currency>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}

--- a/specs/Qowaiv.Specs/Financial/Currency_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Currency_specs.cs
@@ -46,24 +46,25 @@ public class Supports_type_conversion
 public class Supports_JSON_serialization
 {
     [TestCase(null, null)]
-    [TestCase("EUR", 978L)]
-    [TestCase("EUR", 978.0)]
+    [TestCase(978L, "EUR")]
+    [TestCase(978d, "EUR")]
     [TestCase("EUR", "EUR")]
-    public void System_Text_JSON_deserialization(Currency svo, object json)
+    public void System_Text_JSON_deserialization(object json, Currency svo)
         => JsonTester.Read_System_Text_JSON<Currency>(json).Should().Be(svo);
 
+    [TestCase(978L, "EUR")]
+    [TestCase("EUR", "EUR")]
+    public void convention_based_deserialization(object json, Currency svo)
+       => JsonTester.Read<Currency>(json).Should().Be(svo);
+
     [TestCase(null, null)]
     [TestCase("EUR", "EUR")]
-    public void System_Text_JSON_serialization(object json, Currency svo)
+    public void System_Text_JSON_serialization(Currency svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase("EUR", "EUR")]
-    public void convention_based_deserialization(Currency svo, object json)
-        => JsonTester.Read<Currency>(json).Should().Be(svo);
-
     [TestCase(null, null)]
     [TestCase("EUR", "EUR")]
-    public void convention_based_serialization(object json, Currency svo)
+    public void convention_based_serialization(Currency svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
@@ -160,6 +160,38 @@ public class Supports_type_conversion
     }
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase(null, null)]
+    [TestCase("NL20INGB0001234567", "NL20INGB0001234567")]
+    public void System_Text_JSON_deserialization(InternationalBankAccountNumber svo, object json)
+        => JsonTester.Read_System_Text_JSON<InternationalBankAccountNumber>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase("NL20INGB0001234567", "NL20INGB0001234567")]
+    public void System_Text_JSON_serialization(object json, InternationalBankAccountNumber svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("NL20INGB0001234567", "NL20INGB0001234567")]
+    public void convention_based_deserialization(InternationalBankAccountNumber svo, object json)
+        => JsonTester.Read<InternationalBankAccountNumber>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase("NL20INGB0001234567", "NL20INGB0001234567")]
+    public void convention_based_serialization(object json, InternationalBankAccountNumber svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<InternationalBankAccountNumber>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
+
+
 public class Input_is_invalid_when
 {
     [Test]

--- a/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
@@ -164,22 +164,22 @@ public class Supports_JSON_serialization
 {
     [TestCase(null, null)]
     [TestCase("NL20INGB0001234567", "NL20INGB0001234567")]
-    public void System_Text_JSON_deserialization(InternationalBankAccountNumber svo, object json)
+    public void System_Text_JSON_deserialization(object json, InternationalBankAccountNumber svo)
         => JsonTester.Read_System_Text_JSON<InternationalBankAccountNumber>(json).Should().Be(svo);
 
-    [TestCase(null, null)]
     [TestCase("NL20INGB0001234567", "NL20INGB0001234567")]
-    public void System_Text_JSON_serialization(object json, InternationalBankAccountNumber svo)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
-    [TestCase("NL20INGB0001234567", "NL20INGB0001234567")]
-    public void convention_based_deserialization(InternationalBankAccountNumber svo, object json)
-        => JsonTester.Read<InternationalBankAccountNumber>(json).Should().Be(svo);
+    public void convention_based_deserialization(object json, InternationalBankAccountNumber svo)
+       => JsonTester.Read<InternationalBankAccountNumber>(json).Should().Be(svo);
 
     [TestCase(null, null)]
     [TestCase("NL20INGB0001234567", "NL20INGB0001234567")]
-    public void convention_based_serialization(object json, InternationalBankAccountNumber svo)
-        => JsonTester.Write(svo).Should().Be(json);
+    public void System_Text_JSON_serialization(InternationalBankAccountNumber svo, object json)
+    => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(null, null)]
+    [TestCase("NL20INGB0001234567", "NL20INGB0001234567")]
+    public void convention_based_serialization(InternationalBankAccountNumber svo, object json)
+       => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]
     [TestCase("2017-06-11", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Financial/Money_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Money_specs.cs
@@ -48,6 +48,41 @@ public class Supports_type_conversion
     }
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase("EUR 42.17", "EUR 42.17")]
+    [TestCase("EUR 42.17", "EUR42.17")]
+    [TestCase("EUR 42.17", "€42.17")]
+    [TestCase("100", 100L)]
+    [TestCase("42.17", 42.17)]
+    public void System_Text_JSON_deserialization(Money svo, object json)
+        => JsonTester.Read_System_Text_JSON<Money>(json).Should().Be(svo);
+
+    [TestCase("EUR42.17", "EUR42.17")]
+    public void System_Text_JSON_serialization(object json, Money svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("EUR 42.17", "EUR 42.17")]
+    [TestCase("EUR 42.17", "EUR42.17")]
+    [TestCase("EUR 42.17", "€42.17")]
+    [TestCase("100", 100L)]
+    [TestCase("42.17", 42.17)]
+    public void convention_based_deserialization(Money svo, object json)
+        => JsonTester.Read<Money>(json).Should().Be(svo);
+
+    [TestCase("EUR42.17", "EUR42.17")]
+    public void convention_based_serialization(object json, Money svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<Money>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
 public class Has_operators
 {
     [Test]

--- a/specs/Qowaiv.Specs/Financial/Money_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Money_specs.cs
@@ -51,27 +51,27 @@ public class Supports_type_conversion
 public class Supports_JSON_serialization
 {
     [TestCase("EUR 42.17", "EUR 42.17")]
-    [TestCase("EUR 42.17", "EUR42.17")]
-    [TestCase("EUR 42.17", "€42.17")]
-    [TestCase("100", 100L)]
-    [TestCase("42.17", 42.17)]
-    public void System_Text_JSON_deserialization(Money svo, object json)
+    [TestCase("EUR42.17", "EUR 42.17")]
+    [TestCase("€42.17", "EUR 42.17")]
+    [TestCase(100L, "100.00")]
+    [TestCase(42.17, "42.17")]
+    public void System_Text_JSON_deserialization(object json, Money svo)
         => JsonTester.Read_System_Text_JSON<Money>(json).Should().Be(svo);
 
+    [TestCase("EUR 42.17", "EUR 42.17")]
+    [TestCase("EUR42.17", "EUR 42.17")]
+    [TestCase("€42.17", "EUR 42.17")]
+    [TestCase(100L, "100.00")]
+    [TestCase(42.17, "42.17")]
+    public void convention_based_deserialization(object json, Money svo)
+       => JsonTester.Read<Money>(json).Should().Be(svo);
+
     [TestCase("EUR42.17", "EUR42.17")]
-    public void System_Text_JSON_serialization(object json, Money svo)
+    public void System_Text_JSON_serialization(Money svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase("EUR 42.17", "EUR 42.17")]
-    [TestCase("EUR 42.17", "EUR42.17")]
-    [TestCase("EUR 42.17", "€42.17")]
-    [TestCase("100", 100L)]
-    [TestCase("42.17", 42.17)]
-    public void convention_based_deserialization(Money svo, object json)
-        => JsonTester.Read<Money>(json).Should().Be(svo);
-
     [TestCase("EUR42.17", "EUR42.17")]
-    public void convention_based_serialization(object json, Money svo)
+    public void convention_based_serialization(Money svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Gender_specs.cs
+++ b/specs/Qowaiv.Specs/Gender_specs.cs
@@ -407,6 +407,17 @@ public class Supports_JSON_serialization
     [TestCase("?", "unknown")]
     [TestCase("Female", 2L)]
     [TestCase("Female", 2d)]
+    public void System_Text_JSON_deserialization(Gender svo, object json)
+    => JsonTester.Read_System_Text_JSON<Gender>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("Female", "Female")]
+    public void System_Text_JSON_serialization(object json, Gender svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("?", "unknown")]
+    [TestCase("Female", 2L)]
+    [TestCase("Female", 2d)]
     public void convention_based_deserialization(Gender expected, object json)
     {
         var actual = JsonTester.Read<Gender>(json);
@@ -414,7 +425,6 @@ public class Supports_JSON_serialization
     }
 
     [TestCase(null, "")]
-
     public void convention_based_serialization(object expected, Gender svo)
     {
         var serialized = JsonTester.Write(svo);

--- a/specs/Qowaiv.Specs/Globalization/Country_specs.cs
+++ b/specs/Qowaiv.Specs/Globalization/Country_specs.cs
@@ -45,26 +45,30 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("NL", "Netherlands")]
-    [TestCase("NL", "nl")]
-    [TestCase("AF", 4L)]
-    [TestCase("BG", 100L)]
-    public void System_Text_JSON_deserialization(Country svo, object json)
+    [TestCase("Netherlands", "NL")]
+    [TestCase("nl", "NL")]
+    [TestCase(4.00, "AF")]
+    [TestCase(100L, "BG")]
+    [TestCase(null, null)]
+    [TestCase("?", "?")]
+    public void System_Text_JSON_deserialization(object json, Country svo)
         => JsonTester.Read_System_Text_JSON<Country>(json).Should().Be(svo);
 
-    [TestCase("NL", "NL")]
-    public void System_Text_JSON_serialization(object json, Country svo)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
-    [TestCase("NL", "Netherlands")]
-    [TestCase("NL", "nl")]
-    [TestCase("AF", 4L)]
-    [TestCase("BG", 100L)]
-    public void convention_based_deserialization(Country svo, object json)
+    [TestCase("Netherlands", "NL")]
+    [TestCase("nl", "NL")]
+    [TestCase(100L, "BG")]
+    [TestCase("?", "?")]
+    public void convention_based_deserialization(object json, Country svo)
         => JsonTester.Read<Country>(json).Should().Be(svo);
 
+    [TestCase(null, null)]
     [TestCase("NL", "NL")]
-    public void convention_based_serialization(object json, Country svo)
+    public void System_Text_JSON_serialization(Country svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(null, null)]
+    [TestCase("NL", "NL")]
+    public void convention_based_serialization(Country svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Globalization/Country_specs.cs
+++ b/specs/Qowaiv.Specs/Globalization/Country_specs.cs
@@ -42,3 +42,37 @@ public class Supports_type_conversion
         }
     }
 }
+
+public class Supports_JSON_serialization
+{
+    [TestCase("NL", "Netherlands")]
+    [TestCase("NL", "nl")]
+    [TestCase("AF", 4L)]
+    [TestCase("BG", 100L)]
+    public void System_Text_JSON_deserialization(Country svo, object json)
+        => JsonTester.Read_System_Text_JSON<Country>(json).Should().Be(svo);
+
+    [TestCase("NL", "NL")]
+    public void System_Text_JSON_serialization(object json, Country svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("NL", "Netherlands")]
+    [TestCase("NL", "nl")]
+    [TestCase("AF", 4L)]
+    [TestCase("BG", 100L)]
+    public void convention_based_deserialization(Country svo, object json)
+        => JsonTester.Read<Country>(json).Should().Be(svo);
+
+    [TestCase("NL", "NL")]
+    public void convention_based_serialization(object json, Country svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<Country>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}

--- a/specs/Qowaiv.Specs/HouseNumber_specs.cs
+++ b/specs/Qowaiv.Specs/HouseNumber_specs.cs
@@ -96,6 +96,41 @@ public class Supports_type_conversion
         => Converting.To<long>().From(Svo.HouseNumber).Should().Be(123456789L);
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase("", null)]
+    [TestCase("13", 13.0)]
+    [TestCase("123456789", 123456789L)]
+    [TestCase("123456789", "123456789")]
+    public void System_Text_JSON_deserialization(HouseNumber svo, object json)
+        => JsonTester.Read_System_Text_JSON<HouseNumber>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("123456789", 123456789L)]
+    public void System_Text_JSON_serialization(object json, HouseNumber svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("13", 13.0)]
+    [TestCase("123456789", 123456789L)]
+    [TestCase("123456789", "123456789")]
+    public void convention_based_deserialization(HouseNumber svo, object json)
+        => JsonTester.Read<HouseNumber>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("123456789", 123456789L)]
+    public void convention_based_serialization(object json, HouseNumber svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<HouseNumber>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/HouseNumber_specs.cs
+++ b/specs/Qowaiv.Specs/HouseNumber_specs.cs
@@ -98,27 +98,29 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("", null)]
-    [TestCase("13", 13.0)]
-    [TestCase("123456789", 123456789L)]
-    [TestCase("123456789", "123456789")]
-    public void System_Text_JSON_deserialization(HouseNumber svo, object json)
+    [TestCase(null, null)]
+    [TestCase("?", "?")]
+    [TestCase("17", "17")]
+    [TestCase(17d, "17")]
+    [TestCase(17L, "17")]
+    public void System_Text_JSON_deserialization(object json, HouseNumber svo)
         => JsonTester.Read_System_Text_JSON<HouseNumber>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
-    [TestCase("123456789", 123456789L)]
-    public void System_Text_JSON_serialization(object json, HouseNumber svo)
+    [TestCase("?", "?")]
+    [TestCase("17", "17")]
+    [TestCase(17d, "17")]
+    [TestCase(17L, "17")]
+    public void convention_based_deserialization(HouseNumber svo, object json)
+       => JsonTester.Read<HouseNumber>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase(17, "17")]
+    public void System_Text_JSON_serialization(HouseNumber svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase("13", 13.0)]
-    [TestCase("123456789", 123456789L)]
-    [TestCase("123456789", "123456789")]
-    public void convention_based_deserialization(HouseNumber svo, object json)
-        => JsonTester.Read<HouseNumber>(json).Should().Be(svo);
-
-    [TestCase(null, "")]
-    [TestCase("123456789", 123456789L)]
-    public void convention_based_serialization(object json, HouseNumber svo)
+    [TestCase(null, null)]
+    [TestCase(17, "17")]
+    public void convention_based_serialization(HouseNumber svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
+++ b/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
@@ -219,6 +219,42 @@ public class Supports_type_conversion
         => Converting.To<long>().From(Svo.StreamSize).Should().Be(123456789);
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase(1600, "1600")]
+    [TestCase(17_000_000, "17MB")]
+    [TestCase(1_766, "1.766Kb")]
+    [TestCase(1234, 1234L)]
+    [TestCase(1258, 1258.9)]
+    public void System_Text_JSON_deserialization(StreamSize svo, object json)
+        => JsonTester.Read_System_Text_JSON<StreamSize>(json).Should().Be(svo);
+
+    [TestCase(123456789L, 123456789L)]
+    [TestCase(123456789L, "123456789")]
+    public void System_Text_JSON_serialization(object json, StreamSize svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(1600, "1600")]
+    [TestCase(17_000_000, "17MB")]
+    [TestCase(1_766, "1.766Kb")]
+    [TestCase(1234, 1234L)]
+    [TestCase(1258, 1258.9)]
+    public void convention_based_deserialization(StreamSize svo, object json)
+        => JsonTester.Read<StreamSize>(json).Should().Be(svo);
+
+    [TestCase(123456789L, 123456789L)]
+    [TestCase(123456789L, "123456789")]
+    public void convention_based_serialization(object json, StreamSize svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<StreamSize>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
+++ b/specs/Qowaiv.Specs/IO/StreamSize_specs.cs
@@ -221,30 +221,28 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase(1600, "1600")]
-    [TestCase(17_000_000, "17MB")]
-    [TestCase(1_766, "1.766Kb")]
-    [TestCase(1234, 1234L)]
-    [TestCase(1258, 1258.9)]
-    public void System_Text_JSON_deserialization(StreamSize svo, object json)
+    [TestCase("1600", 1_600)]
+    [TestCase("17MB", 17_000_000)]
+    [TestCase("1.766Kb", 1_766)]
+    [TestCase(1234L, 1234)]
+    [TestCase(1258.9, 1258)]
+    public void System_Text_JSON_deserialization(object json, StreamSize svo)
         => JsonTester.Read_System_Text_JSON<StreamSize>(json).Should().Be(svo);
 
-    [TestCase(123456789L, 123456789L)]
-    [TestCase(123456789L, "123456789")]
-    public void System_Text_JSON_serialization(object json, StreamSize svo)
+    [TestCase("1600", 1_600)]
+    [TestCase("17MB", 17_000_000)]
+    [TestCase("1.766Kb", 1_766)]
+    [TestCase(1234L, 1234)]
+    [TestCase(1258.9, 1258)]
+    public void convention_based_deserialization(object json, StreamSize svo)
+       => JsonTester.Read<StreamSize>(json).Should().Be(svo);
+
+    [TestCase(17L, 17L)]
+    public void System_Text_JSON_serialization(StreamSize svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase(1600, "1600")]
-    [TestCase(17_000_000, "17MB")]
-    [TestCase(1_766, "1.766Kb")]
-    [TestCase(1234, 1234L)]
-    [TestCase(1258, 1258.9)]
-    public void convention_based_deserialization(StreamSize svo, object json)
-        => JsonTester.Read<StreamSize>(json).Should().Be(svo);
-
-    [TestCase(123456789L, 123456789L)]
-    [TestCase(123456789L, "123456789")]
-    public void convention_based_serialization(object json, StreamSize svo)
+    [TestCase(17L, 17L)]
+    public void convention_based_serialization(StreamSize svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -2,26 +2,28 @@
 
 public class Supports_JSON_serialization
 {
-    [TestCase("", "")]
-    [TestCase(123456789L, "123456789")]
-    public void System_Text_JSON_deserialization(Int64Id svo, object json)
+    [TestCase("", null)]
+    [TestCase(null, null)]
+    [TestCase(17.0, 017L)]
+    [TestCase(123456789L, 123456789L)]
+    [TestCase("123456789", 123456789L)]
+    public void System_Text_JSON_deserialization(object json, Int64Id svo)
         => JsonTester.Read_System_Text_JSON<Int64Id>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
+    [TestCase("", null)]
+    [TestCase(123456789L, 123456789L)]
     [TestCase("123456789", 123456789L)]
-    [TestCase("123456789", "123456789")]
-    public void System_Text_JSON_serialization(object json, Int64Id svo)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
-    [TestCase("", "")]
-    [TestCase(123456789L, "123456789")]
-    public void convention_based_deserialization(Int64Id svo, object json)
+    public void convention_based_deserialization(object json, Int64Id svo)
         => JsonTester.Read<Int64Id>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
-    [TestCase("123456789", 123456789L)]
-    [TestCase("123456789", "123456789")]
-    public void convention_based_serialization(object json, Int64Id svo)
+    [TestCase(null, null)]
+    [TestCase(123456789L, "123456789")]
+    public void System_Text_JSON_serialization(Int64Id svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(null, null)]
+    [TestCase(123456789L, "123456789")]
+    public void convention_based_serialization(Int64Id svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 }
 

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -4,6 +4,17 @@ public class Supports_JSON_serialization
 {
     [TestCase("", "")]
     [TestCase(123456789L, "123456789")]
+    public void System_Text_JSON_deserialization(Int64Id svo, object json)
+        => JsonTester.Read_System_Text_JSON<Int64Id>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("123456789", 123456789L)]
+    [TestCase("123456789", "123456789")]
+    public void System_Text_JSON_serialization(object json, Int64Id svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("", "")]
+    [TestCase(123456789L, "123456789")]
     public void convention_based_deserialization(Int64Id svo, object json)
         => JsonTester.Read<Int64Id>(json).Should().Be(svo);
 

--- a/specs/Qowaiv.Specs/Json/System.Text.JSON_specs.cs
+++ b/specs/Qowaiv.Specs/Json/System.Text.JSON_specs.cs
@@ -1,0 +1,12 @@
+﻿namespace Json.System_Text_JSON_specs;
+
+public class All_SVO_s : SvoTypeTest
+{
+	[TestCaseSource(nameof(AllSvos))]
+	public void have_JSON_Type_converter_attribute(Type type)
+	{
+		type.Should().BeDecoratedWith<System.Text.Json.Serialization.JsonConverterAttribute>();
+		var converterType = type.GetCustomAttribute<System.Text.Json.Serialization.JsonConverterAttribute>().ConverterType;
+		typeof(SvoJsonConverter<>).MakeGenericType(type).Should().NotBeAssignableTo(converterType);
+	}
+}

--- a/specs/Qowaiv.Specs/LocalDateTime_specs.cs
+++ b/specs/Qowaiv.Specs/LocalDateTime_specs.cs
@@ -113,22 +113,22 @@
 
     public class Supports_JSON_serialization
     {
-        [TestCase("1988-06-13 22:10:05.001", 627178398050010000L)]
+        [TestCase(627178398050010000L, "1988-06-13 22:10:05.001")]
         [TestCase("1988-06-13 22:10:05.001", "1988-06-13 22:10:05.001")]
-        public void System_Text_JSON_deserialization(LocalDateTime svo, object json)
+        public void System_Text_JSON_deserialization(object json, LocalDateTime svo)
             => JsonTester.Read_System_Text_JSON<LocalDateTime>(json).Should().Be(svo);
 
+        [TestCase(627178398050010000L, "1988-06-13 22:10:05.001")]
         [TestCase("1988-06-13 22:10:05.001", "1988-06-13 22:10:05.001")]
-        public void System_Text_JSON_serialization(object json, LocalDateTime svo)
+        public void convention_based_deserialization(object json, LocalDateTime svo)
+          => JsonTester.Read<LocalDateTime>(json).Should().Be(svo);
+
+        [TestCase("1988-06-13 22:10:05.001", "1988-06-13 22:10:05.001")]
+        public void System_Text_JSON_serialization(LocalDateTime svo, object json)
             => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-        [TestCase("1988-06-13 22:10:05.001", 627178398050010000L)]
         [TestCase("1988-06-13 22:10:05.001", "1988-06-13 22:10:05.001")]
-        public void convention_based_deserialization(LocalDateTime svo, object json)
-            => JsonTester.Read<LocalDateTime>(json).Should().Be(svo);
-
-        [TestCase("1988-06-13 22:10:05.001", "1988-06-13 22:10:05.001")]
-        public void convention_based_serialization(object json, LocalDateTime svo)
+        public void convention_based_serialization(LocalDateTime svo, object json)
             => JsonTester.Write(svo).Should().Be(json);
 
         [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/LocalDateTime_specs.cs
+++ b/specs/Qowaiv.Specs/LocalDateTime_specs.cs
@@ -110,4 +110,34 @@
         public void to_WeekDate()
             => Converting.To<WeekDate>().From(Svo.LocalDateTime).Should().Be(Svo.WeekDate);
     }
+
+    public class Supports_JSON_serialization
+    {
+        [TestCase("1988-06-13 22:10:05.001", 627178398050010000L)]
+        [TestCase("1988-06-13 22:10:05.001", "1988-06-13 22:10:05.001")]
+        public void System_Text_JSON_deserialization(LocalDateTime svo, object json)
+            => JsonTester.Read_System_Text_JSON<LocalDateTime>(json).Should().Be(svo);
+
+        [TestCase("1988-06-13 22:10:05.001", "1988-06-13 22:10:05.001")]
+        public void System_Text_JSON_serialization(object json, LocalDateTime svo)
+            => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+        [TestCase("1988-06-13 22:10:05.001", 627178398050010000L)]
+        [TestCase("1988-06-13 22:10:05.001", "1988-06-13 22:10:05.001")]
+        public void convention_based_deserialization(LocalDateTime svo, object json)
+            => JsonTester.Read<LocalDateTime>(json).Should().Be(svo);
+
+        [TestCase("1988-06-13 22:10:05.001", "1988-06-13 22:10:05.001")]
+        public void convention_based_serialization(object json, LocalDateTime svo)
+            => JsonTester.Write(svo).Should().Be(json);
+
+        [TestCase("Invalid input", typeof(FormatException))]
+        [TestCase("yyyy-06-11", typeof(FormatException))]
+        [TestCase(true, typeof(InvalidOperationException))]
+        public void throws_for_invalid_json(object json, Type exceptionType)
+        {
+            var exception = Assert.Catch(() => JsonTester.Read<LocalDateTime>(json));
+            Assert.IsInstanceOf(exceptionType, exception);
+        }
+    }
 }

--- a/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
+++ b/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
@@ -185,28 +185,28 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("4/1", 4L)]
-    [TestCase("3/1", 3.0)]
-    [TestCase("1/3", "14/42")]
-    [TestCase("13/100", "13%")]
-    public void System_Text_JSON_deserialization(Fraction svo, object json)
+    [TestCase(4L, "4/1")]
+    [TestCase(3d, "3/1")]
+    [TestCase("13%", "13/100")]
+    [TestCase("14/42", "1/3")]
+    public void System_Text_JSON_deserialization(object json, Fraction svo)
         => JsonTester.Read_System_Text_JSON<Fraction>(json).Should().Be(svo);
 
-    [TestCase("1/3", "1/3")]
-    [TestCase("4/3", "4/3")]
-    public void System_Text_JSON_serialization(object json, Fraction svo)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
-    [TestCase("4/1", 4L)]
-    [TestCase("3/1", 3.0)]
-    [TestCase("1/3", "14/42")]
-    [TestCase("13/100", "13%")]
-    public void convention_based_deserialization(Fraction svo, object json)
+    [TestCase(4L, "4/1")]
+    [TestCase(3d, "3/1")]
+    [TestCase("13%", "13/100")]
+    [TestCase("14/42", "1/3")]
+    public void convention_based_deserialization(object json, Fraction svo)
         => JsonTester.Read<Fraction>(json).Should().Be(svo);
 
     [TestCase("1/3", "1/3")]
     [TestCase("4/3", "4/3")]
-    public void convention_based_serialization(object json, Fraction svo)
+    public void System_Text_JSON_serialization(Fraction svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+    
+    [TestCase("1/3", "1/3")]
+    [TestCase("4/3", "4/3")]
+    public void convention_based_serialization(Fraction svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase(double.MaxValue, typeof(OverflowException))]

--- a/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
+++ b/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
@@ -183,6 +183,43 @@ public class Supports_type_conversion
     }
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase("4/1", 4L)]
+    [TestCase("3/1", 3.0)]
+    [TestCase("1/3", "14/42")]
+    [TestCase("13/100", "13%")]
+    public void System_Text_JSON_deserialization(Fraction svo, object json)
+        => JsonTester.Read_System_Text_JSON<Fraction>(json).Should().Be(svo);
+
+    [TestCase("1/3", "1/3")]
+    [TestCase("4/3", "4/3")]
+    public void System_Text_JSON_serialization(object json, Fraction svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("4/1", 4L)]
+    [TestCase("3/1", 3.0)]
+    [TestCase("1/3", "14/42")]
+    [TestCase("13/100", "13%")]
+    public void convention_based_deserialization(Fraction svo, object json)
+        => JsonTester.Read<Fraction>(json).Should().Be(svo);
+
+    [TestCase("1/3", "1/3")]
+    [TestCase("4/3", "4/3")]
+    public void convention_based_serialization(object json, Fraction svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase(double.MaxValue, typeof(OverflowException))]
+    [TestCase(double.MinValue, typeof(OverflowException))]
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<Fraction>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/MonthSpan_specs.cs
+++ b/specs/Qowaiv.Specs/MonthSpan_specs.cs
@@ -98,22 +98,23 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("5Y+9M", 69L)]
+    [TestCase(69d, "5Y+9M")]
+    [TestCase(69L, "5Y+9M")]
     [TestCase("5Y+9M", "5Y+9M")]
-    public void System_Text_JSON_deserialization(MonthSpan svo, object json)
+    public void System_Text_JSON_deserialization(object json, MonthSpan svo)
         => JsonTester.Read_System_Text_JSON<MonthSpan>(json).Should().Be(svo);
 
+    [TestCase(69L, "5Y+9M")]
     [TestCase("5Y+9M", "5Y+9M")]
-    public void System_Text_JSON_serialization(object json, MonthSpan svo)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
-    [TestCase("5Y+9M", 69L)]
-    [TestCase("5Y+9M", "5Y+9M")]
-    public void convention_based_deserialization(MonthSpan svo, object json)
+    public void convention_based_deserialization(object json, MonthSpan svo)
         => JsonTester.Read<MonthSpan>(json).Should().Be(svo);
 
     [TestCase("5Y+9M", "5Y+9M")]
-    public void convention_based_serialization(object json, MonthSpan svo)
+    public void System_Text_JSON_serialization(MonthSpan svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("5Y+9M", "5Y+9M")]
+    public void convention_based_serialization(MonthSpan svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/MonthSpan_specs.cs
+++ b/specs/Qowaiv.Specs/MonthSpan_specs.cs
@@ -96,6 +96,36 @@ public class Supports_type_conversion
         => Converting.To<int>().From(Svo.MonthSpan).Should().Be(69);
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase("5Y+9M", 69L)]
+    [TestCase("5Y+9M", "5Y+9M")]
+    public void System_Text_JSON_deserialization(MonthSpan svo, object json)
+        => JsonTester.Read_System_Text_JSON<MonthSpan>(json).Should().Be(svo);
+
+    [TestCase("5Y+9M", "5Y+9M")]
+    public void System_Text_JSON_serialization(object json, MonthSpan svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("5Y+9M", 69L)]
+    [TestCase("5Y+9M", "5Y+9M")]
+    public void convention_based_deserialization(MonthSpan svo, object json)
+        => JsonTester.Read<MonthSpan>(json).Should().Be(svo);
+
+    [TestCase("5Y+9M", "5Y+9M")]
+    public void convention_based_serialization(object json, MonthSpan svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<MonthSpan>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -501,6 +501,17 @@ public class Supports_JSON_serialization
     [TestCase("?", "unknown")]
     [TestCase("February", 2.0)]
     [TestCase("February", 2L)]
+    public void System_Text_JSON_deserialization(Month svo, object json)
+        => JsonTester.Read_System_Text_JSON<Month>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("Feb", "February")]
+    public void System_Text_JSON_serialization(object json, Month svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("?", "unknown")]
+    [TestCase("February", 2.0)]
+    [TestCase("February", 2L)]
     public void convention_based_deserialization(Month expected, object json)
     {
         var actual = JsonTester.Read<Month>(json);

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -498,33 +498,30 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("?", "unknown")]
-    [TestCase("February", 2.0)]
-    [TestCase("February", 2L)]
-    public void System_Text_JSON_deserialization(Month svo, object json)
+    [TestCase(null, null)]
+    [TestCase("?", "?")]
+    [TestCase(2.0, "February")]
+    [TestCase(2L, "February")]
+    [TestCase("feb", "February")]
+    public void System_Text_JSON_deserialization(object json, Month svo)
         => JsonTester.Read_System_Text_JSON<Month>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
-    [TestCase("Feb", "February")]
-    public void System_Text_JSON_serialization(object json, Month svo)
+    [TestCase("?", "?")]
+    [TestCase(2.0, "February")]
+    [TestCase(2L, "February")]
+    [TestCase("feb", "February")]
+    public void convention_based_deserialization(object json, Month svo)
+        => JsonTester.Read<Month>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase("Feb", "Feb")]
+    public void System_Text_JSON_serialization(Month svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase("?", "unknown")]
-    [TestCase("February", 2.0)]
-    [TestCase("February", 2L)]
-    public void convention_based_deserialization(Month expected, object json)
-    {
-        var actual = JsonTester.Read<Month>(json);
-        Assert.AreEqual(expected, actual);
-    }
-
-    [TestCase(null, "")]
-    [TestCase("Feb", "February")]
-    public void convention_based_serialization(object expected, Month svo)
-    {
-        var serialized = JsonTester.Write(svo);
-        Assert.AreEqual(expected, serialized);
-    }
+    [TestCase(null, null)]
+    [TestCase("Feb", "Feb")]
+    public void convention_based_serialization(Month svo, object json)
+        => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]
     [TestCase("2017-06-11", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -1137,34 +1137,26 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("17.51%", "17.51")]
-    [TestCase("17.51%", "175.1‰")]
-    [TestCase("17.51%", 0.1751)]
-    [TestCase("100%", 1L)]
-    public void System_Text_JSON_deserialization(Percentage svo, object json)
+    [TestCase("17.51", "17.51%")]
+    [TestCase("175.1‰", "17.51%")]
+    [TestCase(0.1751, "17.51%")]
+    [TestCase(1L, "100%")]
+    public void System_Text_JSON_deserialization(object json, Percentage svo)
         => JsonTester.Read_System_Text_JSON<Percentage>(json).Should().Be(svo);
 
+    [TestCase("17.51", "17.51%")]
+    [TestCase("175.1‰", "17.51%")]
+    [TestCase(0.1751, "17.51%")]
+    public void convention_based_deserialization(object json, Percentage svo)
+        => JsonTester.Read<Percentage>(json).Should().Be(svo);
+
     [TestCase("17.51%", "17.51%")]
-    [TestCase("0%", "0%")]
-    public void System_Text_JSON_serialization(object json, Percentage svo)
+    public void System_Text_JSON_serialization(Percentage svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase("17.51%", "17.51")]
-    [TestCase("17.51%", "175.1‰")]
-    [TestCase("17.51%", 0.1751)]
-    public void convention_based_deserialization(Percentage expected, object json)
-    {
-        var actual = JsonTester.Read<Percentage>(json);
-        Assert.AreEqual(expected, actual);
-    }
-
     [TestCase("17.51%", "17.51%")]
-    [TestCase("0%", "0%")]
-    public void convention_based_serialization(object expected, Percentage svo)
-    {
-        var serialized = JsonTester.Write(svo);
-        Assert.AreEqual(expected, serialized);
-    }
+    public void convention_based_serialization(Percentage svo, object json)
+        => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]
     public void throws_for_invalid_json(object json, Type exceptionType)

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -1140,6 +1140,18 @@ public class Supports_JSON_serialization
     [TestCase("17.51%", "17.51")]
     [TestCase("17.51%", "175.1‰")]
     [TestCase("17.51%", 0.1751)]
+    [TestCase("100%", 1L)]
+    public void System_Text_JSON_deserialization(Percentage svo, object json)
+        => JsonTester.Read_System_Text_JSON<Percentage>(json).Should().Be(svo);
+
+    [TestCase("17.51%", "17.51%")]
+    [TestCase("0%", "0%")]
+    public void System_Text_JSON_serialization(object json, Percentage svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("17.51%", "17.51")]
+    [TestCase("17.51%", "175.1‰")]
+    [TestCase("17.51%", 0.1751)]
     public void convention_based_deserialization(Percentage expected, object json)
     {
         var actual = JsonTester.Read<Percentage>(json);

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -1,4 +1,6 @@
-﻿namespace Postal_code_specs;
+﻿using System.Text.Json;
+
+namespace Postal_code_specs;
 
 public class With_domain_logic
 {
@@ -444,35 +446,23 @@ public class Supports_JSON_serialization
 {
     [TestCase("?", "unknown")]
     [TestCase("1234", "1234")]
-    public void System_Text_JSON_based_deserialization(PostalCode expected, string json)
-    {
-        var actual = System.Text.Json.JsonSerializer.Deserialize<PostalCode>(json);
-        Assert.AreEqual(expected, actual);
-    }
+    public void System_Text_JSON_deserialization(PostalCode svo, object json)
+        => JsonTester.Read_System_Text_JSON<PostalCode>(json).Should().Be(svo);
 
     [TestCase(null, "")]
     [TestCase("1234", "1234")]
-    public void System_Text_JSON_serialization(object expected, PostalCode svo)
-    {
-        var serialized = System.Text.Json.JsonSerializer.Serialize(svo);
-        Assert.AreEqual(expected, serialized);
-    }
-
+    public void System_Text_JSON_based_serialization(object json, PostalCode svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+    
     [TestCase("?", "unknown")]
     [TestCase("1234", "1234")]
-    public void convention_based_deserialization(PostalCode expected, object json)
-    {
-        var actual = JsonTester.Read<PostalCode>(json);
-        Assert.AreEqual(expected, actual);
-    }
+    public void convention_based_deserialization(PostalCode svo, object json)
+        => JsonTester.Read<PostalCode>(json).Should().Be(svo);
 
     [TestCase(null, "")]
     [TestCase("1234", "1234")]
-    public void convention_based_serialization(object expected, PostalCode svo)
-    {
-        var serialized = JsonTester.Write(svo);
-        Assert.AreEqual(expected, serialized);
-    }
+    public void convention_based_serialization(string json, PostalCode svo)
+        => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("01234567890", typeof(FormatException))]
     public void throws_for_invalid_json(object json, Type exceptionType)

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -444,24 +444,25 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("?", "unknown")]
+    [TestCase("?", "?")]
+    [TestCase(null, null)]
     [TestCase("1234", "1234")]
-    public void System_Text_JSON_deserialization(PostalCode svo, object json)
+    public void System_Text_JSON_deserialization(object json, PostalCode svo)
         => JsonTester.Read_System_Text_JSON<PostalCode>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
+    [TestCase("?", "?")]
     [TestCase("1234", "1234")]
-    public void System_Text_JSON_based_serialization(object json, PostalCode svo)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-    
-    [TestCase("?", "unknown")]
-    [TestCase("1234", "1234")]
-    public void convention_based_deserialization(PostalCode svo, object json)
-        => JsonTester.Read<PostalCode>(json).Should().Be(svo);
+    public void convention_based_deserialization(object json, PostalCode svo)
+      => JsonTester.Read<PostalCode>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
+    [TestCase(null, null)]
     [TestCase("1234", "1234")]
-    public void convention_based_serialization(string json, PostalCode svo)
+    public void System_Text_JSON_based_serialization(PostalCode svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(null, null)]
+    [TestCase("1234", "1234")]
+    public void convention_based_serialization(PostalCode svo, string json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("01234567890", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -444,6 +444,22 @@ public class Supports_JSON_serialization
 {
     [TestCase("?", "unknown")]
     [TestCase("1234", "1234")]
+    public void System_Text_JSON_based_deserialization(PostalCode expected, string json)
+    {
+        var actual = System.Text.Json.JsonSerializer.Deserialize<PostalCode>(json);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase(null, "")]
+    [TestCase("1234", "1234")]
+    public void System_Text_JSON_serialization(object expected, PostalCode svo)
+    {
+        var serialized = System.Text.Json.JsonSerializer.Serialize(svo);
+        Assert.AreEqual(expected, serialized);
+    }
+
+    [TestCase("?", "unknown")]
+    [TestCase("1234", "1234")]
     public void convention_based_deserialization(PostalCode expected, object json)
     {
         var actual = JsonTester.Read<PostalCode>(json);

--- a/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
+++ b/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
@@ -126,6 +126,10 @@ public class Does_not_support_type_converstion_to
 public class Supports_JSON_deserialization
 {
     [Test]
+    public void System_Text_JSON_deserialization()
+        => JsonTester.Read_System_Text_JSON<CryptographicSeed>("Qowaiv==").Value().Should().Be(Svo.CryptographicSeed.Value());
+
+    [Test]
     public void convention_based_deserialization()
         => JsonTester.Read<CryptographicSeed>("Qowaiv==").Value().Should().Be(Svo.CryptographicSeed.Value());
 
@@ -133,6 +137,10 @@ public class Supports_JSON_deserialization
 
 public class Does_not_supports_JSON_serialization
 {
+    [Test]
+    public void serializes_to_null_System_Text_JSON()
+       => JsonTester.Write_System_Text_JSON(Svo.CryptographicSeed).Should().BeNull();
+
     [Test]
     public void serializes_to_null()
         => JsonTester.Write(Svo.CryptographicSeed).Should().BeNull();

--- a/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
+++ b/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
@@ -132,7 +132,6 @@ public class Supports_JSON_deserialization
     [Test]
     public void convention_based_deserialization()
         => JsonTester.Read<CryptographicSeed>("Qowaiv==").Value().Should().Be(Svo.CryptographicSeed.Value());
-
 }
 
 public class Does_not_supports_JSON_serialization

--- a/specs/Qowaiv.Specs/Security/Secret_specs.cs
+++ b/specs/Qowaiv.Specs/Security/Secret_specs.cs
@@ -124,7 +124,6 @@ public class Supports_JSON_deserialization
     [Test]
     public void convention_based_deserialization()
         => JsonTester.Read<Secret>("Ken sent me!").Value().Should().Be(Svo.Secret.Value());
-
 }
 
 public class Does_not_supports_JSON_serialization

--- a/specs/Qowaiv.Specs/Security/Secret_specs.cs
+++ b/specs/Qowaiv.Specs/Security/Secret_specs.cs
@@ -118,6 +118,10 @@ public class Does_not_support_type_converstion_to
 public class Supports_JSON_deserialization
 {
     [Test]
+    public void System_Text_JSON_deserialization()
+         => JsonTester.Read_System_Text_JSON<Secret>("Ken sent me!").Value().Should().Be(Svo.Secret.Value());
+
+    [Test]
     public void convention_based_deserialization()
         => JsonTester.Read<Secret>("Ken sent me!").Value().Should().Be(Svo.Secret.Value());
 
@@ -125,6 +129,10 @@ public class Supports_JSON_deserialization
 
 public class Does_not_supports_JSON_serialization
 {
+    [Test]
+    public void serializes_to_null_System_Text_JSON()
+        => JsonTester.Write_System_Text_JSON(Svo.Secret).Should().BeNull();
+
     [Test]
     public void serializes_to_null()
         => JsonTester.Write(Svo.Secret).Should().BeNull();

--- a/specs/Qowaiv.Specs/Sex_specs.cs
+++ b/specs/Qowaiv.Specs/Sex_specs.cs
@@ -406,35 +406,30 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("?", "unknown")]
-    [TestCase("Female", 2L)]
-    [TestCase("Female", 2.0)]
+    [TestCase("?", "?")]
+    [TestCase(null, null)]
+    [TestCase(2L, "Female")]
+    [TestCase(2d, "Female")]
     [TestCase("Female", "Female")]
-    public void System_Text_JSON_deserialization(Sex svo, object json)
+    public void System_Text_JSON_deserialization(object json, Sex svo)
         => JsonTester.Read_System_Text_JSON<Sex>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
+    [TestCase("?", "?")]
+    [TestCase(2L, "Female")]
+    [TestCase(2d, "Female")]
     [TestCase("Female", "Female")]
-    public void System_Text_JSON_serialization(object json, Sex svo)
+    public void convention_based_deserialization(object json, Sex svo)
+        => JsonTester.Read<Sex>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase("Female", "Female")]
+    public void System_Text_JSON_serialization(Sex svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase("?", "unknown")]
-    [TestCase("Female", 2L)]
-    [TestCase("Female", 2d)]
+    [TestCase(null, null)]
     [TestCase("Female", "Female")]
-    public void convention_based_deserialization(Sex expected, object json)
-    {
-        var actual = JsonTester.Read<Sex>(json);
-        Assert.AreEqual(expected, actual);
-    }
-
-    [TestCase(null, "")]
-    [TestCase("Female", "Female")]
-    public void convention_based_serialization(object expected, Sex svo)
-    {
-        var serialized = JsonTester.Write(svo);
-        Assert.AreEqual(expected, serialized);
-    }
+    public void convention_based_serialization(Sex svo, object json)
+        => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]
     [TestCase("2017-06-11", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Sex_specs.cs
+++ b/specs/Qowaiv.Specs/Sex_specs.cs
@@ -408,7 +408,20 @@ public class Supports_JSON_serialization
 {
     [TestCase("?", "unknown")]
     [TestCase("Female", 2L)]
+    [TestCase("Female", 2.0)]
+    [TestCase("Female", "Female")]
+    public void System_Text_JSON_deserialization(Sex svo, object json)
+        => JsonTester.Read_System_Text_JSON<Sex>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("Female", "Female")]
+    public void System_Text_JSON_serialization(object json, Sex svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("?", "unknown")]
+    [TestCase("Female", 2L)]
     [TestCase("Female", 2d)]
+    [TestCase("Female", "Female")]
     public void convention_based_deserialization(Sex expected, object json)
     {
         var actual = JsonTester.Read<Sex>(json);
@@ -416,6 +429,7 @@ public class Supports_JSON_serialization
     }
 
     [TestCase(null, "")]
+    [TestCase("Female", "Female")]
     public void convention_based_serialization(object expected, Sex svo)
     {
         var serialized = JsonTester.Write(svo);

--- a/specs/Qowaiv.Specs/Sql/Timestamp_specs.cs
+++ b/specs/Qowaiv.Specs/Sql/Timestamp_specs.cs
@@ -45,6 +45,45 @@ public class Is_equal_by_value
     }
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase(null, null)]
+    [TestCase(null, "0x0000000000000000")]
+    [TestCase("0x000000006E3AB701", "1849341697")]
+    [TestCase("0x000000006E3AB701", "0x000000006E3AB701")]
+    [TestCase("0x000000006E3AB701", 1849341697L)]
+    [TestCase("0x000000006E3AB701", 1849341697.0)]
+    public void System_Text_JSON_deserialization(Timestamp svo, object json)
+        => JsonTester.Read_System_Text_JSON<Timestamp>(json).Should().Be(svo);
+
+    [TestCase("0x0000000000000000", null)]
+    [TestCase("0x000000006E3AB701", "0x000000006E3AB701")]
+    public void System_Text_JSON_serialization(object json, Timestamp svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(null, "0x0000000000000000")]
+    [TestCase("0x000000006E3AB701", "1849341697")]
+    [TestCase("0x000000006E3AB701", "0x000000006E3AB701")]
+    [TestCase("0x000000006E3AB701", 1849341697L)]
+    [TestCase("0x000000006E3AB701", 1849341697.0)]
+    public void convention_based_deserialization(Timestamp svo, object json)
+        => JsonTester.Read<Timestamp>(json).Should().Be(svo);
+
+    [TestCase("0x0000000000000000", null)]
+    [TestCase("0x000000006E3AB701", "0x000000006E3AB701")]
+    public void convention_based_serialization(object json, Timestamp svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("2017-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<Timestamp>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
+
 
 public class Is_Open_API_data_type
 {

--- a/specs/Qowaiv.Specs/Sql/Timestamp_specs.cs
+++ b/specs/Qowaiv.Specs/Sql/Timestamp_specs.cs
@@ -48,30 +48,28 @@ public class Is_equal_by_value
 public class Supports_JSON_serialization
 {
     [TestCase(null, null)]
-    [TestCase(null, "0x0000000000000000")]
-    [TestCase("0x000000006E3AB701", "1849341697")]
+    [TestCase(1849341697d, "0x000000006E3AB701")]
+    [TestCase(1849341697L, "0x000000006E3AB701")]
+    [TestCase("1849341697", "0x000000006E3AB701")]
     [TestCase("0x000000006E3AB701", "0x000000006E3AB701")]
-    [TestCase("0x000000006E3AB701", 1849341697L)]
-    [TestCase("0x000000006E3AB701", 1849341697.0)]
-    public void System_Text_JSON_deserialization(Timestamp svo, object json)
+    public void System_Text_JSON_deserialization(object json, Timestamp svo)
         => JsonTester.Read_System_Text_JSON<Timestamp>(json).Should().Be(svo);
 
-    [TestCase("0x0000000000000000", null)]
+    [TestCase(1849341697d, "0x000000006E3AB701")]
+    [TestCase(1849341697L, "0x000000006E3AB701")]
+    [TestCase("1849341697", "0x000000006E3AB701")]
     [TestCase("0x000000006E3AB701", "0x000000006E3AB701")]
-    public void System_Text_JSON_serialization(object json, Timestamp svo)
+    public void convention_based_deserialization(object json, Timestamp svo)
+      => JsonTester.Read<Timestamp>(json).Should().Be(svo);
+
+    [TestCase(null, "0x0000000000000000")]
+    [TestCase("0x000000006E3AB701", "0x000000006E3AB701")]
+    public void System_Text_JSON_serialization(Timestamp svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
     [TestCase(null, "0x0000000000000000")]
-    [TestCase("0x000000006E3AB701", "1849341697")]
     [TestCase("0x000000006E3AB701", "0x000000006E3AB701")]
-    [TestCase("0x000000006E3AB701", 1849341697L)]
-    [TestCase("0x000000006E3AB701", 1849341697.0)]
-    public void convention_based_deserialization(Timestamp svo, object json)
-        => JsonTester.Read<Timestamp>(json).Should().Be(svo);
-
-    [TestCase("0x0000000000000000", null)]
-    [TestCase("0x000000006E3AB701", "0x000000006E3AB701")]
-    public void convention_based_serialization(object json, Timestamp svo)
+    public void convention_based_serialization(Timestamp svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
+++ b/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
@@ -107,28 +107,26 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase(1600, "1600*")]
-    [TestCase(1700, "1700")]
-    [TestCase(1234, 1234L)]
+    [TestCase("1600*", 1600.0)]
+    [TestCase("1700", 1700.0)]
+    [TestCase(1234L, 1234.0)]
     [TestCase(1258.9, 1258.9)]
-    public void System_Text_JSON_deserialization(Elo svo, object json)
+    public void System_Text_JSON_deserialization(object json, Elo svo)
         => JsonTester.Read_System_Text_JSON<Elo>(json).Should().Be(svo);
 
-    [TestCase(1234, 1234L)]
+    [TestCase("1600*", 1600.0)]
+    [TestCase("1700", 1700.0)]
+    [TestCase(1234L, 1234.0)]
     [TestCase(1258.9, 1258.9)]
-    public void System_Text_JSON_serialization(object json, Elo svo)
+    public void convention_based_deserialization(object json, Elo svo)
+       => JsonTester.Read<Elo>(json).Should().Be(svo);
+
+    [TestCase(1258.9, 1258.9)]
+    public void System_Text_JSON_serialization(Elo svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
-    [TestCase(1600, "1600*")]
-    [TestCase(1700, "1700")]
-    [TestCase(1234, 1234L)]
+       
     [TestCase(1258.9, 1258.9)]
-    public void convention_based_deserialization(Elo svo, object json)
-        => JsonTester.Read<Elo>(json).Should().Be(svo);
-
-    [TestCase(1234, 1234L)]
-    [TestCase(1258.9, 1258.9)]
-    public void convention_based_serialization(object json, Elo svo)
+    public void convention_based_serialization(Elo svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
+++ b/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
@@ -105,6 +105,40 @@ public class Supports_type_conversion
     }
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase(1600, "1600*")]
+    [TestCase(1700, "1700")]
+    [TestCase(1234, 1234L)]
+    [TestCase(1258.9, 1258.9)]
+    public void System_Text_JSON_deserialization(Elo svo, object json)
+        => JsonTester.Read_System_Text_JSON<Elo>(json).Should().Be(svo);
+
+    [TestCase(1234, 1234L)]
+    [TestCase(1258.9, 1258.9)]
+    public void System_Text_JSON_serialization(object json, Elo svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(1600, "1600*")]
+    [TestCase(1700, "1700")]
+    [TestCase(1234, 1234L)]
+    [TestCase(1258.9, 1258.9)]
+    public void convention_based_deserialization(Elo svo, object json)
+        => JsonTester.Read<Elo>(json).Should().Be(svo);
+
+    [TestCase(1234, 1234L)]
+    [TestCase(1258.9, 1258.9)]
+    public void convention_based_serialization(object json, Elo svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase(double.NaN, typeof(ArgumentOutOfRangeException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<Elo>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -557,6 +557,17 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
+    [TestCase("", null)]
+    [TestCase("", "")]
+    [TestCase("Qowaiv_SVOLibrary_GUIA", "Qowaiv_SVOLibrary_GUIA")]
+    public void System_Text_JSON_deserialization(Uuid svo, object json)
+    => JsonTester.Read_System_Text_JSON<Uuid>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("Qowaiv_SVOLibrary_GUIA", "Qowaiv_SVOLibrary_GUIA")]
+    public void System_Text_JSON_serialization(object json, Uuid svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
     [TestCase(null, "")]
     [TestCase("Qowaiv_SVOLibrary_GUIA", "Qowaiv_SVOLibrary_GUIA")]
     public void convention_based_deserialization(Uuid expected, object json)

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -558,31 +558,24 @@ public class Supports_type_conversion
 public class Supports_JSON_serialization
 {
     [TestCase("", null)]
-    [TestCase("", "")]
+    [TestCase(null, null)]
     [TestCase("Qowaiv_SVOLibrary_GUIA", "Qowaiv_SVOLibrary_GUIA")]
-    public void System_Text_JSON_deserialization(Uuid svo, object json)
-    => JsonTester.Read_System_Text_JSON<Uuid>(json).Should().Be(svo);
+    public void System_Text_JSON_deserialization(object json, Uuid svo)
+        => JsonTester.Read_System_Text_JSON<Uuid>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
     [TestCase("Qowaiv_SVOLibrary_GUIA", "Qowaiv_SVOLibrary_GUIA")]
-    public void System_Text_JSON_serialization(object json, Uuid svo)
+    public void convention_based_deserialization(object json, Uuid svo)
+       => JsonTester.Read<Uuid>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase("Qowaiv_SVOLibrary_GUIA", "Qowaiv_SVOLibrary_GUIA")]
+    public void System_Text_JSON_serialization(Uuid svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-    [TestCase(null, "")]
+    [TestCase(null, null)]
     [TestCase("Qowaiv_SVOLibrary_GUIA", "Qowaiv_SVOLibrary_GUIA")]
-    public void convention_based_deserialization(Uuid expected, object json)
-    {
-        var actual = JsonTester.Read<Uuid>(json);
-        Assert.AreEqual(expected, actual);
-    }
-
-    [TestCase(null, "")]
-    [TestCase("Qowaiv_SVOLibrary_GUIA", "Qowaiv_SVOLibrary_GUIA")]
-    public void convention_based_serialization(object expected, Uuid svo)
-    {
-        var serialized = JsonTester.Write(svo);
-        Assert.AreEqual(expected, serialized);
-    }
+    public void convention_based_serialization(Uuid svo, object json)
+        => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]
     public void throws_for_invalid_json(object json, Type exceptionType)

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
@@ -254,36 +254,6 @@ public class DateSpanTest
 
     #endregion
 
-    #region JSON (De)serialization tests
-
-    [Test]
-    public void FromJson_StringValue_AreEqual()
-    {
-        var act = JsonTester.Read<DateSpan>(TestStruct.ToString(CultureInfo.InvariantCulture));
-        var exp = TestStruct;
-
-        Assert.AreEqual(exp, act);
-    }
-
-    [Test]
-    public void ToJson_DefaultValue_AreEqual()
-    {
-        object act = JsonTester.Write(default(DateSpan));
-        object exp = "0Y+0M+0D";
-
-        Assert.AreEqual(exp, act);
-    }
-    [Test]
-    public void ToJson_TestStruct_AreEqual()
-    {
-        var act = JsonTester.Write(TestStruct);
-        var exp = TestStruct.ToString(CultureInfo.InvariantCulture);
-
-        Assert.AreEqual(exp, act);
-    }
-
-    #endregion
-
     #region IFormattable / Tostring tests
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
@@ -246,55 +246,6 @@ public class DateTest
 
     #endregion
 
-    #region JSON (De)serialization tests
-
-    [Test]
-    public void FromJson_InvalidStringValue_AssertFormatException()
-    {
-        Assert.Catch<FormatException>(() =>
-        {
-            JsonTester.Read<Date>("InvalidStringValue");
-        },
-        "Not a valid date");
-    }
-
-    [TestCase("2012-04-23")]
-    [TestCase("2012-04-23T18:25:43.511Z")]
-    [TestCase("2012-04-23T10:25:43-05:00")]
-    public void FromJson_StringValue_AreEqual(string str)
-    {
-        var act = JsonTester.Read<Date>(str);
-        var exp = new Date(2012, 04, 23);
-
-        Assert.AreEqual(exp, act);
-    }
-
-    [Test]
-    public void FromJson_Int64Value_AreEqual()
-    {
-        var act = JsonTester.Read<Date>(TestStruct.Ticks);
-        var exp = TestStruct;
-
-        Assert.AreEqual(exp, act);
-    }
-
-    [Test]
-    public void ToJson_DefaultValue_AreEqual()
-    {
-        object act = JsonTester.Write(default(Date));
-        object exp = "0001-01-01";
-        Assert.AreEqual(exp, act);
-    }
-    [Test]
-    public void ToJson_TestStruct_AreEqual()
-    {
-        var act = JsonTester.Write(TestStruct);
-        var exp = "1970-02-14";
-        Assert.AreEqual(exp, act);
-    }
-
-    #endregion
-
     #region IFormattable / Tostring tests
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
@@ -1,384 +1,340 @@
-﻿using NUnit.Framework;
-using Qowaiv.TestTools;
-using System;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests;
 
-namespace Qowaiv.UnitTests
+[TestFixture]
+public class EmailAddressCollectionTest
 {
-    [TestFixture]
-    public class EmailAddressCollectionTest
+    public static EmailAddressCollection GetTestInstance() 
+        => EmailAddressCollection.Parse("info@qowaiv.org,test@qowaiv.org");
+
+    #region (XML) (De)serialization tests
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
     {
-        public static EmailAddressCollection GetTestInstance() 
-            => EmailAddressCollection.Parse("info@qowaiv.org,test@qowaiv.org");
+        ISerializable obj = GetTestInstance();
+        var info = new SerializationInfo(typeof(EmailAddressCollection), new FormatterConverter());
+        obj.GetObjectData(info, default);
 
-        #region (XML) (De)serialization tests
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = GetTestInstance();
-            var info = new SerializationInfo(typeof(EmailAddressCollection), new FormatterConverter());
-            obj.GetObjectData(info, default);
-
-            Assert.AreEqual("info@qowaiv.org,test@qowaiv.org", info.GetString("Value"));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = GetTestInstance();
-            var exp = GetTestInstance();
-            var act = SerializeDeserialize.Binary(input);
-            CollectionAssert.AreEqual(exp, act);
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = GetTestInstance();
-            var exp = GetTestInstance();
-            var act = SerializeDeserialize.DataContract(input);
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(GetTestInstance());
-            var exp = "info@qowaiv.org,test@qowaiv.org";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<EmailAddressCollection>("info@qowaiv.org,test@qowaiv.org");
-            Assert.AreEqual(GetTestInstance(), act);
-        }
-
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_EmailAddressSerializeObject_AreEqual()
-        {
-            var input = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = GetTestInstance(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = GetTestInstance(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_EmailAddressSerializeObject_AreEqual()
-        {
-            var input = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = GetTestInstance(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = GetTestInstance(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_EmailAddressSerializeObject_AreEqual()
-        {
-            var input = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = GetTestInstance(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = GetTestInstance(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = new EmailAddressCollection(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = new EmailAddressCollection(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = new EmailAddressCollection(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new EmailAddressCollectionSerializeObject
-            {
-                Id = 17,
-                Obj = new EmailAddressCollection(),
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = GetTestInstance();
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [Test]
-        public void FromJson_InvalidStringValue_AssertFormatException()
-        {
-            Assert.Catch<FormatException>(() =>
-            {
-                JsonTester.Read<EmailAddressCollection>("InvalidStringValue");
-            },
-            "Not valid email addresses");
-        }
-        [Test]
-        public void FromJson_StringValue_AreEqual()
-        {
-            var act = JsonTester.Read<EmailAddressCollection>("info@qowaiv.org,test@qowaiv.org");
-            var exp = EmailAddressCollection.Parse("info@qowaiv.org, test@qowaiv.org");
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_IsNull()
-        {
-            object act = JsonTester.Write(new EmailAddressCollection());
-            Assert.IsNull(act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(EmailAddressCollection.Parse("info@qowaiv.org, test@qowaiv.org"));
-            var exp = "info@qowaiv.org,test@qowaiv.org";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region ToString
-
-        [Test]
-        public void ToString_EmptyCollection_StringEmpty()
-        {
-            var collection = new EmailAddressCollection();
-
-            var exp = string.Empty;
-            var act = collection.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_1Item_infoAtQowaivDotOrg()
-        {
-            var collection = new EmailAddressCollection(EmailAddress.Parse("info@qowaiv.org"));
-
-            var exp = "info@qowaiv.org";
-            var act = collection.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_2Items_infoAtQowaivDotOrgCommaTestAtQowaivDotOrg()
-        {
-            var collection = new EmailAddressCollection(EmailAddress.Parse("info@qowaiv.org"), EmailAddress.Parse("test@qowaiv.org"));
-
-            var exp = "info@qowaiv.org,test@qowaiv.org";
-            var act = collection.ToString();
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = GetTestInstance().ToString("U", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: 'INFO@QOWAIV.ORG,TEST@QOWAIV.ORG', format: 'U'";
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_TestStructFormatMailtoF_AreEqual()
-        {
-            var act = GetTestInstance().ToString(@"mai\lto:f");
-            var exp = "mailto:info@qowaiv.org,mailto:test@qowaiv.org";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region Methods
-
-        [Test]
-        public void Add_EmailAddressEmptyToEmptyCollection_DoesNotExtendTheCollection()
-        {
-            var exp = new EmailAddressCollection();
-            var act = new EmailAddressCollection
-            {
-                EmailAddress.Empty
-            };
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Add_EmailAddressUnknownToEmptyCollection_DoesNotExtendTheCollection()
-        {
-            var exp = new EmailAddressCollection();
-            var act = new EmailAddressCollection
-            {
-                EmailAddress.Unknown
-            };
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Add_EmailAddressEmptyToCollection_DoesNotExtendTheCollection()
-        {
-            var exp = GetTestInstance();
-            var act = GetTestInstance();
-            act.Add(EmailAddress.Empty);
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Add_EmailAddressUnknownToCollection_DoesNotExtendTheCollection()
-        {
-            var exp = GetTestInstance();
-            var act = GetTestInstance();
-            act.Add(EmailAddress.Unknown);
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region (Try)parse
-
-        [Test]
-        public void TryParse_TestInstanceWithUnknownAdded_EqualsTestInstance()
-        {
-            var act = EmailAddressCollection.Parse("info@qowaiv.org,test@qowaiv.org,?");
-            var exp = GetTestInstance();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void TryParse_Null_EmptyCollection()
-        {
-            EmailAddressCollection exp = new();
-            Assert.IsTrue(EmailAddressCollection.TryParse(null, out EmailAddressCollection act));
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void TryParse_StringEmpty_EmptyCollection()
-        {
-            EmailAddressCollection exp = new();
-            Assert.IsTrue(EmailAddressCollection.TryParse(string.Empty, out EmailAddressCollection act));
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void TryParse_Invalid_EmptyCollection()
-        {
-            var act = EmailAddressCollection.TryParse("invalid");
-            var exp = new EmailAddressCollection();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void TryParse_SingleEmailAddress_CollectionWithOneItems()
-        {
-            var act = EmailAddressCollection.TryParse("svo@qowaiv.org");
-            var exp = new EmailAddressCollection { EmailAddress.Parse("svo@qowaiv.org") };
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region Extensions
-
-        [Test]
-        public void ToCollection_EnumerartionOfEmailAddresses_EmailAddressCollection()
-        {
-            var collection = EmailAddressCollection.Parse("mail@qowaiv.org,info@qowaiv.org,test@qowaiv.org").AsEnumerable();
-
-            var act = collection.ToCollection();
-            var exp = EmailAddressCollection.Parse("mail@qowaiv.org,info@qowaiv.org,test@qowaiv.org");
-
-            Assert.AreEqual(typeof(EmailAddressCollection), act.GetType(), "The outcome of to collection should be an email address collection.");
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        #endregion
+        Assert.AreEqual("info@qowaiv.org,test@qowaiv.org", info.GetString("Value"));
     }
 
-    [Serializable]
-    public class EmailAddressCollectionSerializeObject
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
     {
-        public int Id { get; set; }
-        public EmailAddressCollection Obj { get; set; }
-        public DateTime Date { get; set; }
+        var input = GetTestInstance();
+        var exp = GetTestInstance();
+        var act = SerializeDeserialize.Binary(input);
+        CollectionAssert.AreEqual(exp, act);
     }
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = GetTestInstance();
+        var exp = GetTestInstance();
+        var act = SerializeDeserialize.DataContract(input);
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(GetTestInstance());
+        var exp = "info@qowaiv.org,test@qowaiv.org";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<EmailAddressCollection>("info@qowaiv.org,test@qowaiv.org");
+        Assert.AreEqual(GetTestInstance(), act);
+    }
+
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_EmailAddressSerializeObject_AreEqual()
+    {
+        var input = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = GetTestInstance(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = GetTestInstance(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_EmailAddressSerializeObject_AreEqual()
+    {
+        var input = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = GetTestInstance(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = GetTestInstance(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_EmailAddressSerializeObject_AreEqual()
+    {
+        var input = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = GetTestInstance(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = GetTestInstance(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = new EmailAddressCollection(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = new EmailAddressCollection(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = new EmailAddressCollection(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new EmailAddressCollectionSerializeObject
+        {
+            Id = 17,
+            Obj = new EmailAddressCollection(),
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = GetTestInstance();
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    #endregion
+
+    #region ToString
+
+    [Test]
+    public void ToString_EmptyCollection_StringEmpty()
+    {
+        var collection = new EmailAddressCollection();
+
+        var exp = string.Empty;
+        var act = collection.ToString();
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_1Item_infoAtQowaivDotOrg()
+    {
+        var collection = new EmailAddressCollection(EmailAddress.Parse("info@qowaiv.org"));
+
+        var exp = "info@qowaiv.org";
+        var act = collection.ToString();
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_2Items_infoAtQowaivDotOrgCommaTestAtQowaivDotOrg()
+    {
+        var collection = new EmailAddressCollection(EmailAddress.Parse("info@qowaiv.org"), EmailAddress.Parse("test@qowaiv.org"));
+
+        var exp = "info@qowaiv.org,test@qowaiv.org";
+        var act = collection.ToString();
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = GetTestInstance().ToString("U", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: 'INFO@QOWAIV.ORG,TEST@QOWAIV.ORG', format: 'U'";
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_TestStructFormatMailtoF_AreEqual()
+    {
+        var act = GetTestInstance().ToString(@"mai\lto:f");
+        var exp = "mailto:info@qowaiv.org,mailto:test@qowaiv.org";
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region Methods
+
+    [Test]
+    public void Add_EmailAddressEmptyToEmptyCollection_DoesNotExtendTheCollection()
+    {
+        var exp = new EmailAddressCollection();
+        var act = new EmailAddressCollection
+        {
+            EmailAddress.Empty
+        };
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Add_EmailAddressUnknownToEmptyCollection_DoesNotExtendTheCollection()
+    {
+        var exp = new EmailAddressCollection();
+        var act = new EmailAddressCollection
+        {
+            EmailAddress.Unknown
+        };
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Add_EmailAddressEmptyToCollection_DoesNotExtendTheCollection()
+    {
+        var exp = GetTestInstance();
+        var act = GetTestInstance();
+        act.Add(EmailAddress.Empty);
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Add_EmailAddressUnknownToCollection_DoesNotExtendTheCollection()
+    {
+        var exp = GetTestInstance();
+        var act = GetTestInstance();
+        act.Add(EmailAddress.Unknown);
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region (Try)parse
+
+    [Test]
+    public void TryParse_TestInstanceWithUnknownAdded_EqualsTestInstance()
+    {
+        var act = EmailAddressCollection.Parse("info@qowaiv.org,test@qowaiv.org,?");
+        var exp = GetTestInstance();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void TryParse_Null_EmptyCollection()
+    {
+        EmailAddressCollection exp = new();
+        Assert.IsTrue(EmailAddressCollection.TryParse(null, out EmailAddressCollection act));
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void TryParse_StringEmpty_EmptyCollection()
+    {
+        EmailAddressCollection exp = new();
+        Assert.IsTrue(EmailAddressCollection.TryParse(string.Empty, out EmailAddressCollection act));
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void TryParse_Invalid_EmptyCollection()
+    {
+        var act = EmailAddressCollection.TryParse("invalid");
+        var exp = new EmailAddressCollection();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void TryParse_SingleEmailAddress_CollectionWithOneItems()
+    {
+        var act = EmailAddressCollection.TryParse("svo@qowaiv.org");
+        var exp = new EmailAddressCollection { EmailAddress.Parse("svo@qowaiv.org") };
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region Extensions
+
+    [Test]
+    public void ToCollection_EnumerartionOfEmailAddresses_EmailAddressCollection()
+    {
+        var collection = EmailAddressCollection.Parse("mail@qowaiv.org,info@qowaiv.org,test@qowaiv.org").AsEnumerable();
+
+        var act = collection.ToCollection();
+        var exp = EmailAddressCollection.Parse("mail@qowaiv.org,info@qowaiv.org,test@qowaiv.org");
+
+        Assert.AreEqual(typeof(EmailAddressCollection), act.GetType(), "The outcome of to collection should be an email address collection.");
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    #endregion
+}
+
+[Serializable]
+public class EmailAddressCollectionSerializeObject
+{
+    public int Id { get; set; }
+    public EmailAddressCollection Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
@@ -269,67 +269,6 @@ namespace Qowaiv.Financial.UnitTests
 
         #endregion
 
-        #region JSON (De)serialization tests
-
-        [Test]
-        public void FromJson_InvalidStringValue_AssertFormatException()
-        {
-            Assert.Catch<FormatException>(() =>
-            {
-                JsonTester.Read<Amount>("InvalidStringValue");
-            },
-            "Not a valid Amount");
-        }
-        [Test]
-        public void FromJson_StringValue_AreEqual()
-        {
-            var act = JsonTester.Read<Amount>("42.17");
-            var exp = TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void FromJson_Int64Value_AreEqual()
-        {
-            Amount act = JsonTester.Read<Amount>((long)TestStruct);
-            Amount exp = (Amount)42;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void FromJson_DoubleValue_AreEqual()
-        {
-            var act = JsonTester.Read<Amount>((double)TestStruct);
-            var exp = TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = 42.17m;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToJson_ConstructedZero()
-        {
-            var pls = (Amount)12.456m;
-            var min = (Amount)(-12.456m);
-            var sum = min + pls;
-            
-            var act = sum.ToJson().ToString(CultureInfo.InvariantCulture);
-            var exp = "0";
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
         #region IFormattable / ToString tests
 
         [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
@@ -1,719 +1,673 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Financial;
-using Qowaiv.Globalization;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests.Financial;
 
-namespace Qowaiv.UnitTests.Financial
+/// <summary>Tests the BIC SVO.</summary>
+public class BusinessIdentifierCodeTest
 {
-    /// <summary>Tests the BIC SVO.</summary>
-    public class BusinessIdentifierCodeTest
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly BusinessIdentifierCode TestStruct = BusinessIdentifierCode.Parse("AEGONL2UXXX");
+
+    #region BIC const tests
+
+    /// <summary>BusinessIdentifierCode.Empty should be equal to the default of BIC.</summary>
+    [Test]
+    public void Empty_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly BusinessIdentifierCode TestStruct = BusinessIdentifierCode.Parse("AEGONL2UXXX");
-
-        #region BIC const tests
-
-        /// <summary>BusinessIdentifierCode.Empty should be equal to the default of BIC.</summary>
-        [Test]
-        public void Empty_None_EqualsDefault()
-        {
-            Assert.AreEqual(default(BusinessIdentifierCode), BusinessIdentifierCode.Empty);
-        }
-
-        #endregion
-
-        #region BIC IsEmpty tests
-
-        /// <summary>BusinessIdentifierCode.IsEmpty() should be true for the default of BIC.</summary>
-        [Test]
-        public void IsEmpty_Default_IsTrue()
-        {
-            Assert.IsTrue(default(BusinessIdentifierCode).IsEmpty());
-        }
-        /// <summary>BusinessIdentifierCode.IsEmpty() should be false for BusinessIdentifierCode.Unknown.</summary>
-        [Test]
-        public void IsEmpty_Unknown_IsFalse()
-        {
-            Assert.IsFalse(BusinessIdentifierCode.Unknown.IsEmpty());
-        }
-        /// <summary>BusinessIdentifierCode.IsEmpty() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsEmpty_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmpty());
-        }
-
-        /// <summary>BusinessIdentifierCode.IsUnknown() should be false for the default of BIC.</summary>
-        [Test]
-        public void IsUnknown_Default_IsFalse()
-        {
-            Assert.IsFalse(default(BusinessIdentifierCode).IsUnknown());
-        }
-        /// <summary>BusinessIdentifierCode.IsUnknown() should be true for BusinessIdentifierCode.Unknown.</summary>
-        [Test]
-        public void IsUnknown_Unknown_IsTrue()
-        {
-            Assert.IsTrue(BusinessIdentifierCode.Unknown.IsUnknown());
-        }
-        /// <summary>BusinessIdentifierCode.IsUnknown() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsUnknown_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsUnknown());
-        }
-
-        /// <summary>BusinessIdentifierCode.IsEmptyOrUnknown() should be true for the default of BIC.</summary>
-        [Test]
-        public void IsEmptyOrUnknown_Default_IsFalse()
-        {
-            Assert.IsTrue(default(BusinessIdentifierCode).IsEmptyOrUnknown());
-        }
-        /// <summary>BusinessIdentifierCode.IsEmptyOrUnknown() should be true for BusinessIdentifierCode.Unknown.</summary>
-        [Test]
-        public void IsEmptyOrUnknown_Unknown_IsTrue()
-        {
-            Assert.IsTrue(BusinessIdentifierCode.Unknown.IsEmptyOrUnknown());
-        }
-        /// <summary>BusinessIdentifierCode.IsEmptyOrUnknown() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsEmptyOrUnknown_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmptyOrUnknown());
-        }
-
-        #endregion
-
-        #region TryParse tests
-
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            string str = null;
-            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            string str = string.Empty;
-            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse "?" should be valid and the result should be BusinessIdentifierCode.Unknown.</summary>
-        [Test]
-        public void TryParse_Questionmark_IsValid()
-        {
-            string str = "?";
-            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
-            Assert.IsTrue(val.IsUnknown(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            string str = "AEGONL2UXXX";
-            Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
-            Assert.AreEqual(str, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
-        {
-            string str = "string";
-            Assert.IsFalse(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        [Test]
-        public void Parse_Unknown_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var act = BusinessIdentifierCode.Parse("?");
-                var exp = BusinessIdentifierCode.Unknown;
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Assert.Catch<FormatException>
-                (() =>
-                {
-                    BusinessIdentifierCode.Parse("InvalidInput");
-                },
-                "Not a valid BIC");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = BusinessIdentifierCode.TryParse(exp.ToString());
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void from_invalid_as_null_with_TryParse()
-           => BusinessIdentifierCode.TryParse("invalid input").Should().BeNull();
-
-        #endregion
-
-        #region (XML) (De)serialization tests
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(BusinessIdentifierCode), new FormatterConverter());
-            obj.GetObjectData(info, default);
-
-            Assert.AreEqual(TestStruct.ToString(), info.GetString("Value"));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "AEGONL2UXXX";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<BusinessIdentifierCode>("AEGONL2UXXX");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
-        {
-            var input = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
-        {
-            var input = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
-        {
-            var input = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = BusinessIdentifierCode.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = BusinessIdentifierCode.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = BusinessIdentifierCode.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new BusinessIdentifierCodeSerializeObject
-            {
-                Id = 17,
-                Obj = BusinessIdentifierCode.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [TestCase("Invalid input")]
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<BusinessIdentifierCode>(json));
-        }
-
-        [Test]
-        public void FromJson_AEGONL2UXXX_EqualsTestStruct()
-        {
-            var actual = JsonTester.Read<BusinessIdentifierCode>("AEGONL2UXXX");
-            Assert.AreEqual(TestStruct, actual);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_IsNull()
-        {
-            object act = JsonTester.Write(default(BusinessIdentifierCode));
-            Assert.IsNull(act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "AEGONL2UXXX";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IFormattable / ToString tests
-
-        [Test]
-        public void ToString_Empty_StringEmpty()
-        {
-            var act = BusinessIdentifierCode.Empty.ToString();
-            var exp = "";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_Unknown_QuestionMark()
-        {
-            var act = BusinessIdentifierCode.Unknown.ToString();
-            var exp = "?";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("Unit Test Format", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: 'AEGONL2UXXX', format: 'Unit Test Format'";
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_TestStruct_ComplexPattern()
-        {
-            var act = TestStruct.ToString("");
-            var exp = "AEGONL2UXXX";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IEquatable tests
-
-        /// <summary>GetHash should not fail for BusinessIdentifierCode.Empty.</summary>
-        [Test]
-        public void GetHash_Empty_Hash()
-        {
-            Assert.AreEqual(0, BusinessIdentifierCode.Empty.GetHashCode());
-        }
-
-        /// <summary>GetHash should not fail for the test struct.</summary>
-        [Test]
-        public void GetHash_TestStruct_NotZero()
-        {
-            Assert.NotZero(TestStruct.GetHashCode());
-        }
-
-        [Test]
-        public void Equals_EmptyEmpty_IsTrue()
-        {
-            Assert.IsTrue(BusinessIdentifierCode.Empty.Equals(BusinessIdentifierCode.Empty));
-        }
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            var l = BusinessIdentifierCode.Parse("AEGONL2UXXX", CultureInfo.InvariantCulture);
-            var r = BusinessIdentifierCode.Parse("AEgonL2Uxxx", CultureInfo.InvariantCulture);
-
-            Assert.IsTrue(l.Equals(r));
-        }
-
-        [Test]
-        public void Equals_TestStructTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructEmpty_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(BusinessIdentifierCode.Empty));
-        }
-
-        [Test]
-        public void Equals_EmptyTestStruct_IsFalse()
-        {
-            Assert.IsFalse(BusinessIdentifierCode.Empty.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructObjectTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals((object)TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructNull_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(null));
-        }
-
-        [Test]
-        public void Equals_TestStructObject_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(new object()));
-        }
-
-        [Test]
-        public void OperatorIs_TestStructTestStruct_IsTrue()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsTrue(l == r);
-        }
-
-        [Test]
-        public void OperatorIsNot_TestStructTestStruct_IsFalse()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsFalse(l != r);
-        }
-
-        #endregion
-
-        #region IComparable tests
-
-        /// <summary>Orders a list of BICs ascending.</summary>
-        [Test]
-        public void OrderBy_BusinessIdentifierCode_AreEqual()
-        {
-            var item0 = BusinessIdentifierCode.Parse("AEGONL2UXXX");
-            var item1 = BusinessIdentifierCode.Parse("CEBUNL2U");
-            var item2 = BusinessIdentifierCode.Parse("DSSBNL22");
-            var item3 = BusinessIdentifierCode.Parse("FTSBNL2R");
-
-            var inp = new List<BusinessIdentifierCode> { BusinessIdentifierCode.Empty, item3, item2, item0, item1, BusinessIdentifierCode.Empty };
-            var exp = new List<BusinessIdentifierCode> { BusinessIdentifierCode.Empty, BusinessIdentifierCode.Empty, item0, item1, item2, item3 };
-            var act = inp.OrderBy(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Orders a list of BICs descending.</summary>
-        [Test]
-        public void OrderByDescending_BusinessIdentifierCode_AreEqual()
-        {
-            var item0 = BusinessIdentifierCode.Parse("AEGONL2UXXX");
-            var item1 = BusinessIdentifierCode.Parse("CEBUNL2U");
-            var item2 = BusinessIdentifierCode.Parse("DSSBNL22");
-            var item3 = BusinessIdentifierCode.Parse("FTSBNL2R");
-
-            var inp = new List<BusinessIdentifierCode> { BusinessIdentifierCode.Empty, item3, item2, item0, item1, BusinessIdentifierCode.Empty };
-            var exp = new List<BusinessIdentifierCode> { item3, item2, item1, item0, BusinessIdentifierCode.Empty, BusinessIdentifierCode.Empty };
-            var act = inp.OrderByDescending(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with a to object casted instance should be fine.</summary>
-        [Test]
-        public void CompareTo_ObjectTestStruct_0()
-        {
-            object other = TestStruct;
-
-            var exp = 0;
-            var act = TestStruct.CompareTo(other);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with null should return 1.</summary>
-        [Test]
-        public void CompareTo_null_1()
-        {
-            object @null = null;
-            Assert.AreEqual(1, TestStruct.CompareTo(@null));
-        }
-
-        /// <summary>Compare with a random object should throw an exception.</summary>
-        [Test]
-        public void CompareTo_newObject_ThrowsArgumentException()
-        {
-            Func<int> compare = () => TestStruct.CompareTo(new object());
-            compare.Should().Throw<ArgumentException>();
-        }
-
-        #endregion
-
-        #region Properties
-
-        [Test]
-        public void Length_DefaultValue_0()
-        {
-            var exp = 0;
-            var act = BusinessIdentifierCode.Empty.Length;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Length_Unknown_0()
-        {
-            var exp = 0;
-            var act = BusinessIdentifierCode.Unknown.Length;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Length_TestStruct_IntValue()
-        {
-            var exp = 11;
-            var act = TestStruct.Length;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void BusinessCode_DefaultValue_StringEmpty()
-        {
-            var exp = "";
-            var act = BusinessIdentifierCode.Empty.Business;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void BusinessCode_Unknown_StringEmpty()
-        {
-            var exp = "";
-            var act = BusinessIdentifierCode.Unknown.Business;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void BusinessCode_TestStruct_AEGO()
-        {
-            var exp = "AEGO";
-            var act = TestStruct.Business;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Country_DefaultValue_CountryEmpty()
-        {
-            var exp = Country.Empty;
-            var act = BusinessIdentifierCode.Empty.Country;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Country_Unknown_CountryUnknown()
-        {
-            var exp = Country.Unknown;
-            var act = BusinessIdentifierCode.Unknown.Country;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Country_TestStruct_NL()
-        {
-            var exp = Country.NL;
-            var act = TestStruct.Country;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void LocationCode_DefaultValue_StringEmpty()
-        {
-            var exp = "";
-            var act = BusinessIdentifierCode.Empty.Location;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void LocationCode_Unknown_StringEmpty()
-        {
-            var exp = "";
-            var act = BusinessIdentifierCode.Unknown.Location;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void LocationCode_TestStruct_NL()
-        {
-            var exp = "2U";
-            var act = TestStruct.Location;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void BranchCode_DefaultValue_StringEmpty()
-        {
-            var exp = "";
-            var act = BusinessIdentifierCode.Empty.Branch;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void BranchCode_Unknown_StringEmpty()
-        {
-            var exp = "";
-            var act = BusinessIdentifierCode.Unknown.Branch;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void BranchCode_TestStruct_NL()
-        {
-            var exp = "XXX";
-            var act = TestStruct.Branch;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void BranchCode_AEGONL2U_StringEmpty()
-        {
-            var exp = "";
-            var act = BusinessIdentifierCode.Parse("AEGONL2U").Branch;
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IsValid
-
-
-        [TestCase(null, "null")]
-        [TestCase("", "string.Empty")]
-        [TestCase("1AAANL01", "digit in first four characters")]
-        [TestCase("AAAANLBB1", "Branch length of 1")]
-        [TestCase("AAAANLBB12", "Branch length of 2")]
-        [TestCase("ABCDXX01", "Not existing country")]
-        public void IsValid_False(string str, string message)
-        {
-            Assert.IsFalse(BusinessIdentifierCode.IsValid(str), "{0}, {1}", str, message);
-        }
-
-        [TestCase("PSTBNL21")]
-        [TestCase("ABNANL2A")]
-        [TestCase("BACBBEBB")]
-        [TestCase("GEBABEBB36A")]
-        [TestCase("DEUTDEFF")]
-        [TestCase("NEDSZAJJ")]
-        [TestCase("DABADKKK")]
-        [TestCase("UNCRIT2B912")]
-        [TestCase("DSBACNBXSHA")]
-        [TestCase("AAAANLBË")]
-        public void IsValid_True(string str)
-        {
-            Assert.IsTrue(BusinessIdentifierCode.IsValid(str), str);
-        }
-
-        #endregion
+        Assert.AreEqual(default(BusinessIdentifierCode), BusinessIdentifierCode.Empty);
     }
 
-    [Serializable]
-    public class BusinessIdentifierCodeSerializeObject
+    #endregion
+
+    #region BIC IsEmpty tests
+
+    /// <summary>BusinessIdentifierCode.IsEmpty() should be true for the default of BIC.</summary>
+    [Test]
+    public void IsEmpty_Default_IsTrue()
     {
-        public int Id { get; set; }
-        public BusinessIdentifierCode Obj { get; set; }
-        public DateTime Date { get; set; }
+        Assert.IsTrue(default(BusinessIdentifierCode).IsEmpty());
     }
+    /// <summary>BusinessIdentifierCode.IsEmpty() should be false for BusinessIdentifierCode.Unknown.</summary>
+    [Test]
+    public void IsEmpty_Unknown_IsFalse()
+    {
+        Assert.IsFalse(BusinessIdentifierCode.Unknown.IsEmpty());
+    }
+    /// <summary>BusinessIdentifierCode.IsEmpty() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsEmpty_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmpty());
+    }
+
+    /// <summary>BusinessIdentifierCode.IsUnknown() should be false for the default of BIC.</summary>
+    [Test]
+    public void IsUnknown_Default_IsFalse()
+    {
+        Assert.IsFalse(default(BusinessIdentifierCode).IsUnknown());
+    }
+    /// <summary>BusinessIdentifierCode.IsUnknown() should be true for BusinessIdentifierCode.Unknown.</summary>
+    [Test]
+    public void IsUnknown_Unknown_IsTrue()
+    {
+        Assert.IsTrue(BusinessIdentifierCode.Unknown.IsUnknown());
+    }
+    /// <summary>BusinessIdentifierCode.IsUnknown() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsUnknown_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsUnknown());
+    }
+
+    /// <summary>BusinessIdentifierCode.IsEmptyOrUnknown() should be true for the default of BIC.</summary>
+    [Test]
+    public void IsEmptyOrUnknown_Default_IsFalse()
+    {
+        Assert.IsTrue(default(BusinessIdentifierCode).IsEmptyOrUnknown());
+    }
+    /// <summary>BusinessIdentifierCode.IsEmptyOrUnknown() should be true for BusinessIdentifierCode.Unknown.</summary>
+    [Test]
+    public void IsEmptyOrUnknown_Unknown_IsTrue()
+    {
+        Assert.IsTrue(BusinessIdentifierCode.Unknown.IsEmptyOrUnknown());
+    }
+    /// <summary>BusinessIdentifierCode.IsEmptyOrUnknown() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsEmptyOrUnknown_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmptyOrUnknown());
+    }
+
+    #endregion
+
+    #region TryParse tests
+
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
+    {
+        string str = null;
+        Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
+    {
+        string str = string.Empty;
+        Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse "?" should be valid and the result should be BusinessIdentifierCode.Unknown.</summary>
+    [Test]
+    public void TryParse_Questionmark_IsValid()
+    {
+        string str = "?";
+        Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
+        Assert.IsTrue(val.IsUnknown(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "AEGONL2UXXX";
+        Assert.IsTrue(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
+        Assert.AreEqual(str, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "string";
+        Assert.IsFalse(BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    [Test]
+    public void Parse_Unknown_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var act = BusinessIdentifierCode.Parse("?");
+            var exp = BusinessIdentifierCode.Unknown;
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Assert.Catch<FormatException>
+            (() =>
+            {
+                BusinessIdentifierCode.Parse("InvalidInput");
+            },
+            "Not a valid BIC");
+        }
+    }
+
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = BusinessIdentifierCode.TryParse(exp.ToString());
+
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void from_invalid_as_null_with_TryParse()
+       => BusinessIdentifierCode.TryParse("invalid input").Should().BeNull();
+
+    #endregion
+
+    #region (XML) (De)serialization tests
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(BusinessIdentifierCode), new FormatterConverter());
+        obj.GetObjectData(info, default);
+
+        Assert.AreEqual(TestStruct.ToString(), info.GetString("Value"));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "AEGONL2UXXX";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<BusinessIdentifierCode>("AEGONL2UXXX");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
+    {
+        var input = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
+    {
+        var input = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
+    {
+        var input = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = BusinessIdentifierCode.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = BusinessIdentifierCode.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = BusinessIdentifierCode.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new BusinessIdentifierCodeSerializeObject
+        {
+            Id = 17,
+            Obj = BusinessIdentifierCode.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    #endregion
+
+    #region IFormattable / ToString tests
+
+    [Test]
+    public void ToString_Empty_StringEmpty()
+    {
+        var act = BusinessIdentifierCode.Empty.ToString();
+        var exp = "";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_Unknown_QuestionMark()
+    {
+        var act = BusinessIdentifierCode.Unknown.ToString();
+        var exp = "?";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("Unit Test Format", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: 'AEGONL2UXXX', format: 'Unit Test Format'";
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_TestStruct_ComplexPattern()
+    {
+        var act = TestStruct.ToString("");
+        var exp = "AEGONL2UXXX";
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IEquatable tests
+
+    /// <summary>GetHash should not fail for BusinessIdentifierCode.Empty.</summary>
+    [Test]
+    public void GetHash_Empty_Hash()
+    {
+        Assert.AreEqual(0, BusinessIdentifierCode.Empty.GetHashCode());
+    }
+
+    /// <summary>GetHash should not fail for the test struct.</summary>
+    [Test]
+    public void GetHash_TestStruct_NotZero()
+    {
+        Assert.NotZero(TestStruct.GetHashCode());
+    }
+
+    [Test]
+    public void Equals_EmptyEmpty_IsTrue()
+    {
+        Assert.IsTrue(BusinessIdentifierCode.Empty.Equals(BusinessIdentifierCode.Empty));
+    }
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        var l = BusinessIdentifierCode.Parse("AEGONL2UXXX", CultureInfo.InvariantCulture);
+        var r = BusinessIdentifierCode.Parse("AEgonL2Uxxx", CultureInfo.InvariantCulture);
+
+        Assert.IsTrue(l.Equals(r));
+    }
+
+    [Test]
+    public void Equals_TestStructTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructEmpty_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(BusinessIdentifierCode.Empty));
+    }
+
+    [Test]
+    public void Equals_EmptyTestStruct_IsFalse()
+    {
+        Assert.IsFalse(BusinessIdentifierCode.Empty.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructObjectTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals((object)TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructNull_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(null));
+    }
+
+    [Test]
+    public void Equals_TestStructObject_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(new object()));
+    }
+
+    [Test]
+    public void OperatorIs_TestStructTestStruct_IsTrue()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsTrue(l == r);
+    }
+
+    [Test]
+    public void OperatorIsNot_TestStructTestStruct_IsFalse()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsFalse(l != r);
+    }
+
+    #endregion
+
+    #region IComparable tests
+
+    /// <summary>Orders a list of BICs ascending.</summary>
+    [Test]
+    public void OrderBy_BusinessIdentifierCode_AreEqual()
+    {
+        var item0 = BusinessIdentifierCode.Parse("AEGONL2UXXX");
+        var item1 = BusinessIdentifierCode.Parse("CEBUNL2U");
+        var item2 = BusinessIdentifierCode.Parse("DSSBNL22");
+        var item3 = BusinessIdentifierCode.Parse("FTSBNL2R");
+
+        var inp = new List<BusinessIdentifierCode> { BusinessIdentifierCode.Empty, item3, item2, item0, item1, BusinessIdentifierCode.Empty };
+        var exp = new List<BusinessIdentifierCode> { BusinessIdentifierCode.Empty, BusinessIdentifierCode.Empty, item0, item1, item2, item3 };
+        var act = inp.OrderBy(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Orders a list of BICs descending.</summary>
+    [Test]
+    public void OrderByDescending_BusinessIdentifierCode_AreEqual()
+    {
+        var item0 = BusinessIdentifierCode.Parse("AEGONL2UXXX");
+        var item1 = BusinessIdentifierCode.Parse("CEBUNL2U");
+        var item2 = BusinessIdentifierCode.Parse("DSSBNL22");
+        var item3 = BusinessIdentifierCode.Parse("FTSBNL2R");
+
+        var inp = new List<BusinessIdentifierCode> { BusinessIdentifierCode.Empty, item3, item2, item0, item1, BusinessIdentifierCode.Empty };
+        var exp = new List<BusinessIdentifierCode> { item3, item2, item1, item0, BusinessIdentifierCode.Empty, BusinessIdentifierCode.Empty };
+        var act = inp.OrderByDescending(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with a to object casted instance should be fine.</summary>
+    [Test]
+    public void CompareTo_ObjectTestStruct_0()
+    {
+        object other = TestStruct;
+
+        var exp = 0;
+        var act = TestStruct.CompareTo(other);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with null should return 1.</summary>
+    [Test]
+    public void CompareTo_null_1()
+    {
+        object @null = null;
+        Assert.AreEqual(1, TestStruct.CompareTo(@null));
+    }
+
+    /// <summary>Compare with a random object should throw an exception.</summary>
+    [Test]
+    public void CompareTo_newObject_ThrowsArgumentException()
+    {
+        Func<int> compare = () => TestStruct.CompareTo(new object());
+        compare.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
+    #region Properties
+
+    [Test]
+    public void Length_DefaultValue_0()
+    {
+        var exp = 0;
+        var act = BusinessIdentifierCode.Empty.Length;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Length_Unknown_0()
+    {
+        var exp = 0;
+        var act = BusinessIdentifierCode.Unknown.Length;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Length_TestStruct_IntValue()
+    {
+        var exp = 11;
+        var act = TestStruct.Length;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void BusinessCode_DefaultValue_StringEmpty()
+    {
+        var exp = "";
+        var act = BusinessIdentifierCode.Empty.Business;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void BusinessCode_Unknown_StringEmpty()
+    {
+        var exp = "";
+        var act = BusinessIdentifierCode.Unknown.Business;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void BusinessCode_TestStruct_AEGO()
+    {
+        var exp = "AEGO";
+        var act = TestStruct.Business;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Country_DefaultValue_CountryEmpty()
+    {
+        var exp = Country.Empty;
+        var act = BusinessIdentifierCode.Empty.Country;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Country_Unknown_CountryUnknown()
+    {
+        var exp = Country.Unknown;
+        var act = BusinessIdentifierCode.Unknown.Country;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Country_TestStruct_NL()
+    {
+        var exp = Country.NL;
+        var act = TestStruct.Country;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void LocationCode_DefaultValue_StringEmpty()
+    {
+        var exp = "";
+        var act = BusinessIdentifierCode.Empty.Location;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void LocationCode_Unknown_StringEmpty()
+    {
+        var exp = "";
+        var act = BusinessIdentifierCode.Unknown.Location;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void LocationCode_TestStruct_NL()
+    {
+        var exp = "2U";
+        var act = TestStruct.Location;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void BranchCode_DefaultValue_StringEmpty()
+    {
+        var exp = "";
+        var act = BusinessIdentifierCode.Empty.Branch;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void BranchCode_Unknown_StringEmpty()
+    {
+        var exp = "";
+        var act = BusinessIdentifierCode.Unknown.Branch;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void BranchCode_TestStruct_NL()
+    {
+        var exp = "XXX";
+        var act = TestStruct.Branch;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void BranchCode_AEGONL2U_StringEmpty()
+    {
+        var exp = "";
+        var act = BusinessIdentifierCode.Parse("AEGONL2U").Branch;
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IsValid
+
+
+    [TestCase(null, "null")]
+    [TestCase("", "string.Empty")]
+    [TestCase("1AAANL01", "digit in first four characters")]
+    [TestCase("AAAANLBB1", "Branch length of 1")]
+    [TestCase("AAAANLBB12", "Branch length of 2")]
+    [TestCase("ABCDXX01", "Not existing country")]
+    public void IsValid_False(string str, string message)
+    {
+        Assert.IsFalse(BusinessIdentifierCode.IsValid(str), "{0}, {1}", str, message);
+    }
+
+    [TestCase("PSTBNL21")]
+    [TestCase("ABNANL2A")]
+    [TestCase("BACBBEBB")]
+    [TestCase("GEBABEBB36A")]
+    [TestCase("DEUTDEFF")]
+    [TestCase("NEDSZAJJ")]
+    [TestCase("DABADKKK")]
+    [TestCase("UNCRIT2B912")]
+    [TestCase("DSBACNBXSHA")]
+    [TestCase("AAAANLBË")]
+    public void IsValid_True(string str)
+    {
+        Assert.IsTrue(BusinessIdentifierCode.IsValid(str), str);
+    }
+
+    #endregion
+}
+
+[Serializable]
+public class BusinessIdentifierCodeSerializeObject
+{
+    public int Id { get; set; }
+    public BusinessIdentifierCode Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
@@ -383,39 +383,6 @@ public class CurrencyTest
 
     #endregion
 
-    #region JSON (De)serialization tests
-
-    [TestCase("Invalid input")]
-    [TestCase("2017-06-11")]
-    [TestCase(long.MinValue)]
-    public void FromJson_Invalid_Throws(object json)
-    {
-        Assert.Catch<FormatException>(() => JsonTester.Read<Currency>(json));
-    }
-
-    [Test]
-    public void FromJson_EUR_EqualsTestStruct()
-    {
-        var actual = JsonTester.Read<Currency>("EUR");
-        Assert.AreEqual(TestStruct, actual);
-    }
-
-    [Test]
-    public void ToJson_DefaultValue_IsNull()
-    {
-        object act = JsonTester.Write(default(Currency));
-        Assert.IsNull(act);
-    }
-    [Test]
-    public void ToJson_TestStruct_AreEqual()
-    {
-        var act = JsonTester.Write(TestStruct);
-        var exp = "EUR";
-        Assert.AreEqual(exp, act);
-    }
-
-    #endregion
-
     #region IFormattable / ToString tests
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
@@ -1,595 +1,549 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Financial;
-using Qowaiv.Globalization;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests.Financial;
 
-namespace Qowaiv.UnitTests.Financial
+public class InternationalBankAccountNumberTest
 {
-    [TestFixture]
-    public class InternationalBankAccountNumberTest
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly InternationalBankAccountNumber TestStruct = InternationalBankAccountNumber.Parse("NL20 INGB 0001 2345 67");
+
+    #region IBAN const tests
+
+    /// <summary>InternationalBankAccountNumber.Empty should be equal to the default of IBAN.</summary>
+    [Test]
+    public void Empty_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly InternationalBankAccountNumber TestStruct = InternationalBankAccountNumber.Parse("NL20 INGB 0001 2345 67");
-
-        #region IBAN const tests
-
-        /// <summary>InternationalBankAccountNumber.Empty should be equal to the default of IBAN.</summary>
-        [Test]
-        public void Empty_None_EqualsDefault()
-        {
-            Assert.AreEqual(default(InternationalBankAccountNumber), InternationalBankAccountNumber.Empty);
-        }
-
-        #endregion
-
-        #region IBAN IsEmpty tests
-
-        /// <summary>InternationalBankAccountNumber.IsEmpty() should true for the default of IBAN.</summary>
-        [Test]
-        public void IsEmpty_Default_IsTrue()
-        {
-            Assert.IsTrue(default(InternationalBankAccountNumber).IsEmpty());
-        }
-
-        /// <summary>InternationalBankAccountNumber.IsEmpty() should false for the TestStruct.</summary>
-        [Test]
-        public void IsEmpty_Default_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmpty());
-        }
-
-        #endregion
-
-        #region TryParse tests
-
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            string str = null;
-            Assert.IsTrue(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            string str = string.Empty;
-            Assert.IsTrue(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            string str = "NL20INGB0001234567";
-            Assert.IsTrue(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
-            Assert.AreEqual(str, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_QuestionMark_IsValid()
-        {
-            string str = "?";
-            Assert.IsTrue(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
-            Assert.AreEqual(str, val.ToString(), "Value.ToString()");
-            Assert.AreEqual(InternationalBankAccountNumber.Unknown, val, "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
-        {
-            string str = "string";
-            Assert.IsFalse(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Assert.Catch<FormatException>
-                (() =>
-                {
-                    InternationalBankAccountNumber.Parse("InvalidInput");
-                },
-                "Not a valid IBAN");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = InternationalBankAccountNumber.TryParse(exp.ToString());
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void from_invalid_as_null_with_TryParse()
-            => InternationalBankAccountNumber.TryParse("invalid input").Should().BeNull();
-
-        #endregion
-
-        #region (XML) (De)serialization tests
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = InternationalBankAccountNumberTest.TestStruct;
-            var exp = InternationalBankAccountNumberTest.TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = InternationalBankAccountNumberTest.TestStruct;
-            var exp = InternationalBankAccountNumberTest.TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "NL20INGB0001234567";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<InternationalBankAccountNumber>("NL20INGB0001234567");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()
-        {
-            var input = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumberTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumberTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()
-        {
-            var input = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumberTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumberTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()
-        {
-            var input = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumberTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumberTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumber.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumber.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumber.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new InternationalBankAccountNumberSerializeObject
-            {
-                Id = 17,
-                Obj = InternationalBankAccountNumber.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [TestCase("Invalid input")]
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<InternationalBankAccountNumber>(json));
-        }
-    
-        [Test]
-        public void FromJson_NL20INGB0001234567_EqualsTestStruct()
-        {
-            var actual = JsonTester.Read<InternationalBankAccountNumber>("NL20INGB0001234567");
-            Assert.AreEqual(TestStruct, actual);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_IsNull()
-        {
-            object act = JsonTester.Write(default(InternationalBankAccountNumber));
-            Assert.IsNull(act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "NL20INGB0001234567";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IFormattable / ToString tests
-
-        [Test]
-        public void ToString_Empty_IsStringEmpty()
-        {
-            var act = InternationalBankAccountNumber.Empty.ToString();
-            var exp = "";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("[f]", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: '[nl20 ingb 0001 2345 67]', format: '[f]'";
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_Unknown_IsStringEmpty()
-        {
-            var act = InternationalBankAccountNumber.Unknown.ToString("", null);
-            var exp = "?";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_TestStruct_AreEqual()
-        {
-            var act = TestStruct.ToString();
-            var exp = "NL20INGB0001234567";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_TestStructFormatULower_AreEqual()
-        {
-            var act = TestStruct.ToString("u");
-            var exp = "nl20ingb0001234567";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_TestStructFormatUUpper_AreEqual()
-        {
-            var act = TestStruct.ToString("U");
-            var exp = "NL20INGB0001234567";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_TestStructFormatFLower_AreEqual()
-        {
-            var act = TestStruct.ToString("f");
-            var exp = "nl20 ingb 0001 2345 67";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_TestStructFormatFUpper_AreEqual()
-        {
-            var act = TestStruct.ToString("F");
-            var exp = "NL20 INGB 0001 2345 67";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_EmptyFormatF_AreEqual()
-        {
-            var act = InternationalBankAccountNumber.Empty.ToString("F");
-            var exp = "";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_UnknownFormatF_AreEqual()
-        {
-            var act = InternationalBankAccountNumber.Unknown.ToString("F");
-            var exp = "?";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IEquatable tests
-
-        /// <summary>GetHash should not fail for InternationalBankAccountNumber.Empty.</summary>
-        [Test]
-        public void GetHash_Empty_Hash()
-        {
-            Assert.AreEqual(0, InternationalBankAccountNumber.Empty.GetHashCode());
-        }
-
-        /// <summary>GetHash should not fail for the test struct.</summary>
-        [Test]
-        public void GetHash_TestStruct_NotZero()
-        {
-            Assert.NotZero(TestStruct.GetHashCode());
-        }
-
-        [Test]
-        public void Equals_EmptyEmpty_IsTrue()
-        {
-            Assert.IsTrue(InternationalBankAccountNumber.Empty.Equals(InternationalBankAccountNumber.Empty));
-        }
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            var l = InternationalBankAccountNumber.Parse("NL20 INGB 0001 2345 67");
-            var r = InternationalBankAccountNumber.Parse("nl20ingb0001234567");
-
-            Assert.IsTrue(l.Equals(r));
-        }
-
-        [Test]
-        public void Equals_TestStructTestStruct_IsTrue()
-        {
-            Assert.IsTrue(InternationalBankAccountNumberTest.TestStruct.Equals(InternationalBankAccountNumberTest.TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructEmpty_IsFalse()
-        {
-            Assert.IsFalse(InternationalBankAccountNumberTest.TestStruct.Equals(InternationalBankAccountNumber.Empty));
-        }
-
-        [Test]
-        public void Equals_EmptyTestStruct_IsFalse()
-        {
-            Assert.IsFalse(InternationalBankAccountNumber.Empty.Equals(InternationalBankAccountNumberTest.TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructObjectTestStruct_IsTrue()
-        {
-            Assert.IsTrue(InternationalBankAccountNumberTest.TestStruct.Equals((object)InternationalBankAccountNumberTest.TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructNull_IsFalse()
-        {
-            Assert.IsFalse(InternationalBankAccountNumberTest.TestStruct.Equals(null));
-        }
-
-        [Test]
-        public void Equals_TestStructObject_IsFalse()
-        {
-            Assert.IsFalse(InternationalBankAccountNumberTest.TestStruct.Equals(new object()));
-        }
-
-        [Test]
-        public void OperatorIs_TestStructTestStruct_IsTrue()
-        {
-            var l = InternationalBankAccountNumberTest.TestStruct;
-            var r = InternationalBankAccountNumberTest.TestStruct;
-            Assert.IsTrue(l == r);
-        }
-
-        [Test]
-        public void OperatorIsNot_TestStructTestStruct_IsFalse()
-        {
-            var l = InternationalBankAccountNumberTest.TestStruct;
-            var r = InternationalBankAccountNumberTest.TestStruct;
-            Assert.IsFalse(l != r);
-        }
-
-        #endregion
-
-        #region IComparable tests
-
-        /// <summary>Orders a list of IBANs ascending.</summary>
-        [Test]
-        public void OrderBy_InternationalBankAccountNumber_AreEqual()
-        {
-            var item0 = InternationalBankAccountNumber.Parse("AE950210000000693123456");
-            var item1 = InternationalBankAccountNumber.Parse("BH29BMAG1299123456BH00");
-            var item2 = InternationalBankAccountNumber.Parse("CY17002001280000001200527600");
-            var item3 = InternationalBankAccountNumber.Parse("DK5000400440116243");
-
-            var inp = new List<InternationalBankAccountNumber> { InternationalBankAccountNumber.Empty, item3, item2, item0, item1, InternationalBankAccountNumber.Empty };
-            var exp = new List<InternationalBankAccountNumber> { InternationalBankAccountNumber.Empty, InternationalBankAccountNumber.Empty, item0, item1, item2, item3 };
-            var act = inp.OrderBy(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Orders a list of IBANs descending.</summary>
-        [Test]
-        public void OrderByDescending_InternationalBankAccountNumber_AreEqual()
-        {
-            var item0 = InternationalBankAccountNumber.Parse("AE950210000000693123456");
-            var item1 = InternationalBankAccountNumber.Parse("BH29BMAG1299123456BH00");
-            var item2 = InternationalBankAccountNumber.Parse("CY17002001280000001200527600");
-            var item3 = InternationalBankAccountNumber.Parse("DK5000400440116243");
-
-            var inp = new List<InternationalBankAccountNumber> { InternationalBankAccountNumber.Empty, item3, item2, item0, item1, InternationalBankAccountNumber.Empty };
-            var exp = new List<InternationalBankAccountNumber> { item3, item2, item1, item0, InternationalBankAccountNumber.Empty, InternationalBankAccountNumber.Empty };
-            var act = inp.OrderByDescending(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with a to object casted instance should be fine.</summary>
-        [Test]
-        public void CompareTo_ObjectTestStruct_0()
-        {
-            object other = TestStruct;
-
-            var exp = 0;
-            var act = TestStruct.CompareTo(other);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with null should return 1.</summary>
-        [Test]
-        public void CompareTo_null_1()
-        {
-            object @null = null;
-            Assert.AreEqual(1, TestStruct.CompareTo(@null));
-        }
-
-        /// <summary>Compare with a random object should throw an exception.</summary>
-        [Test]
-        public void CompareTo_newObject_ThrowsArgumentException()
-        {
-            Func<int> compare = () => TestStruct.CompareTo(new object());
-            compare.Should().Throw<ArgumentException>();
-        }
-        #endregion
-
-        #region Properties
-
-        [Test]
-        public void Length_DefaultValue_0()
-        {
-            var exp = 0;
-            var act = InternationalBankAccountNumber.Empty.Length;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Length_Unknown_0()
-        {
-            var exp = 0;
-            var act = InternationalBankAccountNumber.Unknown.Length;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Length_TestStruct_IntValue()
-        {
-            var exp = 18;
-            var act = TestStruct.Length;
-            Assert.AreEqual(exp, act);
-        }
-
-
-        [Test]
-        public void Country_Empty_Null()
-        {
-            var exp = Country.Empty;
-            var act = InternationalBankAccountNumber.Empty.Country;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Country_Unknown_Null()
-        {
-            var exp = Country.Unknown;
-            var act = InternationalBankAccountNumber.Unknown.Country;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Country_TestStruct_Null()
-        {
-            var exp = Country.NL;
-            var act = TestStruct.Country;
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
+        Assert.AreEqual(default(InternationalBankAccountNumber), InternationalBankAccountNumber.Empty);
     }
 
-    [Serializable]
-    public class InternationalBankAccountNumberSerializeObject
+    #endregion
+
+    #region IBAN IsEmpty tests
+
+    /// <summary>InternationalBankAccountNumber.IsEmpty() should true for the default of IBAN.</summary>
+    [Test]
+    public void IsEmpty_Default_IsTrue()
     {
-        public int Id { get; set; }
-        public InternationalBankAccountNumber Obj { get; set; }
-        public DateTime Date { get; set; }
+        Assert.IsTrue(default(InternationalBankAccountNumber).IsEmpty());
     }
+
+    /// <summary>InternationalBankAccountNumber.IsEmpty() should false for the TestStruct.</summary>
+    [Test]
+    public void IsEmpty_Default_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmpty());
+    }
+
+    #endregion
+
+    #region TryParse tests
+
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
+    {
+        string str = null;
+        Assert.IsTrue(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
+    {
+        string str = string.Empty;
+        Assert.IsTrue(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "NL20INGB0001234567";
+        Assert.IsTrue(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
+        Assert.AreEqual(str, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_QuestionMark_IsValid()
+    {
+        string str = "?";
+        Assert.IsTrue(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
+        Assert.AreEqual(str, val.ToString(), "Value.ToString()");
+        Assert.AreEqual(InternationalBankAccountNumber.Unknown, val, "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "string";
+        Assert.IsFalse(InternationalBankAccountNumber.TryParse(str, out var val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Assert.Catch<FormatException>
+            (() =>
+            {
+                InternationalBankAccountNumber.Parse("InvalidInput");
+            },
+            "Not a valid IBAN");
+        }
+    }
+
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = InternationalBankAccountNumber.TryParse(exp.ToString());
+
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void from_invalid_as_null_with_TryParse()
+        => InternationalBankAccountNumber.TryParse("invalid input").Should().BeNull();
+
+    #endregion
+
+    #region (XML) (De)serialization tests
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = InternationalBankAccountNumberTest.TestStruct;
+        var exp = InternationalBankAccountNumberTest.TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = InternationalBankAccountNumberTest.TestStruct;
+        var exp = InternationalBankAccountNumberTest.TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "NL20INGB0001234567";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<InternationalBankAccountNumber>("NL20INGB0001234567");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()
+    {
+        var input = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumberTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumberTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()
+    {
+        var input = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumberTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumberTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()
+    {
+        var input = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumberTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumberTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumber.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumber.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumber.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new InternationalBankAccountNumberSerializeObject
+        {
+            Id = 17,
+            Obj = InternationalBankAccountNumber.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    #endregion
+
+    #region IFormattable / ToString tests
+
+    [Test]
+    public void ToString_Empty_IsStringEmpty()
+    {
+        var act = InternationalBankAccountNumber.Empty.ToString();
+        var exp = "";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("[f]", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: '[nl20 ingb 0001 2345 67]', format: '[f]'";
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_Unknown_IsStringEmpty()
+    {
+        var act = InternationalBankAccountNumber.Unknown.ToString("", null);
+        var exp = "?";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_TestStruct_AreEqual()
+    {
+        var act = TestStruct.ToString();
+        var exp = "NL20INGB0001234567";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_TestStructFormatULower_AreEqual()
+    {
+        var act = TestStruct.ToString("u");
+        var exp = "nl20ingb0001234567";
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_TestStructFormatUUpper_AreEqual()
+    {
+        var act = TestStruct.ToString("U");
+        var exp = "NL20INGB0001234567";
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_TestStructFormatFLower_AreEqual()
+    {
+        var act = TestStruct.ToString("f");
+        var exp = "nl20 ingb 0001 2345 67";
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_TestStructFormatFUpper_AreEqual()
+    {
+        var act = TestStruct.ToString("F");
+        var exp = "NL20 INGB 0001 2345 67";
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_EmptyFormatF_AreEqual()
+    {
+        var act = InternationalBankAccountNumber.Empty.ToString("F");
+        var exp = "";
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_UnknownFormatF_AreEqual()
+    {
+        var act = InternationalBankAccountNumber.Unknown.ToString("F");
+        var exp = "?";
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IEquatable tests
+
+    /// <summary>GetHash should not fail for InternationalBankAccountNumber.Empty.</summary>
+    [Test]
+    public void GetHash_Empty_Hash()
+    {
+        Assert.AreEqual(0, InternationalBankAccountNumber.Empty.GetHashCode());
+    }
+
+    /// <summary>GetHash should not fail for the test struct.</summary>
+    [Test]
+    public void GetHash_TestStruct_NotZero()
+    {
+        Assert.NotZero(TestStruct.GetHashCode());
+    }
+
+    [Test]
+    public void Equals_EmptyEmpty_IsTrue()
+    {
+        Assert.IsTrue(InternationalBankAccountNumber.Empty.Equals(InternationalBankAccountNumber.Empty));
+    }
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        var l = InternationalBankAccountNumber.Parse("NL20 INGB 0001 2345 67");
+        var r = InternationalBankAccountNumber.Parse("nl20ingb0001234567");
+
+        Assert.IsTrue(l.Equals(r));
+    }
+
+    [Test]
+    public void Equals_TestStructTestStruct_IsTrue()
+    {
+        Assert.IsTrue(InternationalBankAccountNumberTest.TestStruct.Equals(InternationalBankAccountNumberTest.TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructEmpty_IsFalse()
+    {
+        Assert.IsFalse(InternationalBankAccountNumberTest.TestStruct.Equals(InternationalBankAccountNumber.Empty));
+    }
+
+    [Test]
+    public void Equals_EmptyTestStruct_IsFalse()
+    {
+        Assert.IsFalse(InternationalBankAccountNumber.Empty.Equals(InternationalBankAccountNumberTest.TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructObjectTestStruct_IsTrue()
+    {
+        Assert.IsTrue(InternationalBankAccountNumberTest.TestStruct.Equals((object)InternationalBankAccountNumberTest.TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructNull_IsFalse()
+    {
+        Assert.IsFalse(InternationalBankAccountNumberTest.TestStruct.Equals(null));
+    }
+
+    [Test]
+    public void Equals_TestStructObject_IsFalse()
+    {
+        Assert.IsFalse(InternationalBankAccountNumberTest.TestStruct.Equals(new object()));
+    }
+
+    [Test]
+    public void OperatorIs_TestStructTestStruct_IsTrue()
+    {
+        var l = InternationalBankAccountNumberTest.TestStruct;
+        var r = InternationalBankAccountNumberTest.TestStruct;
+        Assert.IsTrue(l == r);
+    }
+
+    [Test]
+    public void OperatorIsNot_TestStructTestStruct_IsFalse()
+    {
+        var l = InternationalBankAccountNumberTest.TestStruct;
+        var r = InternationalBankAccountNumberTest.TestStruct;
+        Assert.IsFalse(l != r);
+    }
+
+    #endregion
+
+    #region IComparable tests
+
+    /// <summary>Orders a list of IBANs ascending.</summary>
+    [Test]
+    public void OrderBy_InternationalBankAccountNumber_AreEqual()
+    {
+        var item0 = InternationalBankAccountNumber.Parse("AE950210000000693123456");
+        var item1 = InternationalBankAccountNumber.Parse("BH29BMAG1299123456BH00");
+        var item2 = InternationalBankAccountNumber.Parse("CY17002001280000001200527600");
+        var item3 = InternationalBankAccountNumber.Parse("DK5000400440116243");
+
+        var inp = new List<InternationalBankAccountNumber> { InternationalBankAccountNumber.Empty, item3, item2, item0, item1, InternationalBankAccountNumber.Empty };
+        var exp = new List<InternationalBankAccountNumber> { InternationalBankAccountNumber.Empty, InternationalBankAccountNumber.Empty, item0, item1, item2, item3 };
+        var act = inp.OrderBy(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Orders a list of IBANs descending.</summary>
+    [Test]
+    public void OrderByDescending_InternationalBankAccountNumber_AreEqual()
+    {
+        var item0 = InternationalBankAccountNumber.Parse("AE950210000000693123456");
+        var item1 = InternationalBankAccountNumber.Parse("BH29BMAG1299123456BH00");
+        var item2 = InternationalBankAccountNumber.Parse("CY17002001280000001200527600");
+        var item3 = InternationalBankAccountNumber.Parse("DK5000400440116243");
+
+        var inp = new List<InternationalBankAccountNumber> { InternationalBankAccountNumber.Empty, item3, item2, item0, item1, InternationalBankAccountNumber.Empty };
+        var exp = new List<InternationalBankAccountNumber> { item3, item2, item1, item0, InternationalBankAccountNumber.Empty, InternationalBankAccountNumber.Empty };
+        var act = inp.OrderByDescending(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with a to object casted instance should be fine.</summary>
+    [Test]
+    public void CompareTo_ObjectTestStruct_0()
+    {
+        object other = TestStruct;
+
+        var exp = 0;
+        var act = TestStruct.CompareTo(other);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with null should return 1.</summary>
+    [Test]
+    public void CompareTo_null_1()
+    {
+        object @null = null;
+        Assert.AreEqual(1, TestStruct.CompareTo(@null));
+    }
+
+    /// <summary>Compare with a random object should throw an exception.</summary>
+    [Test]
+    public void CompareTo_newObject_ThrowsArgumentException()
+    {
+        Func<int> compare = () => TestStruct.CompareTo(new object());
+        compare.Should().Throw<ArgumentException>();
+    }
+    #endregion
+
+    #region Properties
+
+    [Test]
+    public void Length_DefaultValue_0()
+    {
+        var exp = 0;
+        var act = InternationalBankAccountNumber.Empty.Length;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Length_Unknown_0()
+    {
+        var exp = 0;
+        var act = InternationalBankAccountNumber.Unknown.Length;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Length_TestStruct_IntValue()
+    {
+        var exp = 18;
+        var act = TestStruct.Length;
+        Assert.AreEqual(exp, act);
+    }
+
+
+    [Test]
+    public void Country_Empty_Null()
+    {
+        var exp = Country.Empty;
+        var act = InternationalBankAccountNumber.Empty.Country;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Country_Unknown_Null()
+    {
+        var exp = Country.Unknown;
+        var act = InternationalBankAccountNumber.Unknown.Country;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Country_TestStruct_Null()
+    {
+        var exp = Country.NL;
+        var act = TestStruct.Country;
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+}
+
+[Serializable]
+public class InternationalBankAccountNumberSerializeObject
+{
+    public int Id { get; set; }
+    public InternationalBankAccountNumber Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
@@ -1,963 +1,919 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Financial;
-using Qowaiv.Globalization;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests.Financial;
 
-namespace Qowaiv.UnitTests.Financial
+/// <summary>Tests the Money SVO.</summary>
+[TestFixture]
+public class MoneyTest
 {
-    /// <summary>Tests the Money SVO.</summary>
-    [TestFixture]
-    public class MoneyTest
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly Money TestStruct = 42.17 + Currency.EUR;
+
+    #region Money const tests
+
+    /// <summary>Money.Empty should be equal to the default of Money.</summary>
+    [Test]
+    public void Zero_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly Money TestStruct = 42.17 + Currency.EUR;
-
-        #region Money const tests
-
-        /// <summary>Money.Empty should be equal to the default of Money.</summary>
-        [Test]
-        public void Zero_None_EqualsDefault()
-        {
-            Assert.AreEqual(default(Money), Money.Zero);
-        }
-
-        #endregion
-
-        #region TryParse tests
-
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            using (TestCultures.Nl_NL.Scoped())
-            {
-                Money exp = 42.17 + Currency.EUR;
-                Assert.IsTrue(Money.TryParse("€42,17", out Money act), "Valid");
-                Assert.AreEqual(exp, act, "Value");
-            }
-        }
-
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
-        {
-            string str = "string";
-            Assert.IsFalse(Money.TryParse(str, out Money val), "Valid");
-            Assert.AreEqual(Money.Zero, val, "Value");
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Assert.Catch<FormatException>
-                (() =>
-                {
-                    Money.Parse("InvalidInput");
-                },
-                "Not a valid amount");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = Money.TryParse("€42.17");
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void from_invalid_as_null_with_TryParse()
-            => Money.TryParse("invalid input").Should().BeNull();
-
-        [Test]
-        public void Parse_EuroSpace12_Parsed()
-        {
-            using (TestCultures.Fr_FR.Scoped())
-            {
-                var exp = 12 + Currency.EUR;
-                var act = Money.Parse("€ 12");
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void Parse_Min12Comma765SpaceEuro_Parsed()
-        {
-            using (TestCultures.Fr_FR.Scoped())
-            {
-                var exp = -12.765 + Currency.EUR;
-                var act = Money.Parse("-12,765 €");
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        #endregion
-
-        #region (XML) (De)serialization tests
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(Money), new FormatterConverter());
-            obj.GetObjectData(info, default);
-
-            Assert.AreEqual(42.17m, info.GetDecimal("Value"));
-            Assert.AreEqual("EUR", info.GetString("Currency"));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "EUR42.17";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<Money>("EUR42.17");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_MoneySerializeObject_AreEqual()
-        {
-            var input = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_MoneySerializeObject_AreEqual()
-        {
-            var input = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_MoneySerializeObject_AreEqual()
-        {
-            var input = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Default_AreEqual()
-        {
-            var input = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = Money.Zero,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new MoneySerializeObject
-            {
-                Id = 17,
-                Obj = Money.Zero,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [TestCase("Invalid input")]
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<Money>(json));
-        }
-
-        [TestCase("EUR 42.17", "EUR 42.17")]
-        [TestCase("EUR 42.17", "EUR42.17")]
-        [TestCase("EUR 42.17", "€42.17")]
-        [TestCase("100", 100L)]
-        [TestCase("42.17", 42.17)]
-        public void FromJson(Money expected, object json)
-        {
-            var actual = JsonTester.Read<Money>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "EUR42.17";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IFormattable / ToString tests
-
-        [Test]
-        public void ToString_Empty_StringEmpty()
-        {
-            using (CultureInfoScope.NewInvariant())
-            {
-                var act = Money.Zero.ToString();
-                var exp = "0";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("0.0", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: '42.2', format: '0.0'";
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_TestStruct_ComplexPattern()
-        {
-            using (TestCultures.Nl_BE.Scoped())
-            {
-                var act = TestStruct.ToString("0.00");
-                var exp = "42,17";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_ValueDutchBelgium_AreEqual()
-        {
-            using (TestCultures.Nl_BE.Scoped())
-            {
-                // 3: n $
-                CultureInfo.CurrentCulture.NumberFormat.CurrencyPositivePattern = 3;
-                var act = Money.Parse("ALL 1600,1").ToString();
-                var exp = "1.600,10 Lekë";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_ValueEnglishGreatBritain_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var act = Money.Parse("EUR 1600.1").ToString();
-                var exp = "€1,600.10";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_AED_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var act = Money.Parse("AED 1600.1").ToString();
-                var exp = "AED1,600.10";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_FormatValueDutchBelgium_AreEqual()
-        {
-            using (TestCultures.Nl_BE.Scoped())
-            {
-                var act = Money.Parse("800").ToString("0000");
-                var exp = "0800";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_FormatValueEnglishGreatBritain_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var act = Money.Parse("800").ToString("0000");
-                var exp = "0800";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_FormatValueSpanishEcuador_AreEqual()
-        {
-            var act = Money.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
-            var exp = "01700,0";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IEquatable tests
-
-        /// <summary>GetHash should not fail for Money.Empty.</summary>
-        [Test]
-        public void GetHash_Empty_Hash()
-        {
-            Assert.AreEqual(0, Money.Zero.GetHashCode());
-        }
-
-        /// <summary>GetHash should not fail for the test struct.</summary>
-        [Test]
-        public void GetHash_TestStruct_NotZero()
-        {
-            Assert.NotZero(TestStruct.GetHashCode());
-        }
-
-        [Test]
-        public void Equals_EmptyEmpty_IsTrue()
-        {
-            Assert.IsTrue(Money.Zero.Equals(Money.Zero));
-        }
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            var l = Money.Parse("€1,234,456.789", CultureInfo.InvariantCulture);
-            var r = Money.Parse("EUR1234456.789", CultureInfo.InvariantCulture);
-
-            Assert.IsTrue(l.Equals(r));
-        }
-
-        [Test]
-        public void Equals_TestStructTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructEmpty_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(Money.Zero));
-        }
-
-        [Test]
-        public void Equals_EmptyTestStruct_IsFalse()
-        {
-            Assert.IsFalse(Money.Zero.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructObjectTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals((object)TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructNull_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(null));
-        }
-
-        [Test]
-        public void Equals_TestStructObject_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(new object()));
-        }
-
-        [Test]
-        public void OperatorIs_TestStructTestStruct_IsTrue()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsTrue(l == r);
-        }
-
-        [Test]
-        public void OperatorIsNot_TestStructTestStruct_IsFalse()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsFalse(l != r);
-        }
-
-        #endregion
-
-        #region IComparable tests
-
-        /// <summary>Orders a list of Moneys ascending.</summary>
-        [Test]
-        public void OrderBy_Money_AreEqual()
-        {
-            var item0 = 124.40 + Currency.EUR;
-            var item1 = 124.41 + Currency.EUR;
-            var item2 = 124.42 + Currency.EUR;
-            var item3 = 124.39 + Currency.GBP;
-
-            var inp = new List<Money> { Money.Zero, item3, item2, item0, item1, Money.Zero };
-            var exp = new List<Money> { Money.Zero, Money.Zero, item0, item1, item2, item3 };
-            var act = inp.OrderBy(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Orders a list of Moneys descending.</summary>
-        [Test]
-        public void OrderByDescending_Money_AreEqual()
-        {
-            var item0 = 124.40 + Currency.EUR;
-            var item1 = 124.41 + Currency.EUR;
-            var item2 = 124.42 + Currency.EUR;
-            var item3 = 124.39 + Currency.GBP;
-
-            var inp = new List<Money> { Money.Zero, item3, item2, item0, item1, Money.Zero };
-            var exp = new List<Money> { item3, item2, item1, item0, Money.Zero, Money.Zero };
-            var act = inp.OrderByDescending(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with a to object casted instance should be fine.</summary>
-        [Test]
-        public void CompareTo_ObjectTestStruct_0()
-        {
-            object other = TestStruct;
-
-            var exp = 0;
-            var act = TestStruct.CompareTo(other);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with null should return 1.</summary>
-        [Test]
-        public void CompareTo_null_1()
-        {
-            object @null = null;
-            Assert.AreEqual(1, TestStruct.CompareTo(@null));
-        }
-
-        /// <summary>Compare with a random object should throw an exception.</summary>
-        [Test]
-        public void CompareTo_newObject_ThrowsArgumentException()
-        {
-            Func<int> compare = () => TestStruct.CompareTo(new object());
-            compare.Should().Throw<ArgumentException>();
-        }
-
-        [Test]
-        public void LessThan_17LT19_IsTrue()
-        {
-            var l = 17 + Currency.DKK;
-            var r = 19 + Currency.DKK;
-
-            Assert.IsTrue(l < r);
-        }
-        [Test]
-        public void GreaterThan_21LT19_IsTrue()
-        {
-            var l = 21 + Currency.DKK;
-            var r = 19 + Currency.DKK;
-
-            Assert.IsTrue(l > r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT19_IsTrue()
-        {
-            var l = 17 + Currency.DKK;
-            var r = 19 + Currency.DKK;
-
-            Assert.IsTrue(l <= r);
-        }
-        [Test]
-        public void GreaterThanOrEqual_21LT19_IsTrue()
-        {
-            var l = 21 + Currency.DKK;
-            var r = 19 + Currency.DKK;
-
-            Assert.IsTrue(l >= r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT17_IsTrue()
-        {
-            var l = 17 + Currency.DKK;
-            var r = 17 + Currency.DKK;
-
-            Assert.IsTrue(l <= r);
-        }
-        [Test]
-        public void GreaterThanOrEqual_21LT21_IsTrue()
-        {
-            var l = 21 + Currency.DKK;
-            var r = 21 + Currency.DKK;
-
-            Assert.IsTrue(l >= r);
-        }
-        #endregion
-
-        #region Properties
-
-        [Test]
-        public void Currency_Set()
-        {
-            var money = 42 + Currency.EUR;
-            Assert.AreEqual(Currency.EUR, money.Currency);
-        }
-
-        [Test]
-        public void Amount_Set()
-        {
-            var money = 42 + Currency.EUR;
-            Assert.AreEqual((Amount)42, money.Amount);
-        }
-
-        #endregion
-
-        #region Operations
-
-        [TestCase(-1, "EUR -1000")]
-        [TestCase(0, "EUR 0")]
-        [TestCase(+1, "EUR 100")]
-        public void Sign(int expected, Money value)
-        {
-            var actual = value.Sign();
-            Assert.AreEqual(expected, actual);
-        }
-
-        [TestCase(23.1234, -23.1234)]
-        [TestCase(23.1234, +23.1234)]
-        public void Abs(decimal expected, decimal value)
-        {
-            var money = value + Currency.USD;
-            var abs = money.Abs();
-            Assert.AreEqual(expected + Currency.USD, abs);
-        }
-
-        [Test]
-        public void Plus_TestStruct_SameValue()
-        {
-            var act = +TestStruct;
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        public void Negates_TestStruct_NegativeValue()
-        {
-            var act = -TestStruct;
-            var exp = -42.17 + Currency.EUR;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Increase_TestStruct_Plus1()
-        {
-            var act = TestStruct;
-            act++;
-            var exp = 43.17 + Currency.EUR;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Decrease_TestStruct_Minus1()
-        {
-            var act = TestStruct;
-            act--;
-            var exp = 41.17 + Currency.EUR;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Add_SameCurrency_Added()
-        {
-            var l = 16 + Currency.EUR;
-            var r = 26 + Currency.EUR;
-            var a = 42 + Currency.EUR;
-
-            Assert.AreEqual(a, l + r);
-        }
-
-        [Test]
-        public void Add_25Percent_Added()
-        {
-            var l = 16 + Currency.EUR;
-            var p = 25.Percent();
-            var a = 20 + Currency.EUR;
-
-            Assert.AreEqual(a, l + p);
-        }
-
-        [Test]
-        public void Add_DifferentCurrency_Throws()
-        {
-            var l = 16 + Currency.EUR;
-            var r = 666 + Currency.USD;
-
-            var x = Assert.Catch<CurrencyMismatchException>(() => l.Add(r));
-            Assert.AreEqual("The addition operation could not be applied. There is a mismatch between EUR and USD.", x.Message);
-        }
-
-        [Test]
-        public void Subtract_SameCurrency_Subtracted()
-        {
-            var l = 69 + Currency.EUR;
-            var r = 27 + Currency.EUR;
-            var a = 42 + Currency.EUR;
-
-            Assert.AreEqual(a, l - r);
-        }
-
-        [Test]
-        public void Subtract_25Percent_Subtracted()
-        {
-            var l = 16 + Currency.EUR;
-            var p = 25.Percent();
-            var a = 12 + Currency.EUR;
-
-            Assert.AreEqual(a, l - p);
-        }
-
-        [Test]
-        public void Subtract_DifferentCurrency_Throws()
-        {
-            var l = 16 + Currency.EUR;
-            var r = 666 + Currency.USD;
-
-            var x = Assert.Catch<CurrencyMismatchException>(() => l.Subtract(r));
-
-            Assert.AreEqual("The subtraction operation could not be applied. There is a mismatch between EUR and USD.", x.Message);
-        }
-
-        [Test]
-        public void Multiply_Percentage()
-        {
-            var money = 100.40m + Currency.USD;
-            var p = 50.Percent();
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money * p);
-        }
-
-        [Test]
-        public void Multiply_Float()
-        {
-            var money = 100.40m + Currency.USD;
-            float p = 0.5F;
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money * p);
-        }
-
-        [Test]
-        public void Multiply_Double()
-        {
-            var money = 100.40m + Currency.USD;
-            double p = 0.5;
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money * p);
-        }
-
-        [Test]
-        public void Multiply_Decimal()
-        {
-            var money = 100.40m + Currency.USD;
-            var p = 0.5m;
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money * p);
-        }
-
-        [Test]
-        public void Multiply_Short()
-        {
-            var money = 100.40m + Currency.USD;
-            short f = 2;
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money * f);
-        }
-
-        [Test]
-        public void Multiply_Int()
-        {
-            var money = 100.40m + Currency.USD;
-            int f = 2;
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money * f);
-        }
-
-        [Test]
-        public void Multiply_Long()
-        {
-            var money = 100.40m + Currency.USD;
-            long f = 2;
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money * f);
-        }
-
-        [Test]
-        public void Multiply_UShort()
-        {
-            var money = 100.40m + Currency.USD;
-            ushort f = 2;
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money * f);
-        }
-
-        [Test]
-        public void Multiply_UInt()
-        {
-            var money = 100.40m + Currency.USD;
-            uint f = 2;
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money * f);
-        }
-
-        [Test]
-        public void Multiply_ULong()
-        {
-            var money = 100.40m + Currency.USD;
-            ulong f = 2;
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money * f);
-        }
-
-        [Test]
-        public void Divide_Percentage()
-        {
-            var money = 100.40m + Currency.USD;
-            var p = 50.Percent();
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money / p);
-        }
-
-        [Test]
-        public void Divide_Float()
-        {
-            var money = 100.40m + Currency.USD;
-            float p = 0.5F;
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money / p);
-        }
-
-        [Test]
-        public void Divide_Double()
-        {
-            var money = 100.40m + Currency.USD;
-            double p = 0.5;
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money / p);
-        }
-
-        [Test]
-        public void Divide_Decimal()
-        {
-            var money = 100.40m + Currency.USD;
-            var p = 0.5m;
-            var expected = 200.8m + Currency.USD;
-            Assert.AreEqual(expected, money / p);
-        }
-
-        [Test]
-        public void Divide_Short()
-        {
-            var money = 100.40m + Currency.USD;
-            short f = 2;
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money / f);
-        }
-
-        [Test]
-        public void Divide_Int()
-        {
-            var money = 100.40m + Currency.USD;
-            int f = 2;
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money / f);
-        }
-
-        [Test]
-        public void Divide_Long()
-        {
-            var money = 100.40m + Currency.USD;
-            long f = 2;
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money / f);
-        }
-
-        [Test]
-        public void Divide_UShort()
-        {
-            var money = 100.40m + Currency.USD;
-            ushort f = 2;
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money / f);
-        }
-
-        [Test]
-        public void Divide_UInt()
-        {
-            var money = 100.40m + Currency.USD;
-            uint f = 2;
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money / f);
-        }
-
-        [Test]
-        public void Divide_ULong()
-        {
-            var money = 100.40m + Currency.USD;
-            ulong f = 2;
-            var expected = 50.20m + Currency.USD;
-            Assert.AreEqual(expected, money / f);
-        }
-
-        [Test]
-        public void Round_EUR_2Digits()
-        {
-            var money = 123.4567m + Currency.EUR;
-            var rounded = money.Round();
-            Assert.AreEqual(123.46m + Currency.EUR, rounded);
-        }
-
-        [Test]
-        public void Round_1Digit()
-        {
-            var money = 123.4567m + Currency.EUR;
-            var rounded = money.Round(1);
-            Assert.AreEqual(123.5m + Currency.EUR, rounded);
-        }
-
-        [Test]
-        public void RoundToMultiple_0d25()
-        {
-            var money = 123.6567m + Currency.EUR;
-            var rounded = money.RoundToMultiple(0.25m);
-            Assert.AreEqual(123.75m + Currency.EUR, rounded);
-        }
-
-        #endregion
-
-        #region IsValid tests
-
-        [Test]
-        public void IsValid_Data_IsFalse()
-        {
-            Assert.IsFalse(Money.IsValid("Complex"), "Complex");
-            Assert.IsFalse(Money.IsValid((String)null), "(String)null");
-            Assert.IsFalse(Money.IsValid(string.Empty), "string.Empty");
-        }
-        [Test]
-        public void IsValid_Data_IsTrue()
-        {
-            Assert.IsTrue(Money.IsValid("USD -12,345.789", CultureInfo.InvariantCulture));
-            Assert.IsTrue(Money.IsValid("USD +12,345.789", CultureInfo.InvariantCulture));
-            Assert.IsTrue(Money.IsValid("€ 12,345.789", CultureInfo.InvariantCulture));
-        }
-        #endregion
+        Assert.AreEqual(default(Money), Money.Zero);
     }
 
-    [Serializable]
-    public class MoneySerializeObject
+    #endregion
+
+    #region TryParse tests
+
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
     {
-        public int Id { get; set; }
-        public Money Obj { get; set; }
-        public DateTime Date { get; set; }
+        using (TestCultures.Nl_NL.Scoped())
+        {
+            Money exp = 42.17 + Currency.EUR;
+            Assert.IsTrue(Money.TryParse("€42,17", out Money act), "Valid");
+            Assert.AreEqual(exp, act, "Value");
+        }
     }
+
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "string";
+        Assert.IsFalse(Money.TryParse(str, out Money val), "Valid");
+        Assert.AreEqual(Money.Zero, val, "Value");
+    }
+
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Assert.Catch<FormatException>
+            (() =>
+            {
+                Money.Parse("InvalidInput");
+            },
+            "Not a valid amount");
+        }
+    }
+
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = Money.TryParse("€42.17");
+
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void from_invalid_as_null_with_TryParse()
+        => Money.TryParse("invalid input").Should().BeNull();
+
+    [Test]
+    public void Parse_EuroSpace12_Parsed()
+    {
+        using (TestCultures.Fr_FR.Scoped())
+        {
+            var exp = 12 + Currency.EUR;
+            var act = Money.Parse("€ 12");
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void Parse_Min12Comma765SpaceEuro_Parsed()
+    {
+        using (TestCultures.Fr_FR.Scoped())
+        {
+            var exp = -12.765 + Currency.EUR;
+            var act = Money.Parse("-12,765 €");
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    #endregion
+
+    #region (XML) (De)serialization tests
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(Money), new FormatterConverter());
+        obj.GetObjectData(info, default);
+
+        Assert.AreEqual(42.17m, info.GetDecimal("Value"));
+        Assert.AreEqual("EUR", info.GetString("Currency"));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "EUR42.17";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<Money>("EUR42.17");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_MoneySerializeObject_AreEqual()
+    {
+        var input = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_MoneySerializeObject_AreEqual()
+    {
+        var input = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_MoneySerializeObject_AreEqual()
+    {
+        var input = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Default_AreEqual()
+    {
+        var input = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = Money.Zero,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new MoneySerializeObject
+        {
+            Id = 17,
+            Obj = Money.Zero,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    #endregion
+
+    #region IFormattable / ToString tests
+
+    [Test]
+    public void ToString_Empty_StringEmpty()
+    {
+        using (CultureInfoScope.NewInvariant())
+        {
+            var act = Money.Zero.ToString();
+            var exp = "0";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("0.0", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: '42.2', format: '0.0'";
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_TestStruct_ComplexPattern()
+    {
+        using (TestCultures.Nl_BE.Scoped())
+        {
+            var act = TestStruct.ToString("0.00");
+            var exp = "42,17";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_ValueDutchBelgium_AreEqual()
+    {
+        using (TestCultures.Nl_BE.Scoped())
+        {
+            // 3: n $
+            CultureInfo.CurrentCulture.NumberFormat.CurrencyPositivePattern = 3;
+            var act = Money.Parse("ALL 1600,1").ToString();
+            var exp = "1.600,10 Lekë";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_ValueEnglishGreatBritain_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var act = Money.Parse("EUR 1600.1").ToString();
+            var exp = "€1,600.10";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_AED_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var act = Money.Parse("AED 1600.1").ToString();
+            var exp = "AED1,600.10";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_FormatValueDutchBelgium_AreEqual()
+    {
+        using (TestCultures.Nl_BE.Scoped())
+        {
+            var act = Money.Parse("800").ToString("0000");
+            var exp = "0800";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_FormatValueEnglishGreatBritain_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var act = Money.Parse("800").ToString("0000");
+            var exp = "0800";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_FormatValueSpanishEcuador_AreEqual()
+    {
+        var act = Money.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
+        var exp = "01700,0";
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IEquatable tests
+
+    /// <summary>GetHash should not fail for Money.Empty.</summary>
+    [Test]
+    public void GetHash_Empty_Hash()
+    {
+        Assert.AreEqual(0, Money.Zero.GetHashCode());
+    }
+
+    /// <summary>GetHash should not fail for the test struct.</summary>
+    [Test]
+    public void GetHash_TestStruct_NotZero()
+    {
+        Assert.NotZero(TestStruct.GetHashCode());
+    }
+
+    [Test]
+    public void Equals_EmptyEmpty_IsTrue()
+    {
+        Assert.IsTrue(Money.Zero.Equals(Money.Zero));
+    }
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        var l = Money.Parse("€1,234,456.789", CultureInfo.InvariantCulture);
+        var r = Money.Parse("EUR1234456.789", CultureInfo.InvariantCulture);
+
+        Assert.IsTrue(l.Equals(r));
+    }
+
+    [Test]
+    public void Equals_TestStructTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructEmpty_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(Money.Zero));
+    }
+
+    [Test]
+    public void Equals_EmptyTestStruct_IsFalse()
+    {
+        Assert.IsFalse(Money.Zero.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructObjectTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals((object)TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructNull_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(null));
+    }
+
+    [Test]
+    public void Equals_TestStructObject_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(new object()));
+    }
+
+    [Test]
+    public void OperatorIs_TestStructTestStruct_IsTrue()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsTrue(l == r);
+    }
+
+    [Test]
+    public void OperatorIsNot_TestStructTestStruct_IsFalse()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsFalse(l != r);
+    }
+
+    #endregion
+
+    #region IComparable tests
+
+    /// <summary>Orders a list of Moneys ascending.</summary>
+    [Test]
+    public void OrderBy_Money_AreEqual()
+    {
+        var item0 = 124.40 + Currency.EUR;
+        var item1 = 124.41 + Currency.EUR;
+        var item2 = 124.42 + Currency.EUR;
+        var item3 = 124.39 + Currency.GBP;
+
+        var inp = new List<Money> { Money.Zero, item3, item2, item0, item1, Money.Zero };
+        var exp = new List<Money> { Money.Zero, Money.Zero, item0, item1, item2, item3 };
+        var act = inp.OrderBy(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Orders a list of Moneys descending.</summary>
+    [Test]
+    public void OrderByDescending_Money_AreEqual()
+    {
+        var item0 = 124.40 + Currency.EUR;
+        var item1 = 124.41 + Currency.EUR;
+        var item2 = 124.42 + Currency.EUR;
+        var item3 = 124.39 + Currency.GBP;
+
+        var inp = new List<Money> { Money.Zero, item3, item2, item0, item1, Money.Zero };
+        var exp = new List<Money> { item3, item2, item1, item0, Money.Zero, Money.Zero };
+        var act = inp.OrderByDescending(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with a to object casted instance should be fine.</summary>
+    [Test]
+    public void CompareTo_ObjectTestStruct_0()
+    {
+        object other = TestStruct;
+
+        var exp = 0;
+        var act = TestStruct.CompareTo(other);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with null should return 1.</summary>
+    [Test]
+    public void CompareTo_null_1()
+    {
+        object @null = null;
+        Assert.AreEqual(1, TestStruct.CompareTo(@null));
+    }
+
+    /// <summary>Compare with a random object should throw an exception.</summary>
+    [Test]
+    public void CompareTo_newObject_ThrowsArgumentException()
+    {
+        Func<int> compare = () => TestStruct.CompareTo(new object());
+        compare.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void LessThan_17LT19_IsTrue()
+    {
+        var l = 17 + Currency.DKK;
+        var r = 19 + Currency.DKK;
+
+        Assert.IsTrue(l < r);
+    }
+    [Test]
+    public void GreaterThan_21LT19_IsTrue()
+    {
+        var l = 21 + Currency.DKK;
+        var r = 19 + Currency.DKK;
+
+        Assert.IsTrue(l > r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT19_IsTrue()
+    {
+        var l = 17 + Currency.DKK;
+        var r = 19 + Currency.DKK;
+
+        Assert.IsTrue(l <= r);
+    }
+    [Test]
+    public void GreaterThanOrEqual_21LT19_IsTrue()
+    {
+        var l = 21 + Currency.DKK;
+        var r = 19 + Currency.DKK;
+
+        Assert.IsTrue(l >= r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT17_IsTrue()
+    {
+        var l = 17 + Currency.DKK;
+        var r = 17 + Currency.DKK;
+
+        Assert.IsTrue(l <= r);
+    }
+    [Test]
+    public void GreaterThanOrEqual_21LT21_IsTrue()
+    {
+        var l = 21 + Currency.DKK;
+        var r = 21 + Currency.DKK;
+
+        Assert.IsTrue(l >= r);
+    }
+    #endregion
+
+    #region Properties
+
+    [Test]
+    public void Currency_Set()
+    {
+        var money = 42 + Currency.EUR;
+        Assert.AreEqual(Currency.EUR, money.Currency);
+    }
+
+    [Test]
+    public void Amount_Set()
+    {
+        var money = 42 + Currency.EUR;
+        Assert.AreEqual((Amount)42, money.Amount);
+    }
+
+    #endregion
+
+    #region Operations
+
+    [TestCase(-1, "EUR -1000")]
+    [TestCase(0, "EUR 0")]
+    [TestCase(+1, "EUR 100")]
+    public void Sign(int expected, Money value)
+    {
+        var actual = value.Sign();
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase(23.1234, -23.1234)]
+    [TestCase(23.1234, +23.1234)]
+    public void Abs(decimal expected, decimal value)
+    {
+        var money = value + Currency.USD;
+        var abs = money.Abs();
+        Assert.AreEqual(expected + Currency.USD, abs);
+    }
+
+    [Test]
+    public void Plus_TestStruct_SameValue()
+    {
+        var act = +TestStruct;
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    public void Negates_TestStruct_NegativeValue()
+    {
+        var act = -TestStruct;
+        var exp = -42.17 + Currency.EUR;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Increase_TestStruct_Plus1()
+    {
+        var act = TestStruct;
+        act++;
+        var exp = 43.17 + Currency.EUR;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Decrease_TestStruct_Minus1()
+    {
+        var act = TestStruct;
+        act--;
+        var exp = 41.17 + Currency.EUR;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Add_SameCurrency_Added()
+    {
+        var l = 16 + Currency.EUR;
+        var r = 26 + Currency.EUR;
+        var a = 42 + Currency.EUR;
+
+        Assert.AreEqual(a, l + r);
+    }
+
+    [Test]
+    public void Add_25Percent_Added()
+    {
+        var l = 16 + Currency.EUR;
+        var p = 25.Percent();
+        var a = 20 + Currency.EUR;
+
+        Assert.AreEqual(a, l + p);
+    }
+
+    [Test]
+    public void Add_DifferentCurrency_Throws()
+    {
+        var l = 16 + Currency.EUR;
+        var r = 666 + Currency.USD;
+
+        var x = Assert.Catch<CurrencyMismatchException>(() => l.Add(r));
+        Assert.AreEqual("The addition operation could not be applied. There is a mismatch between EUR and USD.", x.Message);
+    }
+
+    [Test]
+    public void Subtract_SameCurrency_Subtracted()
+    {
+        var l = 69 + Currency.EUR;
+        var r = 27 + Currency.EUR;
+        var a = 42 + Currency.EUR;
+
+        Assert.AreEqual(a, l - r);
+    }
+
+    [Test]
+    public void Subtract_25Percent_Subtracted()
+    {
+        var l = 16 + Currency.EUR;
+        var p = 25.Percent();
+        var a = 12 + Currency.EUR;
+
+        Assert.AreEqual(a, l - p);
+    }
+
+    [Test]
+    public void Subtract_DifferentCurrency_Throws()
+    {
+        var l = 16 + Currency.EUR;
+        var r = 666 + Currency.USD;
+
+        var x = Assert.Catch<CurrencyMismatchException>(() => l.Subtract(r));
+
+        Assert.AreEqual("The subtraction operation could not be applied. There is a mismatch between EUR and USD.", x.Message);
+    }
+
+    [Test]
+    public void Multiply_Percentage()
+    {
+        var money = 100.40m + Currency.USD;
+        var p = 50.Percent();
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money * p);
+    }
+
+    [Test]
+    public void Multiply_Float()
+    {
+        var money = 100.40m + Currency.USD;
+        float p = 0.5F;
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money * p);
+    }
+
+    [Test]
+    public void Multiply_Double()
+    {
+        var money = 100.40m + Currency.USD;
+        double p = 0.5;
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money * p);
+    }
+
+    [Test]
+    public void Multiply_Decimal()
+    {
+        var money = 100.40m + Currency.USD;
+        var p = 0.5m;
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money * p);
+    }
+
+    [Test]
+    public void Multiply_Short()
+    {
+        var money = 100.40m + Currency.USD;
+        short f = 2;
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money * f);
+    }
+
+    [Test]
+    public void Multiply_Int()
+    {
+        var money = 100.40m + Currency.USD;
+        int f = 2;
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money * f);
+    }
+
+    [Test]
+    public void Multiply_Long()
+    {
+        var money = 100.40m + Currency.USD;
+        long f = 2;
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money * f);
+    }
+
+    [Test]
+    public void Multiply_UShort()
+    {
+        var money = 100.40m + Currency.USD;
+        ushort f = 2;
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money * f);
+    }
+
+    [Test]
+    public void Multiply_UInt()
+    {
+        var money = 100.40m + Currency.USD;
+        uint f = 2;
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money * f);
+    }
+
+    [Test]
+    public void Multiply_ULong()
+    {
+        var money = 100.40m + Currency.USD;
+        ulong f = 2;
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money * f);
+    }
+
+    [Test]
+    public void Divide_Percentage()
+    {
+        var money = 100.40m + Currency.USD;
+        var p = 50.Percent();
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money / p);
+    }
+
+    [Test]
+    public void Divide_Float()
+    {
+        var money = 100.40m + Currency.USD;
+        float p = 0.5F;
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money / p);
+    }
+
+    [Test]
+    public void Divide_Double()
+    {
+        var money = 100.40m + Currency.USD;
+        double p = 0.5;
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money / p);
+    }
+
+    [Test]
+    public void Divide_Decimal()
+    {
+        var money = 100.40m + Currency.USD;
+        var p = 0.5m;
+        var expected = 200.8m + Currency.USD;
+        Assert.AreEqual(expected, money / p);
+    }
+
+    [Test]
+    public void Divide_Short()
+    {
+        var money = 100.40m + Currency.USD;
+        short f = 2;
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money / f);
+    }
+
+    [Test]
+    public void Divide_Int()
+    {
+        var money = 100.40m + Currency.USD;
+        int f = 2;
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money / f);
+    }
+
+    [Test]
+    public void Divide_Long()
+    {
+        var money = 100.40m + Currency.USD;
+        long f = 2;
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money / f);
+    }
+
+    [Test]
+    public void Divide_UShort()
+    {
+        var money = 100.40m + Currency.USD;
+        ushort f = 2;
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money / f);
+    }
+
+    [Test]
+    public void Divide_UInt()
+    {
+        var money = 100.40m + Currency.USD;
+        uint f = 2;
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money / f);
+    }
+
+    [Test]
+    public void Divide_ULong()
+    {
+        var money = 100.40m + Currency.USD;
+        ulong f = 2;
+        var expected = 50.20m + Currency.USD;
+        Assert.AreEqual(expected, money / f);
+    }
+
+    [Test]
+    public void Round_EUR_2Digits()
+    {
+        var money = 123.4567m + Currency.EUR;
+        var rounded = money.Round();
+        Assert.AreEqual(123.46m + Currency.EUR, rounded);
+    }
+
+    [Test]
+    public void Round_1Digit()
+    {
+        var money = 123.4567m + Currency.EUR;
+        var rounded = money.Round(1);
+        Assert.AreEqual(123.5m + Currency.EUR, rounded);
+    }
+
+    [Test]
+    public void RoundToMultiple_0d25()
+    {
+        var money = 123.6567m + Currency.EUR;
+        var rounded = money.RoundToMultiple(0.25m);
+        Assert.AreEqual(123.75m + Currency.EUR, rounded);
+    }
+
+    #endregion
+
+    #region IsValid tests
+
+    [Test]
+    public void IsValid_Data_IsFalse()
+    {
+        Assert.IsFalse(Money.IsValid("Complex"), "Complex");
+        Assert.IsFalse(Money.IsValid((String)null), "(String)null");
+        Assert.IsFalse(Money.IsValid(string.Empty), "string.Empty");
+    }
+    [Test]
+    public void IsValid_Data_IsTrue()
+    {
+        Assert.IsTrue(Money.IsValid("USD -12,345.789", CultureInfo.InvariantCulture));
+        Assert.IsTrue(Money.IsValid("USD +12,345.789", CultureInfo.InvariantCulture));
+        Assert.IsTrue(Money.IsValid("€ 12,345.789", CultureInfo.InvariantCulture));
+    }
+    #endregion
+}
+
+[Serializable]
+public class MoneySerializeObject
+{
+    public int Id { get; set; }
+    public Money Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -1,995 +1,945 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Financial;
-using Qowaiv.Globalization;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests.Globalization;
 
-namespace Qowaiv.UnitTests.Globalization
+public class CountryTest
 {
-    public class CountryTest
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly Country TestStruct = Country.VA;
+
+    /// <summary>Country.Empty should be equal to the default of Country.</summary>
+    [Test]
+    public void Empty_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly Country TestStruct = Country.VA;
+        Assert.AreEqual(default(Country), Country.Empty);
+    }
 
-        /// <summary>Country.Empty should be equal to the default of Country.</summary>
-        [Test]
-        public void Empty_None_EqualsDefault()
+    [Test]
+    public void All_None_260Countries()
+    {
+        Assert.AreEqual(260, Country.All.Count);
+    }
+
+    [Test]
+    public void GetExisting_Januari2016_250Countries()
+    {
+        Assert.AreEqual(250, Country.GetExisting(new Date(2016, 01, 01)).Count());
+    }
+
+    #region Current
+
+    [Test]
+    public void Current_CurrentCultureDeDE_Germany()
+    {
+        using (TestCultures.De_DE.Scoped())
         {
-            Assert.AreEqual(default(Country), Country.Empty);
-        }
+            var act = Country.Current;
+            var exp = Country.DE;
 
-        [Test]
-        public void All_None_260Countries()
-        {
-            Assert.AreEqual(260, Country.All.Count);
-        }
-
-        [Test]
-        public void GetExisting_Januari2016_250Countries()
-        {
-            Assert.AreEqual(250, Country.GetExisting(new Date(2016, 01, 01)).Count());
-        }
-
-
-        #region Current
-
-        [Test]
-        public void Current_CurrentCultureDeDE_Germany()
-        {
-            using (TestCultures.De_DE.Scoped())
-            {
-                var act = Country.Current;
-                var exp = Country.DE;
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void Current_CurrentCultureEsEC_Ecuador()
-        {
-            using (TestCultures.Es_EC.Scoped())
-            {
-                var act = Country.Current;
-                var exp = Country.EC;
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void Current_CurrentCultureEn_Empty()
-        {
-            using (TestCultures.En.Scoped())
-            {
-                var act = Country.Current;
-                var exp = Country.Empty;
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        #endregion
-
-        #region Country IsEmpty tests
-
-        /// <summary>Country.IsEmpty() should true for the default of Country.</summary>
-        [Test]
-        public void IsEmpty_Default_IsTrue()
-        {
-            Assert.IsTrue(default(Country).IsEmpty());
-        }
-
-        /// <summary>Country.IsEmpty() should false for the TestStruct.</summary>
-        [Test]
-        public void IsEmpty_Default_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmpty());
-        }
-
-        #endregion
-
-        #region TryParse tests
-
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            string str = null;
-            Assert.IsTrue(Country.TryParse(str, out Country val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            string str = string.Empty;
-            Assert.IsTrue(Country.TryParse(str, out Country val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse "?" should be valid and the result should be Country.Unknown.</summary>
-        [Test]
-        public void TryParse_Questionmark_IsValid()
-        {
-            string str = "?";
-            Assert.IsTrue(Country.TryParse(str, out Country val), "Valid");
-            Assert.IsTrue(val.IsUnknown(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_NullCultureStringValue_IsValid()
-        {
-            string str = "VA";
-            Assert.IsTrue(Country.TryParse(str, null, out Country val), "Valid");
-            Assert.AreEqual(str, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            string str = "VA";
-            Assert.IsTrue(Country.TryParse(str, out Country val), "Valid");
-            Assert.AreEqual(str, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
-        {
-            string str = "string";
-            Assert.IsFalse(Country.TryParse(str, out Country val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Assert.Catch<FormatException>
-                (() =>
-                {
-                    Country.Parse("InvalidInput");
-                },
-                "Not a valid country");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = Country.TryParse(exp.ToString());
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void from_invalid_as_null_with_TryParse()
-            => Country.TryParse("invalid input").Should().BeNull();
-
-        #endregion
-
-        #region Create tests
-
-        [Test]
-        public void Create_RegionInfoNull_Empty()
-        {
-            var exp = Country.Empty;
-            var act = Country.Create((RegionInfo)null);
             Assert.AreEqual(exp, act);
         }
+    }
 
-        [Test]
-        public void Create_CultureInfoNull_Empty()
+    [Test]
+    public void Current_CurrentCultureEsEC_Ecuador()
+    {
+        using (TestCultures.Es_EC.Scoped())
         {
-            var exp = Country.Empty;
-            var act = Country.Create((CultureInfo)null);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Create_NL_NL()
-        {
-            var exp = Country.NL;
-            var act = Country.Create(new RegionInfo("NL"));
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Create_CultureInfoInvariant_Empty()
-        {
-            var exp = Country.Empty;
-            var act = Country.Create(CultureInfo.InvariantCulture);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Create_CultureInfoEs_Empty()
-        {
-            var exp = Country.Empty;
-            var act = Country.Create(new CultureInfo("es"));
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Create_CultureInfoEsEC_Empty()
-        {
+            var act = Country.Current;
             var exp = Country.EC;
-            var act = Country.Create(new CultureInfo("es-EC"));
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Create_CS_CSXX()
-        {
-            var cs = new RegionInfo("CS");
-            var country = Country.Create(cs);
-            Assert.AreEqual(Country.CSXX, country);
-        }
-
-        [TestCaseSource(typeof(Country), nameof(Country.All))]
-        public void RegionInfoExists(Country country)
-        {
-            // As the regions available depend on the environment running, we can't
-            // predict the outcome.
-            Assert.IsTrue(new[] { true, false }.Contains(country.RegionInfoExists));
-        }
-
-        #endregion
-
-        #region (XML) (De)serialization tests
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(Country), new System.Runtime.Serialization.FormatterConverter());
-            obj.GetObjectData(info, default);
-
-            Assert.AreEqual("VA", info.GetString("Value"));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = CountryTest.TestStruct;
-            var exp = CountryTest.TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = CountryTest.TestStruct;
-            var exp = CountryTest.TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "VA";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<Country>("VA");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_CountrySerializeObject_AreEqual()
-        {
-            var input = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = CountryTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = CountryTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_CountrySerializeObject_AreEqual()
-        {
-            var input = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = CountryTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = CountryTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_CountrySerializeObject_AreEqual()
-        {
-            var input = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = CountryTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = CountryTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = Country.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = Country.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = Country.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new CountrySerializeObject
-            {
-                Id = 17,
-                Obj = Country.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [TestCase("Invalid input")]
-        [TestCase("2017-06-11")]
-        [TestCase(-3L)]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<Country>(json));
-        }
-        [TestCase("NL", "Netherlands")]
-        [TestCase("NL", "nl")]
-        [TestCase("AF", 4L)]
-        [TestCase("BG", 100L)]
-        public void FromJson(Country expected, object json)
-        {
-            var actual = JsonTester.Read<Country>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_IsNull()
-        {
-            object act = JsonTester.Write(default(Country));
-            Assert.IsNull(act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "VA";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IFormattable / ToString tests
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("e (3)", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: 'Holy See (VAT)', format: 'e (3)'";
 
             Assert.AreEqual(exp, act);
         }
-
-        [Test]
-        public void ToString_Empty_IsStringEmpty()
-        {
-            var act = Country.Empty.ToString();
-            var exp = "";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_Unknown_Questionmark()
-        {
-            var act = Country.Unknown.ToString();
-            var exp = "?";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString2_NZ_AreEqual()
-        {
-            var exp = "MZ";
-            var act = Country.MZ.ToString("2");
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString3_MZ_AreEqual()
-        {
-            var exp = "MOZ";
-            var act = Country.MZ.ToString("3", new CultureInfo("ja-JP"));
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString0_MZ_AreEqual()
-        {
-            var exp = "508";
-            var act = Country.MZ.ToString("0", new CultureInfo("ja-JP"));
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToStringN_CSHH_AreEqual()
-        {
-            var exp = "CSHH";
-            var act = Country.CSHH.ToString("n", new CultureInfo("ja-JP"));
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToStringE_MZ_AreEqual()
-        {
-            var exp = "Mozambique";
-            var act = Country.MZ.ToString("e", new CultureInfo("ja-JP"));
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToStringF_MZ_AreEqual()
-        {
-            var exp = "モザンビーク";
-            var act = Country.MZ.ToString("f", new CultureInfo("ja-JP"));
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IEquatable tests
-
-        /// <summary>GetHash should not fail for Country.Empty.</summary>
-        [Test]
-        public void GetHash_Empty_Hash()
-        {
-            Assert.AreEqual(0, Country.Empty.GetHashCode());
-        }
-
-        /// <summary>GetHash should not fail for the test struct.</summary>
-        [Test]
-        public void GetHash_TestStruct_NotZero()
-        {
-            Assert.NotZero(TestStruct.GetHashCode());
-        }
-
-        [Test]
-        public void Equals_EmptyEmpty_IsTrue()
-        {
-            Assert.IsTrue(Country.Empty.Equals(Country.Empty));
-        }
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            using (TestCultures.Nl_NL.Scoped())
-            {
-                var l = Country.Parse("België");
-                var r = Country.Parse("belgie");
-
-                Assert.IsTrue(l.Equals(r));
-            }
-        }
-
-        [Test]
-        public void Equals_TestStructTestStruct_IsTrue()
-        {
-            Assert.IsTrue(CountryTest.TestStruct.Equals(CountryTest.TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructEmpty_IsFalse()
-        {
-            Assert.IsFalse(CountryTest.TestStruct.Equals(Country.Empty));
-        }
-
-        [Test]
-        public void Equals_EmptyTestStruct_IsFalse()
-        {
-            Assert.IsFalse(Country.Empty.Equals(CountryTest.TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructObjectTestStruct_IsTrue()
-        {
-            Assert.IsTrue(CountryTest.TestStruct.Equals((object)CountryTest.TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructNull_IsFalse()
-        {
-            Assert.IsFalse(CountryTest.TestStruct.Equals(null));
-        }
-
-        [Test]
-        public void Equals_TestStructObject_IsFalse()
-        {
-            Assert.IsFalse(CountryTest.TestStruct.Equals(new object()));
-        }
-
-        [Test]
-        public void OperatorIs_TestStructTestStruct_IsTrue()
-        {
-            var l = CountryTest.TestStruct;
-            var r = CountryTest.TestStruct;
-            Assert.IsTrue(l == r);
-        }
-
-        [Test]
-        public void OperatorIsNot_TestStructTestStruct_IsFalse()
-        {
-            var l = CountryTest.TestStruct;
-            var r = CountryTest.TestStruct;
-            Assert.IsFalse(l != r);
-        }
-
-        #endregion
-
-        #region IComparable tests
-
-        /// <summary>Orders a list of Countrys ascending.</summary>
-        [Test]
-        public void OrderBy_Country_AreEqual()
-        {
-            var item0 = Country.AE;
-            var item1 = Country.BE;
-            var item2 = Country.CU;
-            var item3 = Country.DO;
-
-            var inp = new List<Country> { Country.Empty, item3, item2, item0, item1, Country.Empty };
-            var exp = new List<Country> { Country.Empty, Country.Empty, item0, item1, item2, item3 };
-            var act = inp.OrderBy(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Orders a list of Countrys descending.</summary>
-        [Test]
-        public void OrderByDescending_Country_AreEqual()
-        {
-            var item0 = Country.AE;
-            var item1 = Country.BE;
-            var item2 = Country.CU;
-            var item3 = Country.DO;
-
-            var inp = new List<Country> { Country.Empty, item3, item2, item0, item1, Country.Empty };
-            var exp = new List<Country> { item3, item2, item1, item0, Country.Empty, Country.Empty };
-            var act = inp.OrderByDescending(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with a to object casted instance should be fine.</summary>
-        [Test]
-        public void CompareTo_ObjectTestStruct_0()
-        {
-            object other = TestStruct;
-
-            var exp = 0;
-            var act = TestStruct.CompareTo(other);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with null should return 1.</summary>
-        [Test]
-        public void CompareTo_null_1()
-        {
-            object @null = null;
-            Assert.AreEqual(1, TestStruct.CompareTo(@null));
-        }
-
-        /// <summary>Compare with a random object should throw an exception.</summary>
-        [Test]
-        public void CompareTo_newObject_ThrowsArgumentException()
-        {
-            Func<int> compare = () => TestStruct.CompareTo(new object());
-            compare.Should().Throw<ArgumentException>();
-        }
-        #endregion
-
-        #region Casting tests
-
-        [Test]
-        public void Implicit_RegionInfoToCountry_AreEqual()
-        {
-            Country exp = Country.NL;
-            Country act = new RegionInfo("NL");
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_CountryToRegionInfo_AreEqual()
-        {
-            var exp = new RegionInfo("NL");
-            var act = (RegionInfo)Country.NL;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region Properties
-
-        [Test]
-        public void CallingCode_Empty_AreEqual()
-        {
-            var exp = "";
-            var act = Country.Empty.CallingCode;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void CallingCode_Unknown_AreEqual()
-        {
-            var exp = "";
-            var act = Country.Unknown.CallingCode;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void CallingCode_TestStruct_AreEqual()
-        {
-            var exp = "+379";
-            var act = TestStruct.CallingCode;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Name_Empty_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = "";
-                var act = Country.Empty.Name;
-                Assert.AreEqual(exp, act);
-            }
-        }
-        [Test]
-        public void Name_Unknown_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = "?";
-                var act = Country.Unknown.Name;
-                Assert.AreEqual(exp, act);
-            }
-        }
-        [Test]
-        public void Name_TestStruct_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = "VA";
-                var act = TestStruct.Name;
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void DisplayName_Empty_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = "";
-                var act = Country.Empty.DisplayName;
-                Assert.AreEqual(exp, act);
-            }
-        }
-        [Test]
-        public void DisplayName_Unknown_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = "Unknown";
-                var act = Country.Unknown.DisplayName;
-                Assert.AreEqual(exp, act);
-            }
-        }
-        [Test]
-        public void DisplayName_TestStruct_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = "Holy See";
-                var act = TestStruct.DisplayName;
-                Assert.AreEqual(exp, act);
-            }
-        }
-        [Test]
-        public void GetDisplayName_TestStruct_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = "Holy See";
-                var act = TestStruct.GetDisplayName(null);
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void IsoNumericCode_Empty_AreEqual()
-        {
-            var exp = 0;
-            var act = Country.Empty.IsoNumericCode;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void IsoNumericCode_Unknown_AreEqual()
-        {
-            var exp = 999;
-            var act = Country.Unknown.IsoNumericCode;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void IsoNumericCode_TestStruct_AreEqual()
-        {
-            var exp = 336;
-            var act = TestStruct.IsoNumericCode;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void StartDate_Empty_AreEqual()
-        {
-            var exp = Date.MinValue;
-            var act = Country.Empty.StartDate;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void StartDate_Unknown_AreEqual()
-        {
-            var exp = Date.MinValue;
-            var act = Country.Unknown.StartDate;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void StartDate_TestStruct_AreEqual()
-        {
-            var exp = new Date(1974, 01, 01);
-            var act = TestStruct.StartDate;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void StartDate_CZ_AreEqual()
-        {
-            var exp = new Date(1993, 01, 01);
-            var act = Country.CZ.StartDate;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void EndDate_Empty_AreEqual()
-        {
-            DateTime? exp = null;
-            var act = Country.Empty.EndDate;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void EndDate_Unknown_AreEqual()
-        {
-            DateTime? exp = null;
-            var act = Country.Unknown.EndDate;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void EndDate_TestStruct_AreEqual()
-        {
-            DateTime? exp = null;
-            var act = TestStruct.EndDate;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void EndDate_CZ_AreEqual()
-        {
-            DateTime? exp = null;
-            var act = Country.CZ.EndDate;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void EndDate_CSHH_AreEqual()
-        {
-            var exp = new Date(1992, 12, 31);
-            var act = Country.CSHH.EndDate;
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region Methods
-
-        [Test]
-        public void IsEmptyOrNotKnown_Empty_IsTrue()
-        {
-            Assert.IsTrue(Country.Empty.IsEmptyOrUnknown());
-        }
-
-        [Test]
-        public void IsEmptyOrNotKnown_NotKnown_IsTrue()
-        {
-            Assert.IsTrue(Country.Unknown.IsEmptyOrUnknown());
-        }
-
-        [Test]
-        public void IsEmptyOrNotKnown_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmptyOrUnknown());
-        }
-
-        [Test]
-        public void ExistsOnDate_SerbiaAndMontenegro1992_IsFalse()
-        {
-            Assert.IsFalse(Country.CSXX.ExistsOnDate(new Date(1992, 12, 31)));
-        }
-        [Test]
-        public void ExistsOnDate_SerbiaAndMontenegro1993_IsTrue()
-        {
-            Assert.IsTrue(Country.CSXX.ExistsOnDate(new Date(1993, 01, 01)));
-        }
-        [Test]
-        public void ExistsOnDate_SerbiaAndMontenegro2012_IsFalse()
-        {
-            Assert.IsFalse(Country.CSXX.ExistsOnDate(new Date(2012, 01, 01)));
-        }
-
-        /// <remarks>
-        /// On 1980, Burkina Faso did not yet exist.
-        /// </remarks>
-        [Test]
-        public void GetCurrency_BF1980_Empty()
-        {
-            var currency = Country.BF.GetCurrency(new Date(1980, 01, 01));
-            Assert.AreEqual(Currency.Empty, currency);
-        }
-
-        [Test]
-        public void GetCurrency_NL2001_NLG()
-        {
-            var act = Country.NL.GetCurrency(new Date(2001, 12, 31));
-            var exp = Currency.NLG;
-
-            Assert.AreEqual(act, exp);
-        }
-
-        [Test]
-        public void GetCurrency_NLToday_EUR()
-        {
-            var act = Country.NL.GetCurrency(Clock.Today());
-            var exp = Currency.EUR;
-
-            Assert.AreEqual(act, exp);
-        }
-
-        #endregion
-
-        #region IsValid tests
-
-        [Test]
-        public void IsValid_Data_IsFalse()
-        {
-            Assert.IsFalse(Country.IsValid("Complex"), "Complex");
-            Assert.IsFalse(Country.IsValid((String)null), "(String)null");
-            Assert.IsFalse(Country.IsValid(string.Empty), "string.Empty");
-        }
-        [Test]
-        public void IsValid_Data_IsTrue()
-        {
-            Assert.IsTrue(Country.IsValid("China", null));
-        }
-        #endregion
-
-        #region Collection tests
-
-        [Test]
-        public void GetCurrent_1973_0()
-        {
-            var exp = 0;
-
-            // before the ISO standard was introduced.
-            var act = Country.GetExisting(new Date(1973, 12, 31)).ToList();
-
-            Assert.AreEqual(exp, act.Count);
-        }
-
-        [Test]
-        public void GetCurrent_None_250()
-        {
-            var exp = 250;
-            var act = Country.GetExisting().ToList();
-
-            Assert.AreEqual(exp, act.Count);
-        }
-
-        #endregion
     }
 
-    [Serializable]
-    public class CountrySerializeObject
+    [Test]
+    public void Current_CurrentCultureEn_Empty()
     {
-        public int Id { get; set; }
-        public Country Obj { get; set; }
-        public DateTime Date { get; set; }
+        using (TestCultures.En.Scoped())
+        {
+            var act = Country.Current;
+            var exp = Country.Empty;
+
+            Assert.AreEqual(exp, act);
+        }
     }
+
+    #endregion
+
+    #region Country IsEmpty tests
+
+    /// <summary>Country.IsEmpty() should true for the default of Country.</summary>
+    [Test]
+    public void IsEmpty_Default_IsTrue()
+    {
+        Assert.IsTrue(default(Country).IsEmpty());
+    }
+
+    /// <summary>Country.IsEmpty() should false for the TestStruct.</summary>
+    [Test]
+    public void IsEmpty_Default_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmpty());
+    }
+
+    #endregion
+
+    #region TryParse tests
+
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
+    {
+        string str = null;
+        Assert.IsTrue(Country.TryParse(str, out Country val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
+    {
+        string str = string.Empty;
+        Assert.IsTrue(Country.TryParse(str, out Country val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse "?" should be valid and the result should be Country.Unknown.</summary>
+    [Test]
+    public void TryParse_Questionmark_IsValid()
+    {
+        string str = "?";
+        Assert.IsTrue(Country.TryParse(str, out Country val), "Valid");
+        Assert.IsTrue(val.IsUnknown(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_NullCultureStringValue_IsValid()
+    {
+        string str = "VA";
+        Assert.IsTrue(Country.TryParse(str, null, out Country val), "Valid");
+        Assert.AreEqual(str, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "VA";
+        Assert.IsTrue(Country.TryParse(str, out Country val), "Valid");
+        Assert.AreEqual(str, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "string";
+        Assert.IsFalse(Country.TryParse(str, out Country val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Assert.Catch<FormatException>
+            (() =>
+            {
+                Country.Parse("InvalidInput");
+            },
+            "Not a valid country");
+        }
+    }
+
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = Country.TryParse(exp.ToString());
+
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void from_invalid_as_null_with_TryParse()
+        => Country.TryParse("invalid input").Should().BeNull();
+
+    #endregion
+
+    #region Create tests
+
+    [Test]
+    public void Create_RegionInfoNull_Empty()
+    {
+        var exp = Country.Empty;
+        var act = Country.Create((RegionInfo)null);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Create_CultureInfoNull_Empty()
+    {
+        var exp = Country.Empty;
+        var act = Country.Create((CultureInfo)null);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Create_NL_NL()
+    {
+        var exp = Country.NL;
+        var act = Country.Create(new RegionInfo("NL"));
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Create_CultureInfoInvariant_Empty()
+    {
+        var exp = Country.Empty;
+        var act = Country.Create(CultureInfo.InvariantCulture);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Create_CultureInfoEs_Empty()
+    {
+        var exp = Country.Empty;
+        var act = Country.Create(new CultureInfo("es"));
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Create_CultureInfoEsEC_Empty()
+    {
+        var exp = Country.EC;
+        var act = Country.Create(new CultureInfo("es-EC"));
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Create_CS_CSXX()
+    {
+        var cs = new RegionInfo("CS");
+        var country = Country.Create(cs);
+        Assert.AreEqual(Country.CSXX, country);
+    }
+
+    [TestCaseSource(typeof(Country), nameof(Country.All))]
+    public void RegionInfoExists(Country country)
+    {
+        // As the regions available depend on the environment running, we can't
+        // predict the outcome.
+        Assert.IsTrue(new[] { true, false }.Contains(country.RegionInfoExists));
+    }
+
+    #endregion
+
+    #region (XML) (De)serialization tests
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(Country), new System.Runtime.Serialization.FormatterConverter());
+        obj.GetObjectData(info, default);
+
+        Assert.AreEqual("VA", info.GetString("Value"));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = CountryTest.TestStruct;
+        var exp = CountryTest.TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = CountryTest.TestStruct;
+        var exp = CountryTest.TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "VA";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<Country>("VA");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_CountrySerializeObject_AreEqual()
+    {
+        var input = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = CountryTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = CountryTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_CountrySerializeObject_AreEqual()
+    {
+        var input = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = CountryTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = CountryTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_CountrySerializeObject_AreEqual()
+    {
+        var input = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = CountryTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = CountryTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = Country.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = Country.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = Country.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new CountrySerializeObject
+        {
+            Id = 17,
+            Obj = Country.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    #endregion
+
+    #region IFormattable / ToString tests
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("e (3)", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: 'Holy See (VAT)', format: 'e (3)'";
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_Empty_IsStringEmpty()
+    {
+        var act = Country.Empty.ToString();
+        var exp = "";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_Unknown_Questionmark()
+    {
+        var act = Country.Unknown.ToString();
+        var exp = "?";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString2_NZ_AreEqual()
+    {
+        var exp = "MZ";
+        var act = Country.MZ.ToString("2");
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString3_MZ_AreEqual()
+    {
+        var exp = "MOZ";
+        var act = Country.MZ.ToString("3", new CultureInfo("ja-JP"));
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString0_MZ_AreEqual()
+    {
+        var exp = "508";
+        var act = Country.MZ.ToString("0", new CultureInfo("ja-JP"));
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToStringN_CSHH_AreEqual()
+    {
+        var exp = "CSHH";
+        var act = Country.CSHH.ToString("n", new CultureInfo("ja-JP"));
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToStringE_MZ_AreEqual()
+    {
+        var exp = "Mozambique";
+        var act = Country.MZ.ToString("e", new CultureInfo("ja-JP"));
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToStringF_MZ_AreEqual()
+    {
+        var exp = "モザンビーク";
+        var act = Country.MZ.ToString("f", new CultureInfo("ja-JP"));
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IEquatable tests
+
+    /// <summary>GetHash should not fail for Country.Empty.</summary>
+    [Test]
+    public void GetHash_Empty_Hash()
+    {
+        Assert.AreEqual(0, Country.Empty.GetHashCode());
+    }
+
+    /// <summary>GetHash should not fail for the test struct.</summary>
+    [Test]
+    public void GetHash_TestStruct_NotZero()
+    {
+        Assert.NotZero(TestStruct.GetHashCode());
+    }
+
+    [Test]
+    public void Equals_EmptyEmpty_IsTrue()
+    {
+        Assert.IsTrue(Country.Empty.Equals(Country.Empty));
+    }
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        using (TestCultures.Nl_NL.Scoped())
+        {
+            var l = Country.Parse("België");
+            var r = Country.Parse("belgie");
+
+            Assert.IsTrue(l.Equals(r));
+        }
+    }
+
+    [Test]
+    public void Equals_TestStructTestStruct_IsTrue()
+    {
+        Assert.IsTrue(CountryTest.TestStruct.Equals(CountryTest.TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructEmpty_IsFalse()
+    {
+        Assert.IsFalse(CountryTest.TestStruct.Equals(Country.Empty));
+    }
+
+    [Test]
+    public void Equals_EmptyTestStruct_IsFalse()
+    {
+        Assert.IsFalse(Country.Empty.Equals(CountryTest.TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructObjectTestStruct_IsTrue()
+    {
+        Assert.IsTrue(CountryTest.TestStruct.Equals((object)CountryTest.TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructNull_IsFalse()
+    {
+        Assert.IsFalse(CountryTest.TestStruct.Equals(null));
+    }
+
+    [Test]
+    public void Equals_TestStructObject_IsFalse()
+    {
+        Assert.IsFalse(CountryTest.TestStruct.Equals(new object()));
+    }
+
+    [Test]
+    public void OperatorIs_TestStructTestStruct_IsTrue()
+    {
+        var l = CountryTest.TestStruct;
+        var r = CountryTest.TestStruct;
+        Assert.IsTrue(l == r);
+    }
+
+    [Test]
+    public void OperatorIsNot_TestStructTestStruct_IsFalse()
+    {
+        var l = CountryTest.TestStruct;
+        var r = CountryTest.TestStruct;
+        Assert.IsFalse(l != r);
+    }
+
+    #endregion
+
+    #region IComparable tests
+
+    /// <summary>Orders a list of Countrys ascending.</summary>
+    [Test]
+    public void OrderBy_Country_AreEqual()
+    {
+        var item0 = Country.AE;
+        var item1 = Country.BE;
+        var item2 = Country.CU;
+        var item3 = Country.DO;
+
+        var inp = new List<Country> { Country.Empty, item3, item2, item0, item1, Country.Empty };
+        var exp = new List<Country> { Country.Empty, Country.Empty, item0, item1, item2, item3 };
+        var act = inp.OrderBy(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Orders a list of Countrys descending.</summary>
+    [Test]
+    public void OrderByDescending_Country_AreEqual()
+    {
+        var item0 = Country.AE;
+        var item1 = Country.BE;
+        var item2 = Country.CU;
+        var item3 = Country.DO;
+
+        var inp = new List<Country> { Country.Empty, item3, item2, item0, item1, Country.Empty };
+        var exp = new List<Country> { item3, item2, item1, item0, Country.Empty, Country.Empty };
+        var act = inp.OrderByDescending(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with a to object casted instance should be fine.</summary>
+    [Test]
+    public void CompareTo_ObjectTestStruct_0()
+    {
+        object other = TestStruct;
+
+        var exp = 0;
+        var act = TestStruct.CompareTo(other);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with null should return 1.</summary>
+    [Test]
+    public void CompareTo_null_1()
+    {
+        object @null = null;
+        Assert.AreEqual(1, TestStruct.CompareTo(@null));
+    }
+
+    /// <summary>Compare with a random object should throw an exception.</summary>
+    [Test]
+    public void CompareTo_newObject_ThrowsArgumentException()
+    {
+        Func<int> compare = () => TestStruct.CompareTo(new object());
+        compare.Should().Throw<ArgumentException>();
+    }
+    #endregion
+
+    #region Casting tests
+
+    [Test]
+    public void Implicit_RegionInfoToCountry_AreEqual()
+    {
+        Country exp = Country.NL;
+        Country act = new RegionInfo("NL");
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Explicit_CountryToRegionInfo_AreEqual()
+    {
+        var exp = new RegionInfo("NL");
+        var act = (RegionInfo)Country.NL;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region Properties
+
+    [Test]
+    public void CallingCode_Empty_AreEqual()
+    {
+        var exp = "";
+        var act = Country.Empty.CallingCode;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void CallingCode_Unknown_AreEqual()
+    {
+        var exp = "";
+        var act = Country.Unknown.CallingCode;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void CallingCode_TestStruct_AreEqual()
+    {
+        var exp = "+379";
+        var act = TestStruct.CallingCode;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Name_Empty_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = "";
+            var act = Country.Empty.Name;
+            Assert.AreEqual(exp, act);
+        }
+    }
+    [Test]
+    public void Name_Unknown_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = "?";
+            var act = Country.Unknown.Name;
+            Assert.AreEqual(exp, act);
+        }
+    }
+    [Test]
+    public void Name_TestStruct_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = "VA";
+            var act = TestStruct.Name;
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void DisplayName_Empty_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = "";
+            var act = Country.Empty.DisplayName;
+            Assert.AreEqual(exp, act);
+        }
+    }
+    [Test]
+    public void DisplayName_Unknown_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = "Unknown";
+            var act = Country.Unknown.DisplayName;
+            Assert.AreEqual(exp, act);
+        }
+    }
+    [Test]
+    public void DisplayName_TestStruct_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = "Holy See";
+            var act = TestStruct.DisplayName;
+            Assert.AreEqual(exp, act);
+        }
+    }
+    [Test]
+    public void GetDisplayName_TestStruct_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = "Holy See";
+            var act = TestStruct.GetDisplayName(null);
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void IsoNumericCode_Empty_AreEqual()
+    {
+        var exp = 0;
+        var act = Country.Empty.IsoNumericCode;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void IsoNumericCode_Unknown_AreEqual()
+    {
+        var exp = 999;
+        var act = Country.Unknown.IsoNumericCode;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void IsoNumericCode_TestStruct_AreEqual()
+    {
+        var exp = 336;
+        var act = TestStruct.IsoNumericCode;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void StartDate_Empty_AreEqual()
+    {
+        var exp = Date.MinValue;
+        var act = Country.Empty.StartDate;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void StartDate_Unknown_AreEqual()
+    {
+        var exp = Date.MinValue;
+        var act = Country.Unknown.StartDate;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void StartDate_TestStruct_AreEqual()
+    {
+        var exp = new Date(1974, 01, 01);
+        var act = TestStruct.StartDate;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void StartDate_CZ_AreEqual()
+    {
+        var exp = new Date(1993, 01, 01);
+        var act = Country.CZ.StartDate;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void EndDate_Empty_AreEqual()
+    {
+        DateTime? exp = null;
+        var act = Country.Empty.EndDate;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void EndDate_Unknown_AreEqual()
+    {
+        DateTime? exp = null;
+        var act = Country.Unknown.EndDate;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void EndDate_TestStruct_AreEqual()
+    {
+        DateTime? exp = null;
+        var act = TestStruct.EndDate;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void EndDate_CZ_AreEqual()
+    {
+        DateTime? exp = null;
+        var act = Country.CZ.EndDate;
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void EndDate_CSHH_AreEqual()
+    {
+        var exp = new Date(1992, 12, 31);
+        var act = Country.CSHH.EndDate;
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region Methods
+
+    [Test]
+    public void IsEmptyOrNotKnown_Empty_IsTrue()
+    {
+        Assert.IsTrue(Country.Empty.IsEmptyOrUnknown());
+    }
+
+    [Test]
+    public void IsEmptyOrNotKnown_NotKnown_IsTrue()
+    {
+        Assert.IsTrue(Country.Unknown.IsEmptyOrUnknown());
+    }
+
+    [Test]
+    public void IsEmptyOrNotKnown_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmptyOrUnknown());
+    }
+
+    [Test]
+    public void ExistsOnDate_SerbiaAndMontenegro1992_IsFalse()
+    {
+        Assert.IsFalse(Country.CSXX.ExistsOnDate(new Date(1992, 12, 31)));
+    }
+    [Test]
+    public void ExistsOnDate_SerbiaAndMontenegro1993_IsTrue()
+    {
+        Assert.IsTrue(Country.CSXX.ExistsOnDate(new Date(1993, 01, 01)));
+    }
+    [Test]
+    public void ExistsOnDate_SerbiaAndMontenegro2012_IsFalse()
+    {
+        Assert.IsFalse(Country.CSXX.ExistsOnDate(new Date(2012, 01, 01)));
+    }
+
+    /// <remarks>
+    /// On 1980, Burkina Faso did not yet exist.
+    /// </remarks>
+    [Test]
+    public void GetCurrency_BF1980_Empty()
+    {
+        var currency = Country.BF.GetCurrency(new Date(1980, 01, 01));
+        Assert.AreEqual(Currency.Empty, currency);
+    }
+
+    [Test]
+    public void GetCurrency_NL2001_NLG()
+    {
+        var act = Country.NL.GetCurrency(new Date(2001, 12, 31));
+        var exp = Currency.NLG;
+
+        Assert.AreEqual(act, exp);
+    }
+
+    [Test]
+    public void GetCurrency_NLToday_EUR()
+    {
+        var act = Country.NL.GetCurrency(Clock.Today());
+        var exp = Currency.EUR;
+
+        Assert.AreEqual(act, exp);
+    }
+
+    #endregion
+
+    #region IsValid tests
+
+    [Test]
+    public void IsValid_Data_IsFalse()
+    {
+        Assert.IsFalse(Country.IsValid("Complex"), "Complex");
+        Assert.IsFalse(Country.IsValid((String)null), "(String)null");
+        Assert.IsFalse(Country.IsValid(string.Empty), "string.Empty");
+    }
+    [Test]
+    public void IsValid_Data_IsTrue()
+    {
+        Assert.IsTrue(Country.IsValid("China", null));
+    }
+    #endregion
+
+    #region Collection tests
+
+    [Test]
+    public void GetCurrent_1973_0()
+    {
+        var exp = 0;
+
+        // before the ISO standard was introduced.
+        var act = Country.GetExisting(new Date(1973, 12, 31)).ToList();
+
+        Assert.AreEqual(exp, act.Count);
+    }
+
+    [Test]
+    public void GetCurrent_None_250()
+    {
+        var exp = 250;
+        var act = Country.GetExisting().ToList();
+
+        Assert.AreEqual(exp, act.Count);
+    }
+
+    #endregion
+}
+
+[Serializable]
+public class CountrySerializeObject
+{
+    public int Id { get; set; }
+    public Country Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
@@ -1,749 +1,682 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Globalization;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests;
 
-namespace Qowaiv.UnitTests
+/// <summary>Tests the house number SVO.</summary>
+[TestFixture]
+public class HouseNumberTest
 {
-    /// <summary>Tests the house number SVO.</summary>
-    [TestFixture]
-    public class HouseNumberTest
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly HouseNumber TestStruct = 123456789L;
+
+    #region house number const tests
+
+    /// <summary>HouseNumber.Empty should be equal to the default of house number.</summary>
+    [Test]
+    public void Empty_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly HouseNumber TestStruct = 123456789L;
+        Assert.AreEqual(default(HouseNumber), HouseNumber.Empty);
+    }
 
-        #region house number const tests
+    [Test]
+    public void MinValue_None_1()
+    {
+        Assert.AreEqual(HouseNumber.Create(1), HouseNumber.MinValue);
+    }
 
-        /// <summary>HouseNumber.Empty should be equal to the default of house number.</summary>
-        [Test]
-        public void Empty_None_EqualsDefault()
+    [Test]
+    public void MaxValue_None_999999999()
+    {
+        Assert.AreEqual(HouseNumber.Create(999999999), HouseNumber.MaxValue);
+    }
+
+    #endregion
+
+    #region house number IsEmpty tests
+
+    /// <summary>HouseNumber.IsEmpty() should be true for the default of house number.</summary>
+    [Test]
+    public void IsEmpty_Default_IsTrue()
+    {
+        Assert.IsTrue(default(HouseNumber).IsEmpty());
+    }
+    /// <summary>HouseNumber.IsEmpty() should be false for HouseNumber.Unknown.</summary>
+    [Test]
+    public void IsEmpty_Unknown_IsFalse()
+    {
+        Assert.IsFalse(HouseNumber.Unknown.IsEmpty());
+    }
+    /// <summary>HouseNumber.IsEmpty() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsEmpty_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmpty());
+    }
+
+    /// <summary>HouseNumber.IsUnknown() should be false for the default of house number.</summary>
+    [Test]
+    public void IsUnknown_Default_IsFalse()
+    {
+        Assert.IsFalse(default(HouseNumber).IsUnknown());
+    }
+    /// <summary>HouseNumber.IsUnknown() should be true for HouseNumber.Unknown.</summary>
+    [Test]
+    public void IsUnknown_Unknown_IsTrue()
+    {
+        Assert.IsTrue(HouseNumber.Unknown.IsUnknown());
+    }
+    /// <summary>HouseNumber.IsUnknown() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsUnknown_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsUnknown());
+    }
+
+    /// <summary>HouseNumber.IsEmptyOrUnknown() should be true for the default of house number.</summary>
+    [Test]
+    public void IsEmptyOrUnknown_Default_IsFalse()
+    {
+        Assert.IsTrue(default(HouseNumber).IsEmptyOrUnknown());
+    }
+    /// <summary>HouseNumber.IsEmptyOrUnknown() should be true for HouseNumber.Unknown.</summary>
+    [Test]
+    public void IsEmptyOrUnknown_Unknown_IsTrue()
+    {
+        Assert.IsTrue(HouseNumber.Unknown.IsEmptyOrUnknown());
+    }
+    /// <summary>HouseNumber.IsEmptyOrUnknown() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsEmptyOrUnknown_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmptyOrUnknown());
+    }
+
+    #endregion
+
+    #region TryParse tests
+
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
+    {
+        string str = null;
+
+        Assert.IsTrue(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
+    {
+        string str = string.Empty;
+
+        Assert.IsTrue(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse "?" should be valid and the result should be HouseNumber.Unknown.</summary>
+    [Test]
+    public void TryParse_Questionmark_IsValid()
+    {
+        string str = "?";
+
+        Assert.IsTrue(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
+        Assert.IsTrue(val.IsUnknown(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "123";
+
+        Assert.IsTrue(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
+        Assert.AreEqual(str, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "string";
+
+        Assert.IsFalse(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
+        Assert.AreEqual(string.Empty, val.ToString(), "Value");
+    }
+
+    [Test]
+    public void Parse_Unknown_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(default(HouseNumber), HouseNumber.Empty);
-        }
-
-        [Test]
-        public void MinValue_None_1()
-        {
-            Assert.AreEqual(HouseNumber.Create(1), HouseNumber.MinValue);
-        }
-
-        [Test]
-        public void MaxValue_None_999999999()
-        {
-            Assert.AreEqual(HouseNumber.Create(999999999), HouseNumber.MaxValue);
-        }
-
-        #endregion
-
-        #region house number IsEmpty tests
-
-        /// <summary>HouseNumber.IsEmpty() should be true for the default of house number.</summary>
-        [Test]
-        public void IsEmpty_Default_IsTrue()
-        {
-            Assert.IsTrue(default(HouseNumber).IsEmpty());
-        }
-        /// <summary>HouseNumber.IsEmpty() should be false for HouseNumber.Unknown.</summary>
-        [Test]
-        public void IsEmpty_Unknown_IsFalse()
-        {
-            Assert.IsFalse(HouseNumber.Unknown.IsEmpty());
-        }
-        /// <summary>HouseNumber.IsEmpty() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsEmpty_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmpty());
-        }
-
-        /// <summary>HouseNumber.IsUnknown() should be false for the default of house number.</summary>
-        [Test]
-        public void IsUnknown_Default_IsFalse()
-        {
-            Assert.IsFalse(default(HouseNumber).IsUnknown());
-        }
-        /// <summary>HouseNumber.IsUnknown() should be true for HouseNumber.Unknown.</summary>
-        [Test]
-        public void IsUnknown_Unknown_IsTrue()
-        {
-            Assert.IsTrue(HouseNumber.Unknown.IsUnknown());
-        }
-        /// <summary>HouseNumber.IsUnknown() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsUnknown_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsUnknown());
-        }
-
-        /// <summary>HouseNumber.IsEmptyOrUnknown() should be true for the default of house number.</summary>
-        [Test]
-        public void IsEmptyOrUnknown_Default_IsFalse()
-        {
-            Assert.IsTrue(default(HouseNumber).IsEmptyOrUnknown());
-        }
-        /// <summary>HouseNumber.IsEmptyOrUnknown() should be true for HouseNumber.Unknown.</summary>
-        [Test]
-        public void IsEmptyOrUnknown_Unknown_IsTrue()
-        {
-            Assert.IsTrue(HouseNumber.Unknown.IsEmptyOrUnknown());
-        }
-        /// <summary>HouseNumber.IsEmptyOrUnknown() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsEmptyOrUnknown_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmptyOrUnknown());
-        }
-
-        #endregion
-
-        #region TryParse tests
-
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            string str = null;
-
-            Assert.IsTrue(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            string str = string.Empty;
-
-            Assert.IsTrue(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse "?" should be valid and the result should be HouseNumber.Unknown.</summary>
-        [Test]
-        public void TryParse_Questionmark_IsValid()
-        {
-            string str = "?";
-
-            Assert.IsTrue(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
-            Assert.IsTrue(val.IsUnknown(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            string str = "123";
-
-            Assert.IsTrue(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
-            Assert.AreEqual(str, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
-        {
-            string str = "string";
-
-            Assert.IsFalse(HouseNumber.TryParse(str, out HouseNumber val), "Valid");
-            Assert.AreEqual(string.Empty, val.ToString(), "Value");
-        }
-
-        [Test]
-        public void Parse_Unknown_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var act = HouseNumber.Parse("?");
-                var exp = HouseNumber.Unknown;
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Assert.Catch<FormatException>
-                (() =>
-                {
-                    HouseNumber.Parse("InvalidInput");
-                },
-                "Not a valid house number");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = HouseNumber.TryParse(exp.ToString());
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void from_invalid_as_null_with_TryParse()
-            => HouseNumber.TryParse("invalid input").Should().BeNull();
-
-        #endregion
-
-        #region TryCreate tests
-
-        [Test]
-        public void TryCreate_Null_IsEmpty()
-        {
-            HouseNumber exp = HouseNumber.Empty;
-            Assert.IsTrue(HouseNumber.TryCreate(null, out HouseNumber act));
+            var act = HouseNumber.Parse("?");
+            var exp = HouseNumber.Unknown;
             Assert.AreEqual(exp, act);
         }
-        [Test]
-        public void TryCreate_Int32MinValue_IsEmpty()
-        {
-            HouseNumber exp = HouseNumber.Empty;
-            Assert.IsFalse(HouseNumber.TryCreate(Int32.MinValue, out HouseNumber act));
-            Assert.AreEqual(exp, act);
-        }
+    }
 
-        [Test]
-        public void TryCreate_Int32MinValue_AreEqual()
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
         {
-            var exp = HouseNumber.Empty;
-            var act = HouseNumber.TryCreate(Int32.MinValue);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void TryCreate_Value_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = HouseNumber.TryCreate(123456789);
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region (XML) (De)serialization tests
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(HouseNumber), new System.Runtime.Serialization.FormatterConverter());
-            obj.GetObjectData(info, default);
-
-            Assert.AreEqual(123456789, info.GetInt32("Value"));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "123456789";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<HouseNumber>("123456789");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_HouseNumberSerializeObject_AreEqual()
-        {
-            var input = new HouseNumberSerializeObject
+            Assert.Catch<FormatException>
+            (() =>
             {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new HouseNumberSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_HouseNumberSerializeObject_AreEqual()
-        {
-            var input = new HouseNumberSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new HouseNumberSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_HouseNumberSerializeObject_AreEqual()
-        {
-            var input = new HouseNumberSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new HouseNumberSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new HouseNumberSerializeObject
-            {
-                Id = 17,
-                Obj = HouseNumber.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new HouseNumberSerializeObject
-            {
-                Id = 17,
-                Obj = HouseNumber.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new HouseNumberSerializeObject
-            {
-                Id = 17,
-                Obj = HouseNumber.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new HouseNumberSerializeObject
-            {
-                Id = 17,
-                Obj = HouseNumber.Empty,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [Test]
-        public void FromJson_InvalidStringValue_AssertFormatException()
-        {
-            Assert.Catch<FormatException>(() =>
-            {
-                JsonTester.Read<HouseNumber>("InvalidStringValue");
+                HouseNumber.Parse("InvalidInput");
             },
             "Not a valid house number");
         }
-        [Test]
-        public void FromJson_StringValue_AreEqual()
-        {
-            var act = JsonTester.Read<HouseNumber>("123456789");
-            var exp = TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void FromJson_Int64Value_AreEqual()
-        {
-            var act = JsonTester.Read<HouseNumber>(123456789L);
-            var exp = TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void FromJson_DoubleValue_AreEqual()
-        {
-            var act = JsonTester.Read<HouseNumber>((Double)TestStruct);
-            var exp = TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_IsNull()
-        {
-            object act = JsonTester.Write(default(HouseNumber));
-            Assert.IsNull(act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "123456789";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IFormattable / Tostring tests
-
-        [Test]
-        public void ToString_Empty_IsStringEmpty()
-        {
-            var act = HouseNumber.Empty.ToString();
-            var exp = "";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_Unknown_QuestionMark()
-        {
-            var act = HouseNumber.Unknown.ToString();
-            var exp = "?";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("#,##0", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: '123,456,789', format: '#,##0'";
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_TestStruct_ComplexPattern()
-        {
-            var act = TestStruct.ToString("");
-            var exp = "123456789";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_FormatValueDutchBelgium_AreEqual()
-        {
-            using (TestCultures.Nl_BE.Scoped())
-            {
-                var act = HouseNumber.Parse("800").ToString("0000");
-                var exp = "0800";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_FormatValueEnglishGreatBritain_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var act = HouseNumber.Parse("800").ToString("0000");
-                var exp = "0800";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_FormatValueSpanishEcuador_AreEqual()
-        {
-            var act = HouseNumber.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
-            var exp = "01700,0";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IComparable tests
-
-        /// <summary>Orders a list of house numbers ascending.</summary>
-        [Test]
-        public void OrderBy_HouseNumber_AreEqual()
-        {
-            HouseNumber item0 = 1;
-            HouseNumber item1 = 12;
-            HouseNumber item2 = 123;
-            HouseNumber item3 = 1234;
-
-            var inp = new List<HouseNumber> { HouseNumber.Empty, item3, item2, item0, item1, HouseNumber.Empty };
-            var exp = new List<HouseNumber> { HouseNumber.Empty, HouseNumber.Empty, item0, item1, item2, item3 };
-            var act = inp.OrderBy(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Orders a list of house numbers descending.</summary>
-        [Test]
-        public void OrderByDescending_HouseNumber_AreEqual()
-        {
-            HouseNumber item0 = 1;
-            HouseNumber item1 = 12;
-            HouseNumber item2 = 123;
-            HouseNumber item3 = 1234;
-
-            var inp = new List<HouseNumber> { HouseNumber.Empty, item3, item2, item0, item1, HouseNumber.Empty };
-            var exp = new List<HouseNumber> { item3, item2, item1, item0, HouseNumber.Empty, HouseNumber.Empty };
-            var act = inp.OrderByDescending(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with a to object casted instance should be fine.</summary>
-        [Test]
-        public void CompareTo_ObjectTestStruct_0()
-        {
-            object other = TestStruct;
-
-            var exp = 0;
-            var act = TestStruct.CompareTo(other);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with null should return 1.</summary>
-        [Test]
-        public void CompareTo_null_1()
-        {
-            object @null = null;
-            Assert.AreEqual(1, TestStruct.CompareTo(@null));
-        }
-
-        /// <summary>Compare with a random object should throw an exception.</summary>
-        [Test]
-        public void CompareTo_newObject_ThrowsArgumentException()
-        {
-            Func<int> compare = () => TestStruct.CompareTo(new object());
-            compare.Should().Throw<ArgumentException>();
-        }
-
-        [Test]
-        public void LessThan_17LT19_IsTrue()
-        {
-            HouseNumber l = 17;
-            HouseNumber r = 19;
-
-            Assert.IsTrue(l < r);
-        }
-        [Test]
-        public void GreaterThan_21LT19_IsTrue()
-        {
-            HouseNumber l = 21;
-            HouseNumber r = 19;
-
-            Assert.IsTrue(l > r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT19_IsTrue()
-        {
-            HouseNumber l = 17;
-            HouseNumber r = 19;
-
-            Assert.IsTrue(l <= r);
-        }
-        [Test]
-        public void GreaterThanOrEqual_21LT19_IsTrue()
-        {
-            HouseNumber l = 21;
-            HouseNumber r = 19;
-
-            Assert.IsTrue(l >= r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT17_IsTrue()
-        {
-            HouseNumber l = 17;
-            HouseNumber r = 17;
-
-            Assert.IsTrue(l <= r);
-        }
-        [Test]
-        public void GreaterThanOrEqual_21LT21_IsTrue()
-        {
-            HouseNumber l = 21;
-            HouseNumber r = 21;
-
-            Assert.IsTrue(l >= r);
-        }
-        #endregion
-
-        #region Casting tests
-
-        [Test]
-        public void Explicit_Int32ToHouseNumber_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (HouseNumber)123456789;
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_HouseNumberToInt32_AreEqual()
-        {
-            var exp = 123456789;
-            var act = (Int32)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-        #endregion
-
-        #region Properties
-
-        [Test]
-        public void IsOdd_Empty_IsFalse()
-        {
-            Assert.IsFalse(HouseNumber.Empty.IsOdd);
-        }
-
-        [Test]
-        public void IsOdd_Unknown_IsFalse()
-        {
-            Assert.IsFalse(HouseNumber.Unknown.IsOdd);
-        }
-
-        [Test]
-        public void IsOdd_TestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.IsOdd);
-        }
-
-        [Test]
-        public void IsEven_Empty_IsFalse()
-        {
-            Assert.IsFalse(HouseNumber.Empty.IsEven);
-        }
-
-        [Test]
-        public void IsEven_Unknown_IsFalse()
-        {
-            Assert.IsFalse(HouseNumber.Unknown.IsEven);
-        }
-
-        [Test]
-        public void IsEven_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEven);
-        }
-
-        [Test]
-        public void IsEven_1234_IsTrue()
-        {
-            Assert.IsTrue(HouseNumber.Create(1234).IsEven);
-        }
-
-
-        [Test]
-        public void Length_Empty_0()
-        {
-            var act = HouseNumber.Empty.Length;
-            var exp = 0;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Length_Unknown_0()
-        {
-            var act = HouseNumber.Unknown.Length;
-            var exp = 0;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Length_TestStruct_9()
-        {
-            var act = TestStruct.Length;
-            var exp = 9;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Length_1234_4()
-        {
-            var act = HouseNumber.Create(1234).Length;
-            var exp = 4;
-            Assert.AreEqual(exp, act);
-        }
-        #endregion
-
-        #region IsValid tests
-
-        [Test]
-        public void IsValid_Data_IsFalse()
-        {
-            Assert.IsFalse(HouseNumber.IsValid("1234567890"), "1234567890");
-            Assert.IsFalse(HouseNumber.IsValid((String)null), "(String)null");
-            Assert.IsFalse(HouseNumber.IsValid(string.Empty), "string.Empty");
-
-            Assert.IsFalse(HouseNumber.IsValid((System.Int32?)null), "(System.Int32?)null");
-        }
-        [Test]
-        public void IsValid_Data_IsTrue()
-        {
-            Assert.IsTrue(HouseNumber.IsValid("123456"));
-        }
-        #endregion
     }
 
-    [Serializable]
-    public class HouseNumberSerializeObject
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
     {
-        public int Id { get; set; }
-        public HouseNumber Obj { get; set; }
-        public DateTime Date { get; set; }
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = HouseNumber.TryParse(exp.ToString());
+
+            Assert.AreEqual(exp, act);
+        }
     }
+
+    [Test]
+    public void from_invalid_as_null_with_TryParse()
+        => HouseNumber.TryParse("invalid input").Should().BeNull();
+
+    #endregion
+
+    #region TryCreate tests
+
+    [Test]
+    public void TryCreate_Null_IsEmpty()
+    {
+        HouseNumber exp = HouseNumber.Empty;
+        Assert.IsTrue(HouseNumber.TryCreate(null, out HouseNumber act));
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void TryCreate_Int32MinValue_IsEmpty()
+    {
+        HouseNumber exp = HouseNumber.Empty;
+        Assert.IsFalse(HouseNumber.TryCreate(Int32.MinValue, out HouseNumber act));
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void TryCreate_Int32MinValue_AreEqual()
+    {
+        var exp = HouseNumber.Empty;
+        var act = HouseNumber.TryCreate(Int32.MinValue);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void TryCreate_Value_AreEqual()
+    {
+        var exp = TestStruct;
+        var act = HouseNumber.TryCreate(123456789);
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region (XML) (De)serialization tests
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(HouseNumber), new System.Runtime.Serialization.FormatterConverter());
+        obj.GetObjectData(info, default);
+
+        Assert.AreEqual(123456789, info.GetInt32("Value"));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "123456789";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<HouseNumber>("123456789");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_HouseNumberSerializeObject_AreEqual()
+    {
+        var input = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_HouseNumberSerializeObject_AreEqual()
+    {
+        var input = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_HouseNumberSerializeObject_AreEqual()
+    {
+        var input = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = HouseNumber.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = HouseNumber.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = HouseNumber.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new HouseNumberSerializeObject
+        {
+            Id = 17,
+            Obj = HouseNumber.Empty,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    #endregion
+
+    #region IFormattable / Tostring tests
+
+    [Test]
+    public void ToString_Empty_IsStringEmpty()
+    {
+        var act = HouseNumber.Empty.ToString();
+        var exp = "";
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_Unknown_QuestionMark()
+    {
+        var act = HouseNumber.Unknown.ToString();
+        var exp = "?";
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("#,##0", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: '123,456,789', format: '#,##0'";
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_TestStruct_ComplexPattern()
+    {
+        var act = TestStruct.ToString("");
+        var exp = "123456789";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_FormatValueDutchBelgium_AreEqual()
+    {
+        using (TestCultures.Nl_BE.Scoped())
+        {
+            var act = HouseNumber.Parse("800").ToString("0000");
+            var exp = "0800";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_FormatValueEnglishGreatBritain_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var act = HouseNumber.Parse("800").ToString("0000");
+            var exp = "0800";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_FormatValueSpanishEcuador_AreEqual()
+    {
+        var act = HouseNumber.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
+        var exp = "01700,0";
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IComparable tests
+
+    /// <summary>Orders a list of house numbers ascending.</summary>
+    [Test]
+    public void OrderBy_HouseNumber_AreEqual()
+    {
+        HouseNumber item0 = 1;
+        HouseNumber item1 = 12;
+        HouseNumber item2 = 123;
+        HouseNumber item3 = 1234;
+
+        var inp = new List<HouseNumber> { HouseNumber.Empty, item3, item2, item0, item1, HouseNumber.Empty };
+        var exp = new List<HouseNumber> { HouseNumber.Empty, HouseNumber.Empty, item0, item1, item2, item3 };
+        var act = inp.OrderBy(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Orders a list of house numbers descending.</summary>
+    [Test]
+    public void OrderByDescending_HouseNumber_AreEqual()
+    {
+        HouseNumber item0 = 1;
+        HouseNumber item1 = 12;
+        HouseNumber item2 = 123;
+        HouseNumber item3 = 1234;
+
+        var inp = new List<HouseNumber> { HouseNumber.Empty, item3, item2, item0, item1, HouseNumber.Empty };
+        var exp = new List<HouseNumber> { item3, item2, item1, item0, HouseNumber.Empty, HouseNumber.Empty };
+        var act = inp.OrderByDescending(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with a to object casted instance should be fine.</summary>
+    [Test]
+    public void CompareTo_ObjectTestStruct_0()
+    {
+        object other = TestStruct;
+
+        var exp = 0;
+        var act = TestStruct.CompareTo(other);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with null should return 1.</summary>
+    [Test]
+    public void CompareTo_null_1()
+    {
+        object @null = null;
+        Assert.AreEqual(1, TestStruct.CompareTo(@null));
+    }
+
+    /// <summary>Compare with a random object should throw an exception.</summary>
+    [Test]
+    public void CompareTo_newObject_ThrowsArgumentException()
+    {
+        Func<int> compare = () => TestStruct.CompareTo(new object());
+        compare.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void LessThan_17LT19_IsTrue()
+    {
+        HouseNumber l = 17;
+        HouseNumber r = 19;
+
+        Assert.IsTrue(l < r);
+    }
+    [Test]
+    public void GreaterThan_21LT19_IsTrue()
+    {
+        HouseNumber l = 21;
+        HouseNumber r = 19;
+
+        Assert.IsTrue(l > r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT19_IsTrue()
+    {
+        HouseNumber l = 17;
+        HouseNumber r = 19;
+
+        Assert.IsTrue(l <= r);
+    }
+    [Test]
+    public void GreaterThanOrEqual_21LT19_IsTrue()
+    {
+        HouseNumber l = 21;
+        HouseNumber r = 19;
+
+        Assert.IsTrue(l >= r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT17_IsTrue()
+    {
+        HouseNumber l = 17;
+        HouseNumber r = 17;
+
+        Assert.IsTrue(l <= r);
+    }
+    [Test]
+    public void GreaterThanOrEqual_21LT21_IsTrue()
+    {
+        HouseNumber l = 21;
+        HouseNumber r = 21;
+
+        Assert.IsTrue(l >= r);
+    }
+    #endregion
+
+    #region Casting tests
+
+    [Test]
+    public void Explicit_Int32ToHouseNumber_AreEqual()
+    {
+        var exp = TestStruct;
+        var act = (HouseNumber)123456789;
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Explicit_HouseNumberToInt32_AreEqual()
+    {
+        var exp = 123456789;
+        var act = (Int32)TestStruct;
+
+        Assert.AreEqual(exp, act);
+    }
+    #endregion
+
+    #region Properties
+
+    [Test]
+    public void IsOdd_Empty_IsFalse()
+    {
+        Assert.IsFalse(HouseNumber.Empty.IsOdd);
+    }
+
+    [Test]
+    public void IsOdd_Unknown_IsFalse()
+    {
+        Assert.IsFalse(HouseNumber.Unknown.IsOdd);
+    }
+
+    [Test]
+    public void IsOdd_TestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.IsOdd);
+    }
+
+    [Test]
+    public void IsEven_Empty_IsFalse()
+    {
+        Assert.IsFalse(HouseNumber.Empty.IsEven);
+    }
+
+    [Test]
+    public void IsEven_Unknown_IsFalse()
+    {
+        Assert.IsFalse(HouseNumber.Unknown.IsEven);
+    }
+
+    [Test]
+    public void IsEven_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEven);
+    }
+
+    [Test]
+    public void IsEven_1234_IsTrue()
+    {
+        Assert.IsTrue(HouseNumber.Create(1234).IsEven);
+    }
+
+
+    [Test]
+    public void Length_Empty_0()
+    {
+        var act = HouseNumber.Empty.Length;
+        var exp = 0;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Length_Unknown_0()
+    {
+        var act = HouseNumber.Unknown.Length;
+        var exp = 0;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Length_TestStruct_9()
+    {
+        var act = TestStruct.Length;
+        var exp = 9;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Length_1234_4()
+    {
+        var act = HouseNumber.Create(1234).Length;
+        var exp = 4;
+        Assert.AreEqual(exp, act);
+    }
+    #endregion
+
+    #region IsValid tests
+
+    [Test]
+    public void IsValid_Data_IsFalse()
+    {
+        Assert.IsFalse(HouseNumber.IsValid("1234567890"), "1234567890");
+        Assert.IsFalse(HouseNumber.IsValid((String)null), "(String)null");
+        Assert.IsFalse(HouseNumber.IsValid(string.Empty), "string.Empty");
+
+        Assert.IsFalse(HouseNumber.IsValid((System.Int32?)null), "(System.Int32?)null");
+    }
+    [Test]
+    public void IsValid_Data_IsTrue()
+    {
+        Assert.IsTrue(HouseNumber.IsValid("123456"));
+    }
+    #endregion
+}
+
+[Serializable]
+public class HouseNumberSerializeObject
+{
+    public int Id { get; set; }
+    public HouseNumber Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
@@ -245,42 +245,6 @@
 
         #endregion
 
-        #region JSON (De)serialization tests
-
-        [TestCase("Invalid input")]
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<StreamSize>(json));
-        }
-        [TestCase(1600, "1600")]
-        [TestCase(17_000_000, "17MB")]
-        [TestCase(1_766, "1.766Kb")]
-        [TestCase(1234, 1234L)]
-        [TestCase(1258, 1258.9)]
-        public void FromJson(StreamSize expected, object json)
-        {
-            var actual = JsonTester.Read<StreamSize>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_IsZero()
-        {
-            object act = JsonTester.Write(default(StreamSize));
-            object exp = 0;
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = 123456789L;
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
         #region IFormattable / ToString tests
 
         [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
@@ -1,539 +1,480 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Globalization;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests;
 
-namespace Qowaiv.UnitTests
+/// <summary>Tests the local date time SVO.</summary>
+public class LocalDateTimeTest
 {
-    /// <summary>Tests the local date time SVO.</summary>
-    public class LocalDateTimeTest
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly LocalDateTime TestStruct = new(1988, 06, 13, 22, 10, 05, 001);
+
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly LocalDateTime TestStructNoMilliseconds = new(2001, 07, 30, 21, 55, 08);
+
+    #region local date time const tests
+
+    /// <summary>LocalDateTime.MinValue should be equal to the default of local date time.</summary>
+    [Test]
+    public void MinValue_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly LocalDateTime TestStruct = new(1988, 06, 13, 22, 10, 05, 001);
+        Assert.AreEqual(default(LocalDateTime), LocalDateTime.MinValue);
+    }
 
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly LocalDateTime TestStructNoMilliseconds = new(2001, 07, 30, 21, 55, 08);
+    #endregion
 
-        #region local date time const tests
+    #region TryParse tests
 
-        /// <summary>LocalDateTime.MinValue should be equal to the default of local date time.</summary>
-        [Test]
-        public void MinValue_None_EqualsDefault()
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsNotValid()
+    {
+        string str = null;
+        Assert.IsFalse(LocalDateTime.TryParse(str, out _), "Valid");
+    }
+
+    /// <summary>TryParse string.MinValue should be valid.</summary>
+    [Test]
+    public void TryParse_StringMinValue_IsNotValid()
+    {
+        string str = string.Empty;
+        Assert.IsFalse(LocalDateTime.TryParse(str, out _), "Valid");
+    }
+
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        using (new CultureInfoScope(TestCultures.Nl_NL))
         {
-            Assert.AreEqual(default(LocalDateTime), LocalDateTime.MinValue);
+            string str = "26-4-2015 17:07:13";
+            Assert.IsTrue(LocalDateTime.TryParse(str, out LocalDateTime val), "Valid");
+            Assert.AreEqual(new LocalDateTime(2015, 04, 26, 17, 07, 13, 000), val, "Value");
         }
+    }
 
-        #endregion
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "invalid format";
+        Assert.IsFalse(LocalDateTime.TryParse(str, out _), "Valid");
+    }
 
-        #region TryParse tests
-
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsNotValid()
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
         {
-            string str = null;
-            Assert.IsFalse(LocalDateTime.TryParse(str, out _), "Valid");
-        }
-
-        /// <summary>TryParse string.MinValue should be valid.</summary>
-        [Test]
-        public void TryParse_StringMinValue_IsNotValid()
-        {
-            string str = string.Empty;
-            Assert.IsFalse(LocalDateTime.TryParse(str, out _), "Valid");
-        }
-
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            using (new CultureInfoScope(TestCultures.Nl_NL))
+            Assert.Catch<FormatException>
+            (() =>
             {
-                string str = "26-4-2015 17:07:13";
-                Assert.IsTrue(LocalDateTime.TryParse(str, out LocalDateTime val), "Valid");
-                Assert.AreEqual(new LocalDateTime(2015, 04, 26, 17, 07, 13, 000), val, "Value");
-            }
-        }
-
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
-        {
-            string str = "invalid format";
-            Assert.IsFalse(LocalDateTime.TryParse(str, out _), "Valid");
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Assert.Catch<FormatException>
-                (() =>
-                {
-                    LocalDateTime.Parse("InvalidInput");
-                },
-                "Not a valid date");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStructNoMilliseconds;
-                var act = LocalDateTime.TryParse(exp.ToString());
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void from_invalid_as_null_with_TryParse()
-            => LocalDateTime.TryParse("invalid input").Should().BeNull();
-
-        #endregion
-
-        #region (XML) (De)serialization tests
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(LocalDateTime), new System.Runtime.Serialization.FormatterConverter());
-            obj.GetObjectData(info, default);
-
-            Assert.AreEqual(new DateTime(1988, 06, 13, 22, 10, 05, 001), info.GetDateTime("Value"));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = LocalDateTimeTest.TestStructNoMilliseconds;
-            var exp = LocalDateTimeTest.TestStructNoMilliseconds;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = LocalDateTimeTest.TestStructNoMilliseconds;
-            var exp = LocalDateTimeTest.TestStructNoMilliseconds;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "1988-06-13 22:10:05.001";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<LocalDateTime>("1988-06-13 22:10:05.001");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
-        {
-            var input = new LocalDateTimeSerializeObject
-            {
-                Id = 17,
-                Obj = LocalDateTimeTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new LocalDateTimeSerializeObject
-            {
-                Id = 17,
-                Obj = LocalDateTimeTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
-        {
-            var input = new LocalDateTimeSerializeObject
-            {
-                Id = 17,
-                Obj = LocalDateTimeTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new LocalDateTimeSerializeObject
-            {
-                Id = 17,
-                Obj = LocalDateTimeTest.TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
-        {
-            var input = new LocalDateTimeSerializeObject
-            {
-                Id = 17,
-                Obj = LocalDateTimeTest.TestStructNoMilliseconds,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new LocalDateTimeSerializeObject
-            {
-                Id = 17,
-                Obj = LocalDateTimeTest.TestStructNoMilliseconds,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_MinValue_AreEqual()
-        {
-            var input = new LocalDateTimeSerializeObject
-            {
-                Id = 17,
-                Obj = LocalDateTime.MinValue,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new LocalDateTimeSerializeObject
-            {
-                Id = 17,
-                Obj = LocalDateTime.MinValue,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [Test]
-        public void FromJson_InvalidStringValue_AssertFormatException()
-        {
-            Assert.Catch<FormatException>(() =>
-            {
-                JsonTester.Read<LocalDateTime>("InvalidStringValue");
+                LocalDateTime.Parse("InvalidInput");
             },
             "Not a valid date");
         }
-        [Test]
-        public void FromJson_StringValue_AreEqual()
-        {
-            var act = JsonTester.Read<LocalDateTime>(TestStructNoMilliseconds.ToString(CultureInfo.InvariantCulture));
-            var exp = TestStructNoMilliseconds;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void FromJson_Int64Value_AreEqual()
-        {
-            var act = JsonTester.Read<LocalDateTime>(627178398050010000L);
-            var exp = TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_AreEqual()
-        {
-            object act = JsonTester.Write(default(LocalDateTime));
-            object exp = "0001-01-01 00:00:00";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "1988-06-13 22:10:05.001";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IFormattable / ToString tests
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("M:d & h:m", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: '6:13 & 10:10', format: 'M:d & h:m'";
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_TestStruct_ComplexPattern()
-        {
-            var act = TestStruct.ToString(@"yyyy-MM-dd\THH:mm:ss.FFFFFFF");
-            var exp = "1988-06-13T22:10:05.001";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IEquatable tests
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var l = LocalDateTime.Parse("14 february 2010", CultureInfo.InvariantCulture);
-                var r = LocalDateTime.Parse("2010-02-14", CultureInfo.InvariantCulture);
-
-                Assert.IsTrue(l.Equals(r));
-            }
-        }
-
-        #endregion
-
-        #region IComparable tests
-
-        /// <summary>Orders a list of local date times ascending.</summary>
-        [Test]
-        public void OrderBy_LocalDateTime_AreEqual()
-        {
-            var item0 = new LocalDateTime(1900, 10, 01, 22, 10, 16);
-            var item1 = new LocalDateTime(1963, 08, 23, 23, 59, 15);
-            var item2 = new LocalDateTime(1999, 12, 05, 04, 13, 14);
-            var item3 = new LocalDateTime(2010, 07, 13, 00, 44, 13);
-
-            var inp = new List<LocalDateTime> { LocalDateTime.MinValue, item3, item2, item0, item1, LocalDateTime.MinValue };
-            var exp = new List<LocalDateTime> { LocalDateTime.MinValue, LocalDateTime.MinValue, item0, item1, item2, item3 };
-            var act = inp.OrderBy(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Orders a list of local date times descending.</summary>
-        [Test]
-        public void OrderByDescending_LocalDateTime_AreEqual()
-        {
-            var item0 = new LocalDateTime(1900, 10, 01, 22, 10, 16);
-            var item1 = new LocalDateTime(1963, 08, 23, 23, 59, 15);
-            var item2 = new LocalDateTime(1999, 12, 05, 04, 13, 14);
-            var item3 = new LocalDateTime(2010, 07, 13, 00, 44, 13);
-
-            var inp = new List<LocalDateTime> { LocalDateTime.MinValue, item3, item2, item0, item1, LocalDateTime.MinValue };
-            var exp = new List<LocalDateTime> { item3, item2, item1, item0, LocalDateTime.MinValue, LocalDateTime.MinValue };
-            var act = inp.OrderByDescending(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with a to object casted instance should be fine.</summary>
-        [Test]
-        public void CompareTo_ObjectTestStruct_0()
-        {
-            object other = TestStruct;
-
-            var exp = 0;
-            var act = TestStruct.CompareTo(other);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with null should return 1.</summary>
-        [Test]
-        public void CompareTo_null_1()
-        {
-            object @null = null;
-            Assert.AreEqual(1, TestStruct.CompareTo(@null));
-        }
-
-        /// <summary>Compare with a random object should throw an exception.</summary>
-        [Test]
-        public void CompareTo_newObject_ThrowsArgumentException()
-        {
-            Func<int> compare = () => TestStruct.CompareTo(new object());
-            compare.Should().Throw<ArgumentException>();
-        }
-
-        #endregion
-
-        #region Properties
-        #endregion
-
-        #region Methods
-
-        [Test]
-        public void Increment_None_AreEqual()
-        {
-            var act = TestStruct;
-            act++;
-            var exp = new LocalDateTime(1988, 06, 14, 22, 10, 05, 001);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Decrement_None_AreEqual()
-        {
-            var act = TestStruct;
-            act--;
-            var exp = new LocalDateTime(1988, 06, 12, 22, 10, 05, 001);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Plus_TimeSpan_AreEqual()
-        {
-            var act = TestStruct + new TimeSpan(25, 30, 15);
-            var exp = new LocalDateTime(1988, 06, 14, 23, 40, 20, 001);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Min_TimeSpan_AreEqual()
-        {
-            var act = TestStruct - new TimeSpan(25, 30, 15);
-            var exp = new LocalDateTime(1988, 06, 12, 20, 39, 50, 001);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Min_LocalDateTimeTime_AreEqual()
-        {
-            var act = TestStruct - new LocalDateTime(1988, 06, 11, 20, 10, 05);
-            var exp = new TimeSpan(2, 02, 00, 00, 001);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void AddTicks_4000001700000_AreEqual()
-        {
-            var act = TestStruct.AddTicks(4000001700000L);
-            var exp = new LocalDateTime(1988, 06, 18, 13, 16, 45, 171);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void AddMilliseconds_Arround3Days_AreEqual()
-        {
-            var act = TestStruct.AddMilliseconds(3 * 24 * 60 * 60 * 1003);
-            var exp = new LocalDateTime(1988, 06, 16, 22, 23, 02, 601);
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void AddSeconds_Arround3Days_AreEqual()
-        {
-            var act = TestStruct.AddSeconds(3 * 24 * 60 * 64);
-            var exp = new LocalDateTime(1988, 06, 17, 02, 58, 05, 001);
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void AddMinutes_2280_AreEqual()
-        {
-            var act = TestStruct.AddMinutes(2 * 24 * 60);
-            var exp = new LocalDateTime(1988, 06, 15, 22, 10, 05, 001);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void AddHours_41_AreEqual()
-        {
-            var act = TestStruct.AddHours(41);
-            var exp = new LocalDateTime(1988, 06, 15, 15, 10, 05, 001);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void AddMonths_12_AreEqual()
-        {
-            var act = TestStruct.AddMonths(12);
-            var exp = new LocalDateTime(1989, 06, 13, 22, 10, 05, 001);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Add_1Year_AreEqual()
-        {
-            var act = TestStruct + MonthSpan.FromYears(1);
-            var exp = new LocalDateTime(1989, 06, 13, 22, 10, 05, 001);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Subtract_1Month_AreEqual()
-        {
-            var act = TestStruct - MonthSpan.FromMonths(1);
-            var exp = new LocalDateTime(1988, 05, 13, 22, 10, 05, 001);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void AddYears_Min12_AreEqual()
-        {
-            var act = TestStruct.AddYears(-12);
-            var exp = new LocalDateTime(1976, 06, 13, 22, 10, 05, 001);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IsValid tests
-
-        [Test]
-        public void IsValid_Data_IsFalse()
-        {
-            Assert.IsFalse(LocalDateTime.IsValid("Complex"), "Complex");
-            Assert.IsFalse(LocalDateTime.IsValid((String)null), "(String)null");
-            Assert.IsFalse(LocalDateTime.IsValid(string.Empty), "String.MinValue");
-        }
-        [Test]
-        public void IsValid_Data_IsTrue()
-        {
-            Assert.IsTrue(LocalDateTime.IsValid("1931-10-10 14:12:03.041", CultureInfo.InvariantCulture));
-        }
-        #endregion
     }
 
-    [Serializable]
-    public class LocalDateTimeSerializeObject
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
     {
-        public int Id { get; set; }
-        public LocalDateTime Obj { get; set; }
-        public DateTime Date { get; set; }
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStructNoMilliseconds;
+            var act = LocalDateTime.TryParse(exp.ToString());
+
+            Assert.AreEqual(exp, act);
+        }
     }
+
+    [Test]
+    public void from_invalid_as_null_with_TryParse()
+        => LocalDateTime.TryParse("invalid input").Should().BeNull();
+
+    #endregion
+
+    #region (XML) (De)serialization tests
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(LocalDateTime), new System.Runtime.Serialization.FormatterConverter());
+        obj.GetObjectData(info, default);
+
+        Assert.AreEqual(new DateTime(1988, 06, 13, 22, 10, 05, 001), info.GetDateTime("Value"));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = LocalDateTimeTest.TestStructNoMilliseconds;
+        var exp = LocalDateTimeTest.TestStructNoMilliseconds;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = LocalDateTimeTest.TestStructNoMilliseconds;
+        var exp = LocalDateTimeTest.TestStructNoMilliseconds;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "1988-06-13 22:10:05.001";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<LocalDateTime>("1988-06-13 22:10:05.001");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
+    {
+        var input = new LocalDateTimeSerializeObject
+        {
+            Id = 17,
+            Obj = LocalDateTimeTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new LocalDateTimeSerializeObject
+        {
+            Id = 17,
+            Obj = LocalDateTimeTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
+    {
+        var input = new LocalDateTimeSerializeObject
+        {
+            Id = 17,
+            Obj = LocalDateTimeTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new LocalDateTimeSerializeObject
+        {
+            Id = 17,
+            Obj = LocalDateTimeTest.TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
+    {
+        var input = new LocalDateTimeSerializeObject
+        {
+            Id = 17,
+            Obj = LocalDateTimeTest.TestStructNoMilliseconds,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new LocalDateTimeSerializeObject
+        {
+            Id = 17,
+            Obj = LocalDateTimeTest.TestStructNoMilliseconds,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_MinValue_AreEqual()
+    {
+        var input = new LocalDateTimeSerializeObject
+        {
+            Id = 17,
+            Obj = LocalDateTime.MinValue,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new LocalDateTimeSerializeObject
+        {
+            Id = 17,
+            Obj = LocalDateTime.MinValue,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    #endregion
+
+    #region IFormattable / ToString tests
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("M:d & h:m", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: '6:13 & 10:10', format: 'M:d & h:m'";
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_TestStruct_ComplexPattern()
+    {
+        var act = TestStruct.ToString(@"yyyy-MM-dd\THH:mm:ss.FFFFFFF");
+        var exp = "1988-06-13T22:10:05.001";
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IEquatable tests
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var l = LocalDateTime.Parse("14 february 2010", CultureInfo.InvariantCulture);
+            var r = LocalDateTime.Parse("2010-02-14", CultureInfo.InvariantCulture);
+
+            Assert.IsTrue(l.Equals(r));
+        }
+    }
+
+    #endregion
+
+    #region IComparable tests
+
+    /// <summary>Orders a list of local date times ascending.</summary>
+    [Test]
+    public void OrderBy_LocalDateTime_AreEqual()
+    {
+        var item0 = new LocalDateTime(1900, 10, 01, 22, 10, 16);
+        var item1 = new LocalDateTime(1963, 08, 23, 23, 59, 15);
+        var item2 = new LocalDateTime(1999, 12, 05, 04, 13, 14);
+        var item3 = new LocalDateTime(2010, 07, 13, 00, 44, 13);
+
+        var inp = new List<LocalDateTime> { LocalDateTime.MinValue, item3, item2, item0, item1, LocalDateTime.MinValue };
+        var exp = new List<LocalDateTime> { LocalDateTime.MinValue, LocalDateTime.MinValue, item0, item1, item2, item3 };
+        var act = inp.OrderBy(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Orders a list of local date times descending.</summary>
+    [Test]
+    public void OrderByDescending_LocalDateTime_AreEqual()
+    {
+        var item0 = new LocalDateTime(1900, 10, 01, 22, 10, 16);
+        var item1 = new LocalDateTime(1963, 08, 23, 23, 59, 15);
+        var item2 = new LocalDateTime(1999, 12, 05, 04, 13, 14);
+        var item3 = new LocalDateTime(2010, 07, 13, 00, 44, 13);
+
+        var inp = new List<LocalDateTime> { LocalDateTime.MinValue, item3, item2, item0, item1, LocalDateTime.MinValue };
+        var exp = new List<LocalDateTime> { item3, item2, item1, item0, LocalDateTime.MinValue, LocalDateTime.MinValue };
+        var act = inp.OrderByDescending(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with a to object casted instance should be fine.</summary>
+    [Test]
+    public void CompareTo_ObjectTestStruct_0()
+    {
+        object other = TestStruct;
+
+        var exp = 0;
+        var act = TestStruct.CompareTo(other);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with null should return 1.</summary>
+    [Test]
+    public void CompareTo_null_1()
+    {
+        object @null = null;
+        Assert.AreEqual(1, TestStruct.CompareTo(@null));
+    }
+
+    /// <summary>Compare with a random object should throw an exception.</summary>
+    [Test]
+    public void CompareTo_newObject_ThrowsArgumentException()
+    {
+        Func<int> compare = () => TestStruct.CompareTo(new object());
+        compare.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
+    #region Properties
+    #endregion
+
+    #region Methods
+
+    [Test]
+    public void Increment_None_AreEqual()
+    {
+        var act = TestStruct;
+        act++;
+        var exp = new LocalDateTime(1988, 06, 14, 22, 10, 05, 001);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Decrement_None_AreEqual()
+    {
+        var act = TestStruct;
+        act--;
+        var exp = new LocalDateTime(1988, 06, 12, 22, 10, 05, 001);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Plus_TimeSpan_AreEqual()
+    {
+        var act = TestStruct + new TimeSpan(25, 30, 15);
+        var exp = new LocalDateTime(1988, 06, 14, 23, 40, 20, 001);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Min_TimeSpan_AreEqual()
+    {
+        var act = TestStruct - new TimeSpan(25, 30, 15);
+        var exp = new LocalDateTime(1988, 06, 12, 20, 39, 50, 001);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Min_LocalDateTimeTime_AreEqual()
+    {
+        var act = TestStruct - new LocalDateTime(1988, 06, 11, 20, 10, 05);
+        var exp = new TimeSpan(2, 02, 00, 00, 001);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void AddTicks_4000001700000_AreEqual()
+    {
+        var act = TestStruct.AddTicks(4000001700000L);
+        var exp = new LocalDateTime(1988, 06, 18, 13, 16, 45, 171);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void AddMilliseconds_Arround3Days_AreEqual()
+    {
+        var act = TestStruct.AddMilliseconds(3 * 24 * 60 * 60 * 1003);
+        var exp = new LocalDateTime(1988, 06, 16, 22, 23, 02, 601);
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void AddSeconds_Arround3Days_AreEqual()
+    {
+        var act = TestStruct.AddSeconds(3 * 24 * 60 * 64);
+        var exp = new LocalDateTime(1988, 06, 17, 02, 58, 05, 001);
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void AddMinutes_2280_AreEqual()
+    {
+        var act = TestStruct.AddMinutes(2 * 24 * 60);
+        var exp = new LocalDateTime(1988, 06, 15, 22, 10, 05, 001);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void AddHours_41_AreEqual()
+    {
+        var act = TestStruct.AddHours(41);
+        var exp = new LocalDateTime(1988, 06, 15, 15, 10, 05, 001);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void AddMonths_12_AreEqual()
+    {
+        var act = TestStruct.AddMonths(12);
+        var exp = new LocalDateTime(1989, 06, 13, 22, 10, 05, 001);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Add_1Year_AreEqual()
+    {
+        var act = TestStruct + MonthSpan.FromYears(1);
+        var exp = new LocalDateTime(1989, 06, 13, 22, 10, 05, 001);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Subtract_1Month_AreEqual()
+    {
+        var act = TestStruct - MonthSpan.FromMonths(1);
+        var exp = new LocalDateTime(1988, 05, 13, 22, 10, 05, 001);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void AddYears_Min12_AreEqual()
+    {
+        var act = TestStruct.AddYears(-12);
+        var exp = new LocalDateTime(1976, 06, 13, 22, 10, 05, 001);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IsValid tests
+
+    [Test]
+    public void IsValid_Data_IsFalse()
+    {
+        Assert.IsFalse(LocalDateTime.IsValid("Complex"), "Complex");
+        Assert.IsFalse(LocalDateTime.IsValid((String)null), "(String)null");
+        Assert.IsFalse(LocalDateTime.IsValid(string.Empty), "String.MinValue");
+    }
+    [Test]
+    public void IsValid_Data_IsTrue()
+    {
+        Assert.IsTrue(LocalDateTime.IsValid("1931-10-10 14:12:03.041", CultureInfo.InvariantCulture));
+    }
+    #endregion
+}
+
+[Serializable]
+public class LocalDateTimeSerializeObject
+{
+    public int Id { get; set; }
+    public LocalDateTime Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
@@ -197,30 +197,6 @@ namespace Qowaiv.UnitTests.Mathematics
             Assert.IsNull(obj.GetSchema());
         }
 
-        [TestCase("Invalid input")]
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<Fraction>(json));
-        }
-
-        [TestCase(double.MaxValue)]
-        [TestCase(double.MinValue)]
-        public void FromJson_Invalid_Overflows(object json)
-        {
-            Assert.Catch<OverflowException>(() => JsonTester.Read<Fraction>(json));
-        }
-
-        [TestCase("4/1", 4L)]
-        [TestCase("3/1", 3.0)]
-        [TestCase("1/3", "14/42")]
-        [TestCase("13/100", "13%")]
-        public void FromJson(Fraction expected, object json)
-        {
-            var actual = JsonTester.Read<Fraction>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
         [Test]
         public void ToString_Zero_StringEmpty()
         {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -1,525 +1,490 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Globalization;
-using Qowaiv.TestTools;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests;
 
-namespace Qowaiv.UnitTests
+/// <summary>Tests the month span SVO.</summary>
+public class MonthSpanTest
 {
-    /// <summary>Tests the month span SVO.</summary>
-    public class MonthSpanTest
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly MonthSpan TestStruct = MonthSpan.FromMonths(69);
+
+    /// <summary>MonthSpan.Zero should be equal to the default of month span.</summary>
+    [Test]
+    public void Zero_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly MonthSpan TestStruct = MonthSpan.FromMonths(69);
+        Assert.AreEqual(default(MonthSpan), MonthSpan.Zero);
+    }
 
-        /// <summary>MonthSpan.Zero should be equal to the default of month span.</summary>
-        [Test]
-        public void Zero_EqualsDefault()
-        {
-            Assert.AreEqual(default(MonthSpan), MonthSpan.Zero);
-        }
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
+    {
+        Assert.IsTrue(MonthSpan.TryParse(null, out var val));
+        Assert.AreEqual(default(MonthSpan), val);
+    }
 
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            Assert.IsTrue(MonthSpan.TryParse(null, out var val));
-            Assert.AreEqual(default(MonthSpan), val);
-        }
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
+    {
+        Assert.IsTrue(MonthSpan.TryParse(string.Empty, out var val));
+        Assert.AreEqual(default(MonthSpan), val);
+    }
 
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            Assert.IsTrue(MonthSpan.TryParse(string.Empty, out var val));
-            Assert.AreEqual(default(MonthSpan), val);
-        }
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "0Y+0M";
+        Assert.IsTrue(MonthSpan.TryParse(str, out var val));
+        Assert.AreEqual(str, val.ToString());
+    }
 
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            string str = "0Y+0M";
-            Assert.IsTrue(MonthSpan.TryParse(str, out var val));
-            Assert.AreEqual(str, val.ToString());
-        }
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "5Y#9M";
+        Assert.IsFalse(MonthSpan.TryParse(str, out var val));
+        Assert.AreEqual(default(MonthSpan), val);
+    }
 
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (new CultureInfoScope("en-GB"))
         {
-            string str = "5Y#9M";
-            Assert.IsFalse(MonthSpan.TryParse(str, out var val));
-            Assert.AreEqual(default(MonthSpan), val);
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (new CultureInfoScope("en-GB"))
+            Assert.Catch<FormatException>(() =>
             {
-                Assert.Catch<FormatException>(() =>
-                {
-                    MonthSpan.Parse("InvalidInput");
-                }
-                , "Not a valid month span");
+                MonthSpan.Parse("InvalidInput");
             }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (new CultureInfoScope("en-GB"))
-            {
-                var exp = TestStruct;
-                var act = MonthSpan.TryParse(exp.ToString());
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void from_invalid_as_null_with_TryParse()
-           => MonthSpan.TryParse("invalid input").Should().BeNull();
-
-        [Test]
-        public void FromYears_20k_Throws()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => MonthSpan.FromYears(20_000));
-        }
-
-        [Test]
-        public void FromMonths_200k_Throws()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => MonthSpan.FromMonths(200_000));
-        }
-
-        [Test]
-        public void Constructor_OutOfRange()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new MonthSpan(years: 9800, months: 5000));
-        }
-
-        [Test]
-        public void Constructor_5Years9Months_69Months()
-        {
-            var ctor = new MonthSpan(years: 5, months: 9);
-            Assert.AreEqual(MonthSpan.FromMonths(69), ctor);
-        }
-
-        [Test]
-        public void GetObjectData_NulSerializationInfo_Throws()
-        {
-            ISerializable obj = TestStruct;
-            Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
-        }
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(MonthSpan), new FormatterConverter());
-            obj.GetObjectData(info, default);
-            Assert.AreEqual(69, info.GetValue("Value", typeof(int)));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "5Y+9M";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<MonthSpan>("69");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_MonthSpanSerializeObject_AreEqual()
-        {
-            var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
-            var exp = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_MonthSpanSerializeObject_AreEqual()
-        {
-            var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
-            var exp = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_MonthSpanSerializeObject_AreEqual()
-        {
-            var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
-            var exp = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Default_AreEqual()
-        {
-            var input = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };
-            var exp = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_Default_AreEqual()
-        {
-            var input = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };
-            var exp = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        [TestCase("2017-06-11")]
-        [TestCase((long)int.MinValue)]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch(() => JsonTester.Read<MonthSpan>(json));
-        }
-
-        [TestCase("5Y+9M", 69L)]
-        [TestCase("5Y+9M", "5Y+9M")]
-        public void FromJson(MonthSpan expected, object json)
-        {
-            var actual = JsonTester.Read<MonthSpan>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ToJson_TestStruct_JsonString()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "5Y+9M";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void FromsYear_3_36M()
-        {
-            var span = MonthSpan.FromYears(3);
-            Assert.AreEqual(MonthSpan.FromMonths(36), span);
-        }
-
-        [Test]
-        public void ToString_Zero_StringEmpty()
-        {
-            var act = MonthSpan.Zero.ToString();
-            var exp = "0Y+0M";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("0.00", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: '69.00', format: '0.00'";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_FormatValueSpanishEcuador_AreEqual()
-        {
-            var act = MonthSpan.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
-            var exp = "01700,0";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            var l = MonthSpan.Parse("69", CultureInfo.InvariantCulture);
-            var r = MonthSpan.Parse("5Y+9M", CultureInfo.InvariantCulture);
-            Assert.IsTrue(l.Equals(r));
-        }
-
-        [Test]
-        public void Plus_TestStruct_Unchanged()
-        {
-            var plus = +TestStruct;
-            Assert.AreEqual(TestStruct, plus);
-        }
-
-        [Test]
-        public void Negated_TestStruct_Min69Months()
-        {
-            var negated = -TestStruct;
-            Assert.AreEqual(MonthSpan.FromMonths(-69), negated);
-        }
-
-        [Test]
-        public void Add_1Year7Months_19Months()
-        {
-            var added = MonthSpan.FromYears(1) + MonthSpan.FromMonths(7);
-            Assert.AreEqual(MonthSpan.FromMonths(19), added);
-        }
-
-        [Test]
-        public void Add_2MonthsToDateTime_2MonthsLater()
-        {
-            var added = new DateTime(1979, 12, 31) + MonthSpan.FromMonths(2);
-            Assert.AreEqual(new DateTime(1980, 02, 29), added);
-        }
-
-        [Test]
-        public void Subtract_19Months6Months_13Months()
-        {
-            var subtracted = MonthSpan.FromMonths(19) - MonthSpan.FromMonths(6);
-            Assert.AreEqual(MonthSpan.FromMonths(13), subtracted);
-        }
-
-        [Test]
-        public void Subtract_9MonthsFromDateTime_9MonthsEarlier()
-        {
-            var added = new DateTime(2017, 06, 11) - MonthSpan.FromMonths(9);
-            Assert.AreEqual(new DateTime(2016, 09, 11), added);
-        }
-
-        [Test]
-        public void Multiply_5MonthsWith3_15Months()
-        {
-            var multiplied = MonthSpan.FromMonths(5) * 3;
-            Assert.AreEqual(MonthSpan.FromMonths(15), multiplied);
-        }
-
-        [Test]
-        public void Multiply_5MonthsWith3Dot3m_16Months()
-        {
-            var multiplied = MonthSpan.FromMonths(5) * 3.3m;
-            Assert.AreEqual(MonthSpan.FromMonths(16), multiplied);
-        }
-
-        [Test]
-        public void Multiply_5MonthsWith3Dot3_16Months()
-        {
-            var multiplied = MonthSpan.FromMonths(5) * 3.3;
-            Assert.AreEqual(MonthSpan.FromMonths(16), multiplied);
-        }
-
-        [Test]
-        public void Divide_16MonthsWith3_5Months()
-        {
-            var multiplied = MonthSpan.FromMonths(16) / 3;
-            Assert.AreEqual(MonthSpan.FromMonths(5), multiplied);
-        }
-
-        [Test]
-        public void Divide_16MonthsWith3Dot4_4Months()
-        {
-            var multiplied = MonthSpan.FromMonths(16) / 3.4;
-            Assert.AreEqual(MonthSpan.FromMonths(4), multiplied);
-        }
-
-        [Test]
-        public void Divide_16MonthsWith3Dot4m_4Months()
-        {
-            var multiplied = MonthSpan.FromMonths(16) / 3.4m;
-            Assert.AreEqual(MonthSpan.FromMonths(4), multiplied);
-        }
-
-        [TestCase(0, "2020-04-30", "2020-04-01")]
-        [TestCase(1, "2020-04-30", "2020-03-31")]
-        [TestCase(11, "2020-01-01", "2019-01-02")]
-        [TestCase(9, "2020-01-01", "2019-03-13")]
-        [TestCase(10, "2020-01-01", "2019-03-01")]
-        [TestCase(-1, "2020-01-01", "2020-02-20")]
-        public void Subtract_TwoDates(MonthSpan expected, Date d1, Date d2)
-        {
-            var delta = MonthSpan.Subtract(d1, d2);
-            Assert.AreEqual(expected, delta);
-        }
-
-        /// <summary>Orders a list of month spans ascending.</summary>
-        [Test]
-        public void OrderBy_MonthSpan_AreEqual()
-        {
-            var item0 = MonthSpan.FromMonths(1);
-            var item1 = MonthSpan.FromMonths(12);
-            var item2 = MonthSpan.FromMonths(13);
-            var item3 = MonthSpan.FromMonths(145);
-            var inp = new List<MonthSpan> { MonthSpan.Zero, item3, item2, item0, item1, MonthSpan.Zero };
-            var exp = new List<MonthSpan> { MonthSpan.Zero, MonthSpan.Zero, item0, item1, item2, item3 };
-            var act = inp.OrderBy(item => item).ToList();
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Orders a list of month spans descending.</summary>
-        [Test]
-        public void OrderByDescending_MonthSpan_AreEqual()
-        {
-            var item0 = MonthSpan.FromMonths(1);
-            var item1 = MonthSpan.FromMonths(12);
-            var item2 = MonthSpan.FromMonths(13);
-            var item3 = MonthSpan.FromMonths(145);
-            var inp = new List<MonthSpan> { MonthSpan.Zero, item3, item2, item0, item1, MonthSpan.Zero };
-            var exp = new List<MonthSpan> { item3, item2, item1, item0, MonthSpan.Zero, MonthSpan.Zero };
-            var act = inp.OrderByDescending(item => item).ToList();
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with a to object casted instance should be fine.</summary>
-        [Test]
-        public void CompareTo_ObjectTestStruct_0()
-        {
-            Assert.AreEqual(0, TestStruct.CompareTo((object)TestStruct));
-        }
-
-        /// <summary>Compare with null should return 1.</summary>
-        [Test]
-        public void CompareTo_null_1()
-        {
-            object @null = null;
-            Assert.AreEqual(1, TestStruct.CompareTo(@null));
-        }
-
-        /// <summary>Compare with a random object should throw an exception.</summary>
-        [Test]
-        public void CompareTo_newObject_Throw()
-        {
-            var x = Assert.Catch<ArgumentException>(() => TestStruct.CompareTo(new object()));
-            Assert.AreEqual("Argument must be MonthSpan. (Parameter 'obj')", x.Message);
-        }
-
-        [Test]
-        public void LessThan_17LT19_IsTrue()
-        {
-            MonthSpan l = MonthSpan.FromMonths(17);
-            MonthSpan r = MonthSpan.FromMonths(19);
-            Assert.IsTrue(l < r);
-        }
-
-        [Test]
-        public void GreaterThan_21LT19_IsTrue()
-        {
-            MonthSpan l = MonthSpan.FromMonths(21);
-            MonthSpan r = MonthSpan.FromMonths(19);
-            Assert.IsTrue(l > r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT19_IsTrue()
-        {
-            MonthSpan l = MonthSpan.FromMonths(17);
-            MonthSpan r = MonthSpan.FromMonths(19);
-            Assert.IsTrue(l <= r);
-        }
-
-        [Test]
-        public void GreaterThanOrEqual_21LT19_IsTrue()
-        {
-            MonthSpan l = MonthSpan.FromMonths(21);
-            MonthSpan r = MonthSpan.FromMonths(19);
-            Assert.IsTrue(l >= r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT17_IsTrue()
-        {
-            MonthSpan l = MonthSpan.FromMonths(17);
-            MonthSpan r = MonthSpan.FromMonths(17);
-            Assert.IsTrue(l <= r);
-        }
-
-        [Test]
-        public void GreaterThanOrEqual_21LT21_IsTrue()
-        {
-            MonthSpan l = MonthSpan.FromMonths(21);
-            MonthSpan r = MonthSpan.FromMonths(21);
-            Assert.IsTrue(l >= r);
-        }
-
-        [Test]
-        public void Explicit_Int32ToMonthSpan_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (MonthSpan)69;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Explicit_MonthSpanToInt32_AreEqual()
-        {
-            var exp = 69;
-            var act = (int)TestStruct;
-            Assert.AreEqual(exp, act);
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase("Complex")]
-        public void IsInvalid_String(string str)
-        {
-            Assert.IsFalse(MonthSpan.IsValid(str));
-        }
-
-        [TestCase("-30Y+50M+2D")]
-        [TestCase("+2Y+0M")]
-        [TestCase("69")]
-        public void IsValid_String(string str)
-        {
-            Assert.IsTrue(MonthSpan.IsValid(str));
+            , "Not a valid month span");
         }
     }
 
-    [Serializable]
-    public class MonthSpanSerializeObject
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
     {
-        public int Id { get; set; }
-        public MonthSpan Obj { get; set; }
-        public DateTime Date { get; set; }
+        using (new CultureInfoScope("en-GB"))
+        {
+            var exp = TestStruct;
+            var act = MonthSpan.TryParse(exp.ToString());
+            Assert.AreEqual(exp, act);
+        }
     }
+
+    [Test]
+    public void from_invalid_as_null_with_TryParse()
+       => MonthSpan.TryParse("invalid input").Should().BeNull();
+
+    [Test]
+    public void FromYears_20k_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => MonthSpan.FromYears(20_000));
+    }
+
+    [Test]
+    public void FromMonths_200k_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => MonthSpan.FromMonths(200_000));
+    }
+
+    [Test]
+    public void Constructor_OutOfRange()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MonthSpan(years: 9800, months: 5000));
+    }
+
+    [Test]
+    public void Constructor_5Years9Months_69Months()
+    {
+        var ctor = new MonthSpan(years: 5, months: 9);
+        Assert.AreEqual(MonthSpan.FromMonths(69), ctor);
+    }
+
+    [Test]
+    public void GetObjectData_NulSerializationInfo_Throws()
+    {
+        ISerializable obj = TestStruct;
+        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
+    }
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(MonthSpan), new FormatterConverter());
+        obj.GetObjectData(info, default);
+        Assert.AreEqual(69, info.GetValue("Value", typeof(int)));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "5Y+9M";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<MonthSpan>("69");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_MonthSpanSerializeObject_AreEqual()
+    {
+        var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
+        var exp = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_MonthSpanSerializeObject_AreEqual()
+    {
+        var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
+        var exp = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_MonthSpanSerializeObject_AreEqual()
+    {
+        var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
+        var exp = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14), };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Default_AreEqual()
+    {
+        var input = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };
+        var exp = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_Default_AreEqual()
+    {
+        var input = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };
+        var exp = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14), };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    [Test]
+    public void FromsYear_3_36M()
+    {
+        var span = MonthSpan.FromYears(3);
+        Assert.AreEqual(MonthSpan.FromMonths(36), span);
+    }
+
+    [Test]
+    public void ToString_Zero_StringEmpty()
+    {
+        var act = MonthSpan.Zero.ToString();
+        var exp = "0Y+0M";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("0.00", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: '69.00', format: '0.00'";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_FormatValueSpanishEcuador_AreEqual()
+    {
+        var act = MonthSpan.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
+        var exp = "01700,0";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        var l = MonthSpan.Parse("69", CultureInfo.InvariantCulture);
+        var r = MonthSpan.Parse("5Y+9M", CultureInfo.InvariantCulture);
+        Assert.IsTrue(l.Equals(r));
+    }
+
+    [Test]
+    public void Plus_TestStruct_Unchanged()
+    {
+        var plus = +TestStruct;
+        Assert.AreEqual(TestStruct, plus);
+    }
+
+    [Test]
+    public void Negated_TestStruct_Min69Months()
+    {
+        var negated = -TestStruct;
+        Assert.AreEqual(MonthSpan.FromMonths(-69), negated);
+    }
+
+    [Test]
+    public void Add_1Year7Months_19Months()
+    {
+        var added = MonthSpan.FromYears(1) + MonthSpan.FromMonths(7);
+        Assert.AreEqual(MonthSpan.FromMonths(19), added);
+    }
+
+    [Test]
+    public void Add_2MonthsToDateTime_2MonthsLater()
+    {
+        var added = new DateTime(1979, 12, 31) + MonthSpan.FromMonths(2);
+        Assert.AreEqual(new DateTime(1980, 02, 29), added);
+    }
+
+    [Test]
+    public void Subtract_19Months6Months_13Months()
+    {
+        var subtracted = MonthSpan.FromMonths(19) - MonthSpan.FromMonths(6);
+        Assert.AreEqual(MonthSpan.FromMonths(13), subtracted);
+    }
+
+    [Test]
+    public void Subtract_9MonthsFromDateTime_9MonthsEarlier()
+    {
+        var added = new DateTime(2017, 06, 11) - MonthSpan.FromMonths(9);
+        Assert.AreEqual(new DateTime(2016, 09, 11), added);
+    }
+
+    [Test]
+    public void Multiply_5MonthsWith3_15Months()
+    {
+        var multiplied = MonthSpan.FromMonths(5) * 3;
+        Assert.AreEqual(MonthSpan.FromMonths(15), multiplied);
+    }
+
+    [Test]
+    public void Multiply_5MonthsWith3Dot3m_16Months()
+    {
+        var multiplied = MonthSpan.FromMonths(5) * 3.3m;
+        Assert.AreEqual(MonthSpan.FromMonths(16), multiplied);
+    }
+
+    [Test]
+    public void Multiply_5MonthsWith3Dot3_16Months()
+    {
+        var multiplied = MonthSpan.FromMonths(5) * 3.3;
+        Assert.AreEqual(MonthSpan.FromMonths(16), multiplied);
+    }
+
+    [Test]
+    public void Divide_16MonthsWith3_5Months()
+    {
+        var multiplied = MonthSpan.FromMonths(16) / 3;
+        Assert.AreEqual(MonthSpan.FromMonths(5), multiplied);
+    }
+
+    [Test]
+    public void Divide_16MonthsWith3Dot4_4Months()
+    {
+        var multiplied = MonthSpan.FromMonths(16) / 3.4;
+        Assert.AreEqual(MonthSpan.FromMonths(4), multiplied);
+    }
+
+    [Test]
+    public void Divide_16MonthsWith3Dot4m_4Months()
+    {
+        var multiplied = MonthSpan.FromMonths(16) / 3.4m;
+        Assert.AreEqual(MonthSpan.FromMonths(4), multiplied);
+    }
+
+    [TestCase(0, "2020-04-30", "2020-04-01")]
+    [TestCase(1, "2020-04-30", "2020-03-31")]
+    [TestCase(11, "2020-01-01", "2019-01-02")]
+    [TestCase(9, "2020-01-01", "2019-03-13")]
+    [TestCase(10, "2020-01-01", "2019-03-01")]
+    [TestCase(-1, "2020-01-01", "2020-02-20")]
+    public void Subtract_TwoDates(MonthSpan expected, Date d1, Date d2)
+    {
+        var delta = MonthSpan.Subtract(d1, d2);
+        Assert.AreEqual(expected, delta);
+    }
+
+    /// <summary>Orders a list of month spans ascending.</summary>
+    [Test]
+    public void OrderBy_MonthSpan_AreEqual()
+    {
+        var item0 = MonthSpan.FromMonths(1);
+        var item1 = MonthSpan.FromMonths(12);
+        var item2 = MonthSpan.FromMonths(13);
+        var item3 = MonthSpan.FromMonths(145);
+        var inp = new List<MonthSpan> { MonthSpan.Zero, item3, item2, item0, item1, MonthSpan.Zero };
+        var exp = new List<MonthSpan> { MonthSpan.Zero, MonthSpan.Zero, item0, item1, item2, item3 };
+        var act = inp.OrderBy(item => item).ToList();
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Orders a list of month spans descending.</summary>
+    [Test]
+    public void OrderByDescending_MonthSpan_AreEqual()
+    {
+        var item0 = MonthSpan.FromMonths(1);
+        var item1 = MonthSpan.FromMonths(12);
+        var item2 = MonthSpan.FromMonths(13);
+        var item3 = MonthSpan.FromMonths(145);
+        var inp = new List<MonthSpan> { MonthSpan.Zero, item3, item2, item0, item1, MonthSpan.Zero };
+        var exp = new List<MonthSpan> { item3, item2, item1, item0, MonthSpan.Zero, MonthSpan.Zero };
+        var act = inp.OrderByDescending(item => item).ToList();
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with a to object casted instance should be fine.</summary>
+    [Test]
+    public void CompareTo_ObjectTestStruct_0()
+    {
+        Assert.AreEqual(0, TestStruct.CompareTo((object)TestStruct));
+    }
+
+    /// <summary>Compare with null should return 1.</summary>
+    [Test]
+    public void CompareTo_null_1()
+    {
+        object @null = null;
+        Assert.AreEqual(1, TestStruct.CompareTo(@null));
+    }
+
+    /// <summary>Compare with a random object should throw an exception.</summary>
+    [Test]
+    public void CompareTo_newObject_Throw()
+    {
+        var x = Assert.Catch<ArgumentException>(() => TestStruct.CompareTo(new object()));
+        Assert.AreEqual("Argument must be MonthSpan. (Parameter 'obj')", x.Message);
+    }
+
+    [Test]
+    public void LessThan_17LT19_IsTrue()
+    {
+        MonthSpan l = MonthSpan.FromMonths(17);
+        MonthSpan r = MonthSpan.FromMonths(19);
+        Assert.IsTrue(l < r);
+    }
+
+    [Test]
+    public void GreaterThan_21LT19_IsTrue()
+    {
+        MonthSpan l = MonthSpan.FromMonths(21);
+        MonthSpan r = MonthSpan.FromMonths(19);
+        Assert.IsTrue(l > r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT19_IsTrue()
+    {
+        MonthSpan l = MonthSpan.FromMonths(17);
+        MonthSpan r = MonthSpan.FromMonths(19);
+        Assert.IsTrue(l <= r);
+    }
+
+    [Test]
+    public void GreaterThanOrEqual_21LT19_IsTrue()
+    {
+        MonthSpan l = MonthSpan.FromMonths(21);
+        MonthSpan r = MonthSpan.FromMonths(19);
+        Assert.IsTrue(l >= r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT17_IsTrue()
+    {
+        MonthSpan l = MonthSpan.FromMonths(17);
+        MonthSpan r = MonthSpan.FromMonths(17);
+        Assert.IsTrue(l <= r);
+    }
+
+    [Test]
+    public void GreaterThanOrEqual_21LT21_IsTrue()
+    {
+        MonthSpan l = MonthSpan.FromMonths(21);
+        MonthSpan r = MonthSpan.FromMonths(21);
+        Assert.IsTrue(l >= r);
+    }
+
+    [Test]
+    public void Explicit_Int32ToMonthSpan_AreEqual()
+    {
+        var exp = TestStruct;
+        var act = (MonthSpan)69;
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Explicit_MonthSpanToInt32_AreEqual()
+    {
+        var exp = 69;
+        var act = (int)TestStruct;
+        Assert.AreEqual(exp, act);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("Complex")]
+    public void IsInvalid_String(string str)
+    {
+        Assert.IsFalse(MonthSpan.IsValid(str));
+    }
+
+    [TestCase("-30Y+50M+2D")]
+    [TestCase("+2Y+0M")]
+    [TestCase("69")]
+    public void IsValid_String(string str)
+    {
+        Assert.IsTrue(MonthSpan.IsValid(str));
+    }
+}
+
+[Serializable]
+public class MonthSpanSerializeObject
+{
+    public int Id { get; set; }
+    public MonthSpan Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
@@ -1,621 +1,572 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Globalization;
-using Qowaiv.Sql;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests.Sql;
 
-namespace Qowaiv.UnitTests.Sql
+/// <summary>Tests the timestamp SVO.</summary>
+public class TimestampTest
 {
-    /// <summary>Tests the timestamp SVO.</summary>
-    public class TimestampTest
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly Timestamp TestStruct = 123456789L;
+
+    #region TryParse tests
+
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly Timestamp TestStruct = 123456789L;
+        string str = null;
 
-        #region TryParse tests
-
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            string str = null;
-
-            Assert.IsFalse(Timestamp.TryParse(str, out Timestamp val), "Valid");
-            Assert.AreEqual(Timestamp.MinValue, val, "Value");
-        }
-
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            string str = string.Empty;
-
-            Assert.IsFalse(Timestamp.TryParse(str, out Timestamp val), "Valid");
-            Assert.AreEqual(Timestamp.MinValue, val, "Value");
-        }
-
-        [Test]
-        public void TryParse_0x00000000075BCD15_IsValid()
-        {
-            string str = "0x00000000075BCD15";
-
-            Assert.IsTrue(Timestamp.TryParse(str, out Timestamp val), "Valid");
-            Assert.AreEqual(TestStruct, val, "Value");
-        }
-        [Test]
-        public void TryParse_123456789_IsValid()
-        {
-            string str = "123456789";
-
-            Assert.IsTrue(Timestamp.TryParse(str, out Timestamp val), "Valid");
-            Assert.AreEqual(TestStruct, val, "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_invalidTimeStamp_IsNotValid()
-        {
-            string str = "invalidTimeStamp";
-
-            Assert.IsFalse(Timestamp.TryParse(str, out Timestamp val), "Valid");
-            Assert.AreEqual(Timestamp.MinValue, val, "Value");
-        }
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_0xInvalidTimeStamp_IsNotValid()
-        {
-            string str = "0xInvalidTimeStamp";
-
-            Assert.IsFalse(Timestamp.TryParse(str, out Timestamp val), "Valid");
-            Assert.AreEqual(Timestamp.MinValue, val, "Value");
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Assert.Catch<FormatException>
-                (() =>
-                {
-                    Timestamp.Parse("InvalidInput");
-                },
-                "Not a valid SQL timestamp");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = Timestamp.TryParse(exp.ToString());
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void from_invalid_as_null_with_TryParse()
-            => Timestamp.TryParse("invalid input").Should().BeNull();
-
-        #endregion
-
-        #region Create tests
-
-        [Test]
-        public void Create_Length8ByteArray_Is578437695752307201()
-        {
-            Timestamp act = Timestamp.Create(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
-            Timestamp exp = 578437695752307201L;
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Create_Length6ByteArray_throwsArgumentException()
-        {
-            Func< Timestamp> create = () => Timestamp.Create(new byte[] { 1, 2, 3, 4, 5, 6 });
-            create.Should().Throw<ArgumentException>()
-                .WithMessage("The byte array should have size of 8. (Parameter 'bytes')");
-        }
-        [Test]
-        public void Create_NegativeInteger_18446744073709551593()
-        {
-            Timestamp act = Timestamp.Create(-23);
-            Timestamp exp = 18446744073709551593L;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region (XML) (De)serialization tests
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(Timestamp), new FormatterConverter());
-            obj.GetObjectData(info, default);
-
-            Assert.AreEqual((Int64)123456789, info.GetInt64("Value"));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-            =>  SerializeDeserialize.Binary(TestStruct).Should().Be(TestStruct);
-
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-            => SerializeDeserialize.DataContract(TestStruct).Should().Be(TestStruct);
-        
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "0x00000000075BCD15";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act = Deserialize.Xml<Timestamp>("0x00000000075BCD15");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TimestampSerializeObject_AreEqual()
-        {
-            var input = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_TimestampSerializeObject_AreEqual()
-        {
-            var input = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_TimestampSerializeObject_AreEqual()
-        {
-            var input = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Default_AreEqual()
-        {
-            var input = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = Timestamp.MinValue,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new TimestampSerializeObject
-            {
-                Id = 17,
-                Obj = Timestamp.MinValue,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [TestCase("InvalidStringValue")]
-        [TestCase("2017-06-11")]
-        public void FromJson_InvalidInput_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<Timestamp>(json));
-        }
-        [TestCase("123456789")]
-        [TestCase(123456789L)]
-        [TestCase(123456789.0)]
-        public void FromJson_ValidInput_EqualsTestStruct(object json)
-        {
-            var act = JsonTester.Read<Timestamp>(json);
-            var exp = TestStruct;
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_AreEqual()
-        {
-            object act = JsonTester.Write(Timestamp.MinValue);
-            object exp = "0x0000000000000000";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "0x00000000075BCD15";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IFormattable / ToString tests
-
-        [Test]
-        public void ToString_MinValue_StringEmpty()
-        {
-            var act = Timestamp.MinValue.ToString();
-            var exp = "0x0000000000000000";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_MaxValue_QuestionMark()
-        {
-            var act = Timestamp.MaxValue.ToString();
-            var exp = "0xFFFFFFFFFFFFFFFF";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("#,##0", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: '123,456,789', format: '#,##0'";
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToString_TestStruct_ComplexPattern()
-        {
-            var act = TestStruct.ToString("");
-            var exp = "0x00000000075BCD15";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_ValueDutchBelgium_AreEqual()
-        {
-            using (TestCultures.Nl_BE.Scoped())
-            {
-                var act = Timestamp.Parse("1600").ToString();
-                var exp = "0x0000000000000640";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_FormatValueDutchBelgium_AreEqual()
-        {
-            using (TestCultures.Nl_BE.Scoped())
-            {
-                var act = Timestamp.Parse("800").ToString("0000");
-                var exp = "0800";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_FormatValueEnglishGreatBritain_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var act = Timestamp.Parse("800").ToString("0000");
-                var exp = "0800";
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_FormatValueSpanishEcuador_AreEqual()
-        {
-            var act = Timestamp.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
-            var exp = "01700,0";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IEquatable tests
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            var l = Timestamp.Parse("0x75bcd15", CultureInfo.InvariantCulture);
-            var r = Timestamp.Parse("0x00000000075BCD15", CultureInfo.InvariantCulture);
-
-            Assert.IsTrue(l.Equals(r));
-        }
-
-        #endregion
-
-        #region IComparable tests
-
-        /// <summary>Orders a list of timestamps ascending.</summary>
-        [Test]
-        public void OrderBy_Timestamp_AreEqual()
-        {
-            Timestamp item0 = 3245;
-            Timestamp item1 = 13245;
-            Timestamp item2 = 132456;
-            Timestamp item3 = 1324589;
-
-            var inp = new List<Timestamp> { Timestamp.MinValue, item3, item2, item0, item1, Timestamp.MinValue };
-            var exp = new List<Timestamp> { Timestamp.MinValue, Timestamp.MinValue, item0, item1, item2, item3 };
-            var act = inp.OrderBy(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Orders a list of timestamps descending.</summary>
-        [Test]
-        public void OrderByDescending_Timestamp_AreEqual()
-        {
-            Timestamp item0 = 3245;
-            Timestamp item1 = 13245;
-            Timestamp item2 = 132456;
-            Timestamp item3 = 1324589;
-
-            var inp = new List<Timestamp> { Timestamp.MinValue, item3, item2, item0, item1, Timestamp.MinValue };
-            var exp = new List<Timestamp> { item3, item2, item1, item0, Timestamp.MinValue, Timestamp.MinValue };
-            var act = inp.OrderByDescending(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with a to object casted instance should be fine.</summary>
-        [Test]
-        public void CompareTo_ObjectTestStruct_0()
-        {
-            object other = TestStruct;
-
-            var exp = 0;
-            var act = TestStruct.CompareTo(other);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with null should return 1.</summary>
-        [Test]
-        public void CompareTo_null_1()
-        {
-            object @null = null;
-            Assert.AreEqual(1, TestStruct.CompareTo(@null));
-        }
-
-        /// <summary>Compare with a random object should throw an exception.</summary>
-        [Test]
-        public void CompareTo_newObject_ThrowsArgumentException()
-        {
-            Func<int> compare = () => TestStruct.CompareTo(new object());
-            compare.Should().Throw<ArgumentException>();
-        }
-
-        [Test]
-        public void LessThan_17LT19_IsTrue()
-        {
-            Timestamp l = 17;
-            Timestamp r = 19;
-
-            Assert.IsTrue(l < r);
-        }
-        [Test]
-        public void GreaterThan_21LT19_IsTrue()
-        {
-            Timestamp l = 21;
-            Timestamp r = 19;
-
-            Assert.IsTrue(l > r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT19_IsTrue()
-        {
-            Timestamp l = 17;
-            Timestamp r = 19;
-
-            Assert.IsTrue(l <= r);
-        }
-        [Test]
-        public void GreaterThanOrEqual_21LT19_IsTrue()
-        {
-            Timestamp l = 21;
-            Timestamp r = 19;
-
-            Assert.IsTrue(l >= r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT17_IsTrue()
-        {
-            Timestamp l = 17;
-            Timestamp r = 17;
-
-            Assert.IsTrue(l <= r);
-        }
-        [Test]
-        public void GreaterThanOrEqual_21LT21_IsTrue()
-        {
-            Timestamp l = 21;
-            Timestamp r = 21;
-
-            Assert.IsTrue(l >= r);
-        }
-        #endregion
-
-        #region Methods
-
-        [Test]
-        public void ToByteArray_TestStruct_()
-        {
-            var act = TestStruct.ToByteArray();
-            var exp = new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region Casting tests
-
-        [Test]
-        public void Explicit_ByteArrayToTimestamp_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (Timestamp)new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_TimestampToByteArray_AreEqual()
-        {
-            var exp = new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
-            var act = (byte[])TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Explicit_Int64ToTimestamp_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (Timestamp)123456789L;
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_TimestampToInt64_AreEqual()
-        {
-            var exp = 123456789L;
-            var act = (Int64)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Explicit_UInt64ToTimestamp_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (Timestamp)123456789UL;
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_TimestampToUInt64_AreEqual()
-        {
-            var exp = 123456789UL;
-            var act = (UInt64)TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IsValid tests
-
-        [Test]
-        public void IsValid_Data_IsFalse()
-        {
-            Assert.IsFalse(Timestamp.IsValid((String)null), "(String)null");
-            Assert.IsFalse(Timestamp.IsValid(string.Empty), "string.Empty");
-
-            Assert.IsFalse(Timestamp.IsValid("75bcd15"), "75bcd15");
-        }
-        [Test]
-        public void IsValid_Data_IsTrue()
-        {
-            Assert.IsTrue(Timestamp.IsValid("0x75BCD15"));
-        }
-        #endregion
+        Assert.IsFalse(Timestamp.TryParse(str, out Timestamp val), "Valid");
+        Assert.AreEqual(Timestamp.MinValue, val, "Value");
     }
 
-    [Serializable]
-    public class TimestampSerializeObject
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
     {
-        public int Id { get; set; }
-        public Timestamp Obj { get; set; }
-        public DateTime Date { get; set; }
+        string str = string.Empty;
+
+        Assert.IsFalse(Timestamp.TryParse(str, out Timestamp val), "Valid");
+        Assert.AreEqual(Timestamp.MinValue, val, "Value");
     }
+
+    [Test]
+    public void TryParse_0x00000000075BCD15_IsValid()
+    {
+        string str = "0x00000000075BCD15";
+
+        Assert.IsTrue(Timestamp.TryParse(str, out Timestamp val), "Valid");
+        Assert.AreEqual(TestStruct, val, "Value");
+    }
+    [Test]
+    public void TryParse_123456789_IsValid()
+    {
+        string str = "123456789";
+
+        Assert.IsTrue(Timestamp.TryParse(str, out Timestamp val), "Valid");
+        Assert.AreEqual(TestStruct, val, "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_invalidTimeStamp_IsNotValid()
+    {
+        string str = "invalidTimeStamp";
+
+        Assert.IsFalse(Timestamp.TryParse(str, out Timestamp val), "Valid");
+        Assert.AreEqual(Timestamp.MinValue, val, "Value");
+    }
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_0xInvalidTimeStamp_IsNotValid()
+    {
+        string str = "0xInvalidTimeStamp";
+
+        Assert.IsFalse(Timestamp.TryParse(str, out Timestamp val), "Valid");
+        Assert.AreEqual(Timestamp.MinValue, val, "Value");
+    }
+
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Assert.Catch<FormatException>
+            (() =>
+            {
+                Timestamp.Parse("InvalidInput");
+            },
+            "Not a valid SQL timestamp");
+        }
+    }
+
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = Timestamp.TryParse(exp.ToString());
+
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void from_invalid_as_null_with_TryParse()
+        => Timestamp.TryParse("invalid input").Should().BeNull();
+
+    #endregion
+
+    #region Create tests
+
+    [Test]
+    public void Create_Length8ByteArray_Is578437695752307201()
+    {
+        Timestamp act = Timestamp.Create(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        Timestamp exp = 578437695752307201L;
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Create_Length6ByteArray_throwsArgumentException()
+    {
+        Func< Timestamp> create = () => Timestamp.Create(new byte[] { 1, 2, 3, 4, 5, 6 });
+        create.Should().Throw<ArgumentException>()
+            .WithMessage("The byte array should have size of 8. (Parameter 'bytes')");
+    }
+    [Test]
+    public void Create_NegativeInteger_18446744073709551593()
+    {
+        Timestamp act = Timestamp.Create(-23);
+        Timestamp exp = 18446744073709551593L;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region (XML) (De)serialization tests
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(Timestamp), new FormatterConverter());
+        obj.GetObjectData(info, default);
+
+        Assert.AreEqual((Int64)123456789, info.GetInt64("Value"));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+        =>  SerializeDeserialize.Binary(TestStruct).Should().Be(TestStruct);
+
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+        => SerializeDeserialize.DataContract(TestStruct).Should().Be(TestStruct);
+    
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "0x00000000075BCD15";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act = Deserialize.Xml<Timestamp>("0x00000000075BCD15");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TimestampSerializeObject_AreEqual()
+    {
+        var input = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_TimestampSerializeObject_AreEqual()
+    {
+        var input = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_TimestampSerializeObject_AreEqual()
+    {
+        var input = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Default_AreEqual()
+    {
+        var input = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = Timestamp.MinValue,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new TimestampSerializeObject
+        {
+            Id = 17,
+            Obj = Timestamp.MinValue,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    #endregion
+
+    #region IFormattable / ToString tests
+
+    [Test]
+    public void ToString_MinValue_StringEmpty()
+    {
+        var act = Timestamp.MinValue.ToString();
+        var exp = "0x0000000000000000";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_MaxValue_QuestionMark()
+    {
+        var act = Timestamp.MaxValue.ToString();
+        var exp = "0xFFFFFFFFFFFFFFFF";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("#,##0", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: '123,456,789', format: '#,##0'";
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void ToString_TestStruct_ComplexPattern()
+    {
+        var act = TestStruct.ToString("");
+        var exp = "0x00000000075BCD15";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_ValueDutchBelgium_AreEqual()
+    {
+        using (TestCultures.Nl_BE.Scoped())
+        {
+            var act = Timestamp.Parse("1600").ToString();
+            var exp = "0x0000000000000640";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_FormatValueDutchBelgium_AreEqual()
+    {
+        using (TestCultures.Nl_BE.Scoped())
+        {
+            var act = Timestamp.Parse("800").ToString("0000");
+            var exp = "0800";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_FormatValueEnglishGreatBritain_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var act = Timestamp.Parse("800").ToString("0000");
+            var exp = "0800";
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_FormatValueSpanishEcuador_AreEqual()
+    {
+        var act = Timestamp.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
+        var exp = "01700,0";
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IEquatable tests
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        var l = Timestamp.Parse("0x75bcd15", CultureInfo.InvariantCulture);
+        var r = Timestamp.Parse("0x00000000075BCD15", CultureInfo.InvariantCulture);
+
+        Assert.IsTrue(l.Equals(r));
+    }
+
+    #endregion
+
+    #region IComparable tests
+
+    /// <summary>Orders a list of timestamps ascending.</summary>
+    [Test]
+    public void OrderBy_Timestamp_AreEqual()
+    {
+        Timestamp item0 = 3245;
+        Timestamp item1 = 13245;
+        Timestamp item2 = 132456;
+        Timestamp item3 = 1324589;
+
+        var inp = new List<Timestamp> { Timestamp.MinValue, item3, item2, item0, item1, Timestamp.MinValue };
+        var exp = new List<Timestamp> { Timestamp.MinValue, Timestamp.MinValue, item0, item1, item2, item3 };
+        var act = inp.OrderBy(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Orders a list of timestamps descending.</summary>
+    [Test]
+    public void OrderByDescending_Timestamp_AreEqual()
+    {
+        Timestamp item0 = 3245;
+        Timestamp item1 = 13245;
+        Timestamp item2 = 132456;
+        Timestamp item3 = 1324589;
+
+        var inp = new List<Timestamp> { Timestamp.MinValue, item3, item2, item0, item1, Timestamp.MinValue };
+        var exp = new List<Timestamp> { item3, item2, item1, item0, Timestamp.MinValue, Timestamp.MinValue };
+        var act = inp.OrderByDescending(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with a to object casted instance should be fine.</summary>
+    [Test]
+    public void CompareTo_ObjectTestStruct_0()
+    {
+        object other = TestStruct;
+
+        var exp = 0;
+        var act = TestStruct.CompareTo(other);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with null should return 1.</summary>
+    [Test]
+    public void CompareTo_null_1()
+    {
+        object @null = null;
+        Assert.AreEqual(1, TestStruct.CompareTo(@null));
+    }
+
+    /// <summary>Compare with a random object should throw an exception.</summary>
+    [Test]
+    public void CompareTo_newObject_ThrowsArgumentException()
+    {
+        Func<int> compare = () => TestStruct.CompareTo(new object());
+        compare.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void LessThan_17LT19_IsTrue()
+    {
+        Timestamp l = 17;
+        Timestamp r = 19;
+
+        Assert.IsTrue(l < r);
+    }
+    [Test]
+    public void GreaterThan_21LT19_IsTrue()
+    {
+        Timestamp l = 21;
+        Timestamp r = 19;
+
+        Assert.IsTrue(l > r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT19_IsTrue()
+    {
+        Timestamp l = 17;
+        Timestamp r = 19;
+
+        Assert.IsTrue(l <= r);
+    }
+    [Test]
+    public void GreaterThanOrEqual_21LT19_IsTrue()
+    {
+        Timestamp l = 21;
+        Timestamp r = 19;
+
+        Assert.IsTrue(l >= r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT17_IsTrue()
+    {
+        Timestamp l = 17;
+        Timestamp r = 17;
+
+        Assert.IsTrue(l <= r);
+    }
+    [Test]
+    public void GreaterThanOrEqual_21LT21_IsTrue()
+    {
+        Timestamp l = 21;
+        Timestamp r = 21;
+
+        Assert.IsTrue(l >= r);
+    }
+    #endregion
+
+    #region Methods
+
+    [Test]
+    public void ToByteArray_TestStruct_()
+    {
+        var act = TestStruct.ToByteArray();
+        var exp = new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region Casting tests
+
+    [Test]
+    public void Explicit_ByteArrayToTimestamp_AreEqual()
+    {
+        var exp = TestStruct;
+        var act = (Timestamp)new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Explicit_TimestampToByteArray_AreEqual()
+    {
+        var exp = new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
+        var act = (byte[])TestStruct;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Explicit_Int64ToTimestamp_AreEqual()
+    {
+        var exp = TestStruct;
+        var act = (Timestamp)123456789L;
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Explicit_TimestampToInt64_AreEqual()
+    {
+        var exp = 123456789L;
+        var act = (Int64)TestStruct;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Explicit_UInt64ToTimestamp_AreEqual()
+    {
+        var exp = TestStruct;
+        var act = (Timestamp)123456789UL;
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Explicit_TimestampToUInt64_AreEqual()
+    {
+        var exp = 123456789UL;
+        var act = (UInt64)TestStruct;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IsValid tests
+
+    [Test]
+    public void IsValid_Data_IsFalse()
+    {
+        Assert.IsFalse(Timestamp.IsValid((String)null), "(String)null");
+        Assert.IsFalse(Timestamp.IsValid(string.Empty), "string.Empty");
+
+        Assert.IsFalse(Timestamp.IsValid("75bcd15"), "75bcd15");
+    }
+    [Test]
+    public void IsValid_Data_IsTrue()
+    {
+        Assert.IsTrue(Timestamp.IsValid("0x75BCD15"));
+    }
+    #endregion
+}
+
+[Serializable]
+public class TimestampSerializeObject
+{
+    public int Id { get; set; }
+    public Timestamp Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
@@ -1,17 +1,4 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Globalization;
-using Qowaiv.Statistics;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
-
-namespace Qowaiv.UnitTests.Statistics
+﻿namespace Qowaiv.UnitTests.Statistics
 {
     /// <summary>Tests the Elo SVO.</summary>
     public class EloTest
@@ -267,34 +254,6 @@ namespace Qowaiv.UnitTests.Statistics
         {
             IXmlSerializable obj = TestStruct;
             Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [TestCase("Invalid input")]
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<Elo>(json));
-        }
-        [TestCase(1600, "1600*")]
-        [TestCase(1700, "1700")]
-        [TestCase(1234, 1234L)]
-        [TestCase(1258.9, 1258.9)]
-        public void FromJson(Elo expected, object json)
-        {
-            var actual = JsonTester.Read<Elo>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = 1732.4000000000001;
-            Assert.AreEqual(exp, act);
         }
 
         #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
@@ -400,38 +400,6 @@ namespace Qowaiv.UnitTests.Web
 
         #endregion
 
-        #region JSON (De)serialization tests
-
-        [TestCase("Invalid input")]
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<InternetMediaType>(json));
-        }
-     
-        [Test]
-        public void FromJson_ApplicationXChesPgn_EqualsTestStruct()
-        {
-            var actual = JsonTester.Read<InternetMediaType>("application/x-chess-pgn");
-            Assert.AreEqual(TestStruct, actual);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_IsNull()
-        {
-            object act = JsonTester.Write(default(InternetMediaType));
-            Assert.IsNull(act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "application/x-chess-pgn";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
         #region IFormattable / ToString tests
 
         [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
@@ -1,750 +1,705 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Globalization;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests;
 
-namespace Qowaiv.UnitTests
+/// <summary>Tests the week date SVO.</summary>
+public class WeekDateTest
 {
-    /// <summary>Tests the week date SVO.</summary>
-    public class WeekDateTest
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly WeekDate TestStruct = new(1997, 14, 6);
+
+    #region week date const tests
+
+    /// <summary>WeekDate.MinValue should be equal to the default of week date.</summary>
+    [Test]
+    public void MinValue_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly WeekDate TestStruct = new(1997, 14, 6);
-
-        #region week date const tests
-
-        /// <summary>WeekDate.MinValue should be equal to the default of week date.</summary>
-        [Test]
-        public void MinValue_None_EqualsDefault()
-        {
-            Assert.AreEqual(default(WeekDate), WeekDate.MinValue);
-        }
-
-        #endregion
-
-        #region week date constructor tests
-
-        [Test]
-        public void Ctor_Y0_ThrowsArgumentOutofRangeException()
-        {
-            Func<WeekDate> create = () => new WeekDate(0000, 10, 4);
-            create.Should()
-                .Throw<ArgumentOutOfRangeException>()
-                .WithMessage("Year should be in range [1,9999]. (Parameter 'year')");
-        }
-        [Test]
-        public void Ctor_Y10000_ThrowsArgumentOutofRangeException()
-        {
-            Func<WeekDate> create = () => new WeekDate(10000, 10, 4);
-            create.Should()
-                .Throw<ArgumentOutOfRangeException>()
-                .WithMessage("Year should be in range [1,9999]. (Parameter 'year')");
-        }
-
-        [Test]
-        public void Ctor_W0_ThrowsArgumentOutofRangeException()
-        {
-            Func<WeekDate> create = () => new WeekDate(1980, 0, 4);
-            create.Should()
-                .Throw<ArgumentOutOfRangeException>()
-                .WithMessage("Week should be in range [1,53]. (Parameter 'week')");
-        }
-        [Test]
-        public void Ctor_W54_ThrowsArgumentOutofRangeException()
-        {
-            Func<WeekDate> create = () => new WeekDate(1980, 54, 4);
-            create.Should()
-                .Throw<ArgumentOutOfRangeException>()
-                .WithMessage("Week should be in range [1,53]. (Parameter 'week')");
-        }
-
-        [Test]
-        public void Ctor_D0_ThrowsArgumentOutofRangeException()
-        {
-            Func<WeekDate> create = () => new WeekDate(1980, 10, 0);
-            create.Should()
-                .Throw<ArgumentOutOfRangeException>()
-                .WithMessage("Day should be in range [1,7]. (Parameter 'day')"); 
-        }
-
-        [Test]
-        public void Ctor_D8_ThrowsArgumentOutofRangeException()
-        {
-            Func<WeekDate> create = () => new WeekDate(1980, 10, 8);
-            create.Should()
-                .Throw<ArgumentOutOfRangeException>()
-                .WithMessage("Day should be in range [1,7]. (Parameter 'day')");
-        }
-
-        [Test]
-        public void Ctor_Y9999W52D6_ThrowsArgumentOutofRangeException()
-        {
-            Func<WeekDate> create = () => new WeekDate(9999, 52, 6);
-            create.Should()
-                .Throw<ArgumentOutOfRangeException>()
-                .WithMessage("Year, Week, and Day parameters describe an un-representable Date.");
-        }
-
-        [Test]
-        public void Ctor_Y9999W53D1_ThrowsArgumentOutofRangeException()
-        {
-            Func<WeekDate> create = () => new WeekDate(9999, 53, 6);
-            create.Should()
-                .Throw<ArgumentOutOfRangeException>()
-                .WithMessage("Year, Week, and Day parameters describe an un-representable Date.");
-        }
-
-        #endregion
-
-        #region TryParse tests
-
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsInvalid()
-        {
-            string str = null;
-            Assert.IsFalse(WeekDate.TryParse(str, out _), "Not valid");
-        }
-
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsInvalid()
-        {
-            Assert.IsFalse(WeekDate.TryParse(string.Empty, out _), "Not valid");
-        }
-
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            string str = "1234-W50-6";
-            Assert.IsTrue(WeekDate.TryParse(str, out WeekDate val), "Valid");
-            Assert.AreEqual(str, val.ToString(), "Value");
-        }
-
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
-        {
-            Assert.IsFalse(WeekDate.TryParse("string", out _), "Valid");
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                Assert.Catch<FormatException>
-                (() =>
-                {
-                    WeekDate.Parse("InvalidInput");
-                },
-                "Not a valid week date");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = WeekDate.TryParse(exp.ToString());
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void from_invalid_as_null_with_TryParse()
-            => WeekDate.TryParse("invalid input").Should().BeNull();
-
-        [Test]
-        public void TryParse_Y0000W21D7_DefaultValue()
-        {
-            WeekDate exp = default;
-            Assert.IsFalse(WeekDate.TryParse("0000-W21-7", out WeekDate act));
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void TryParse_Y2000W53D7_DefaultValue()
-        {
-            WeekDate exp = default;
-            Assert.IsFalse(WeekDate.TryParse("2000-W53-7", out WeekDate act));
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region (XML) (De)serialization tests
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(WeekDate), new System.Runtime.Serialization.FormatterConverter());
-            obj.GetObjectData(info, default);
-
-            Assert.AreEqual((DateTime)TestStruct, info.GetDateTime("Value"));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "1997-W14-6";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<WeekDate>("1997-W14-6");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_WeekDateSerializeObject_AreEqual()
-        {
-            var input = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_WeekDateSerializeObject_AreEqual()
-        {
-            var input = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void DataContractSerializeDeserialize_WeekDateSerializeObject_AreEqual()
-        {
-            var input = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_MinValue_AreEqual()
-        {
-            var input = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = WeekDate.MinValue,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = WeekDate.MinValue,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-        [Test]
-        public void XmlSerializeDeserialize_Empty_AreEqual()
-        {
-            var input = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = WeekDate.MinValue,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var exp = new WeekDateSerializeObject
-            {
-                Id = 17,
-                Obj = WeekDate.MinValue,
-                Date = new DateTime(1970, 02, 14),
-            };
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        #endregion
-
-        #region JSON (De)serialization tests
-
-        [TestCase("Invalid input")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<WeekDate>(json));
-        }
-
-        [Test]
-        public void FromJson_1997W14D6_EqualsTestStruct()
-        {
-            var actual = JsonTester.Read<WeekDate>("1997-W14-6");
-            Assert.AreEqual(TestStruct, actual);
-        }
-
-        [Test]
-        public void ToJson_DefaultValue_AreEqual()
-        {
-            object act = JsonTester.Write(default(WeekDate));
-            object exp = "0001-W01-1";
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void ToJson_TestStruct_AreEqual()
-        {
-            var act = JsonTester.Write(TestStruct);
-            var exp = "1997-W14-6";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IFormattable / ToString tests
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("y#W", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: '1997#14', format: 'y#W'";
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_NullFormatProvider_FormattedString()
-        {
-            using (TestCultures.En_US.Scoped())
-            {
-                var act = TestStruct.ToString(@"y-\WW-d", null);
-                var exp = "1997-W14-6";
-
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void ToString_TestStruct_ComplexPattern()
-        {
-            var act = TestStruct.ToString("");
-            var exp = "1997-W14-6";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_Y1979W3D5FormatWUpper_ComplexPattern()
-        {
-            var act = new WeekDate(1979, 3, 5).ToString(@"y-\WW-d");
-            var exp = "1979-W3-5";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_Y1979W3D5FormatWLower_ComplexPattern()
-        {
-            var act = new WeekDate(1979, 3, 5).ToString(@"y-\Ww-d");
-            var exp = "1979-W03-5";
-            Assert.AreEqual(exp, act);
-        }
-
-        #endregion
-
-        #region IEquatable tests
-
-        /// <summary>GetHash should not fail for WeekDate.Empty.</summary>
-        [Test]
-        public void GetHash_Empty_Hash()
-        {
-            Assert.AreEqual(0, WeekDate.MinValue.GetHashCode());
-        }
-
-        /// <summary>GetHash should not fail for the test struct.</summary>
-        [Test]
-        public void GetHash_TestStruct_Hash()
-        {
-            Assert.AreEqual(2027589483, TestStruct.GetHashCode());
-        }
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            var l = WeekDate.Parse("1997-14-6", CultureInfo.InvariantCulture);
-            var r = WeekDate.Parse("1997-W14-6", CultureInfo.InvariantCulture);
-
-            Assert.IsTrue(l.Equals(r));
-        }
-
-        [Test]
-        public void Equals_TestStructTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructEmpty_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(WeekDate.MinValue));
-        }
-
-        [Test]
-        public void Equals_EmptyTestStruct_IsFalse()
-        {
-            Assert.IsFalse(WeekDate.MinValue.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructObjectTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals((object)TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructNull_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(null));
-        }
-
-        [Test]
-        public void Equals_TestStructObject_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(new object()));
-        }
-
-        [Test]
-        public void OperatorIs_TestStructTestStruct_IsTrue()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsTrue(l == r);
-        }
-
-        [Test]
-        public void OperatorIsNot_TestStructTestStruct_IsFalse()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsFalse(l != r);
-        }
-
-        #endregion
-
-        #region IComparable tests
-
-        /// <summary>Orders a list of week dates ascending.</summary>
-        [Test]
-        public void OrderBy_WeekDate_AreEqual()
-        {
-            var item0 = WeekDate.Parse("2000-W01-3");
-            var item1 = WeekDate.Parse("2000-W11-2");
-            var item2 = WeekDate.Parse("2000-W21-1");
-            var item3 = WeekDate.Parse("2000-W31-7");
-
-            var inp = new List<WeekDate> { WeekDate.MinValue, item3, item2, item0, item1, WeekDate.MinValue };
-            var exp = new List<WeekDate> { WeekDate.MinValue, WeekDate.MinValue, item0, item1, item2, item3 };
-            var act = inp.OrderBy(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Orders a list of week dates descending.</summary>
-        [Test]
-        public void OrderByDescending_WeekDate_AreEqual()
-        {
-            var item0 = WeekDate.Parse("2000-W01-3");
-            var item1 = WeekDate.Parse("2000-W11-2");
-            var item2 = WeekDate.Parse("2000-W21-1");
-            var item3 = WeekDate.Parse("2000-W31-7");
-
-            var inp = new List<WeekDate> { WeekDate.MinValue, item3, item2, item0, item1, WeekDate.MinValue };
-            var exp = new List<WeekDate> { item3, item2, item1, item0, WeekDate.MinValue, WeekDate.MinValue };
-            var act = inp.OrderByDescending(item => item).ToList();
-
-            CollectionAssert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with a to object casted instance should be fine.</summary>
-        [Test]
-        public void CompareTo_ObjectTestStruct_0()
-        {
-            object other = TestStruct;
-
-            var exp = 0;
-            var act = TestStruct.CompareTo(other);
-
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>Compare with null should return 1.</summary>
-        [Test]
-        public void CompareTo_null_1()
-        {
-            object @null = null;
-            Assert.AreEqual(1, TestStruct.CompareTo(@null));
-        }
-
-        /// <summary>Compare with a random object should throw an exception.</summary>
-        [Test]
-        public void CompareTo_newObject_ThrowsArgumentException()
-        {
-            Func<int> compare = () => TestStruct.CompareTo(new object());
-            compare.Should().Throw<ArgumentException>();
-        }
-
-        [Test]
-        public void LessThan_17LT19_IsTrue()
-        {
-            WeekDate l = new(1980, 17, 5);
-            WeekDate r = new(1980, 19, 5);
-
-            Assert.IsTrue(l < r);
-        }
-        [Test]
-        public void GreaterThan_21LT19_IsTrue()
-        {
-            WeekDate l = new(1980, 21, 5);
-            WeekDate r = new(1980, 19, 5);
-
-            Assert.IsTrue(l > r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT19_IsTrue()
-        {
-            WeekDate l = new(1980, 17, 5);
-            WeekDate r = new(1980, 19, 5);
-
-            Assert.IsTrue(l <= r);
-        }
-        [Test]
-        public void GreaterThanOrEqual_21LT19_IsTrue()
-        {
-            WeekDate l = new(1980, 21, 5);
-            WeekDate r = new(1980, 19, 5);
-
-            Assert.IsTrue(l >= r);
-        }
-
-        [Test]
-        public void LessThanOrEqual_17LT17_IsTrue()
-        {
-            WeekDate l = new(1980, 17, 5);
-            WeekDate r = new(1980, 17, 5);
-
-            Assert.IsTrue(l <= r);
-        }
-        [Test]
-        public void GreaterThanOrEqual_21LT21_IsTrue()
-        {
-            WeekDate l = new(1980, 21, 5);
-            WeekDate r = new(1980, 21, 5);
-
-            Assert.IsTrue(l >= r);
-        }
-        #endregion
-
-        #region Casting tests
-
-        [Test]
-        public void Explicit_Int32ToWeekDate_AreEqual()
-        {
-            var exp = TestStruct;
-            var act = (WeekDate)new DateTime(1997, 04, 05);
-
-            Assert.AreEqual(exp, act);
-        }
-        [Test]
-        public void Explicit_WeekDateToInt32_AreEqual()
-        {
-            DateTime exp = new(1997, 04, 05);
-            DateTime act = TestStruct;
-
-            Assert.AreEqual(exp, act);
-        }
-        #endregion
-
-        #region Properties
-
-        [Test]
-        public void Date_TestStruct_AreEqual()
-        {
-            var exp = new Date(1997, 04, 05);
-            var act = TestStruct.Date;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Year_MinValue_AreEqual()
-        {
-            var exp = WeekDate.MinValue.Year;
-            var act = 1;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Year_MaxValue_AreEqual()
-        {
-            var exp = WeekDate.MaxValue.Year;
-            var act = 9999;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Year_Y2010W52D7_AreEqual()
-        {
-            var date = new WeekDate(2010, 52, 7);
-            var exp = 2010;
-            var act = date.Year;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Year_Y2020W01D1_AreEqual()
-        {
-            var date = new WeekDate(2020, 01, 1);
-            var exp = 2020;
-            var act = date.Year;
-
-            Assert.AreEqual(exp, act);
-        }
-
-
-
-
-        [Test]
-        public void Day_TestStruct_AreEqual()
-        {
-            var exp = 6;
-            var act = TestStruct.Day;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void Day_Sunday_AreEqual()
-        {
-            var date = new WeekDate(1990, 40, 7);
-            var exp = 7;
-            var act = date.Day;
-
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void DayOfYear_TestStruct_AreEqual()
-        {
-            var exp = 96;
-            var act = TestStruct.DayOfYear;
-
-            Assert.AreEqual(exp, act);
-        }
-
-
-
-        #endregion
-
-        #region IsValid tests
-
-        [Test]
-        public void IsValid_Data_IsFalse()
-        {
-            Assert.IsFalse(WeekDate.IsValid("Complex"), "Complex");
-            Assert.IsFalse(WeekDate.IsValid((String)null), "(String)null");
-            Assert.IsFalse(WeekDate.IsValid(string.Empty), "string.Empty");
-            Assert.IsFalse(WeekDate.IsValid("0000-W12-6"), "0000-W12-6");
-            Assert.IsFalse(WeekDate.IsValid("0001-W12-8"), "0001-W12-8");
-            Assert.IsFalse(WeekDate.IsValid("9999-W53-1"), "9999-W53-1");
-        }
-        [Test]
-        public void IsValid_Data_IsTrue()
-        {
-            Assert.IsTrue(WeekDate.IsValid("1234-50-6"));
-        }
-        #endregion
+        Assert.AreEqual(default(WeekDate), WeekDate.MinValue);
     }
 
-    [Serializable]
-    public class WeekDateSerializeObject
+    #endregion
+
+    #region week date constructor tests
+
+    [Test]
+    public void Ctor_Y0_ThrowsArgumentOutofRangeException()
     {
-        public int Id { get; set; }
-        public WeekDate Obj { get; set; }
-        public DateTime Date { get; set; }
+        Func<WeekDate> create = () => new WeekDate(0000, 10, 4);
+        create.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Year should be in range [1,9999]. (Parameter 'year')");
     }
+    [Test]
+    public void Ctor_Y10000_ThrowsArgumentOutofRangeException()
+    {
+        Func<WeekDate> create = () => new WeekDate(10000, 10, 4);
+        create.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Year should be in range [1,9999]. (Parameter 'year')");
+    }
+
+    [Test]
+    public void Ctor_W0_ThrowsArgumentOutofRangeException()
+    {
+        Func<WeekDate> create = () => new WeekDate(1980, 0, 4);
+        create.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Week should be in range [1,53]. (Parameter 'week')");
+    }
+    [Test]
+    public void Ctor_W54_ThrowsArgumentOutofRangeException()
+    {
+        Func<WeekDate> create = () => new WeekDate(1980, 54, 4);
+        create.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Week should be in range [1,53]. (Parameter 'week')");
+    }
+
+    [Test]
+    public void Ctor_D0_ThrowsArgumentOutofRangeException()
+    {
+        Func<WeekDate> create = () => new WeekDate(1980, 10, 0);
+        create.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Day should be in range [1,7]. (Parameter 'day')"); 
+    }
+
+    [Test]
+    public void Ctor_D8_ThrowsArgumentOutofRangeException()
+    {
+        Func<WeekDate> create = () => new WeekDate(1980, 10, 8);
+        create.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Day should be in range [1,7]. (Parameter 'day')");
+    }
+
+    [Test]
+    public void Ctor_Y9999W52D6_ThrowsArgumentOutofRangeException()
+    {
+        Func<WeekDate> create = () => new WeekDate(9999, 52, 6);
+        create.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Year, Week, and Day parameters describe an un-representable Date.");
+    }
+
+    [Test]
+    public void Ctor_Y9999W53D1_ThrowsArgumentOutofRangeException()
+    {
+        Func<WeekDate> create = () => new WeekDate(9999, 53, 6);
+        create.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Year, Week, and Day parameters describe an un-representable Date.");
+    }
+
+    #endregion
+
+    #region TryParse tests
+
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsInvalid()
+    {
+        string str = null;
+        Assert.IsFalse(WeekDate.TryParse(str, out _), "Not valid");
+    }
+
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsInvalid()
+    {
+        Assert.IsFalse(WeekDate.TryParse(string.Empty, out _), "Not valid");
+    }
+
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "1234-W50-6";
+        Assert.IsTrue(WeekDate.TryParse(str, out WeekDate val), "Valid");
+        Assert.AreEqual(str, val.ToString(), "Value");
+    }
+
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        Assert.IsFalse(WeekDate.TryParse("string", out _), "Valid");
+    }
+
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Assert.Catch<FormatException>
+            (() =>
+            {
+                WeekDate.Parse("InvalidInput");
+            },
+            "Not a valid week date");
+        }
+    }
+
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = WeekDate.TryParse(exp.ToString());
+
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void from_invalid_as_null_with_TryParse()
+        => WeekDate.TryParse("invalid input").Should().BeNull();
+
+    [Test]
+    public void TryParse_Y0000W21D7_DefaultValue()
+    {
+        WeekDate exp = default;
+        Assert.IsFalse(WeekDate.TryParse("0000-W21-7", out WeekDate act));
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void TryParse_Y2000W53D7_DefaultValue()
+    {
+        WeekDate exp = default;
+        Assert.IsFalse(WeekDate.TryParse("2000-W53-7", out WeekDate act));
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region (XML) (De)serialization tests
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(WeekDate), new System.Runtime.Serialization.FormatterConverter());
+        obj.GetObjectData(info, default);
+
+        Assert.AreEqual((DateTime)TestStruct, info.GetDateTime("Value"));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "1997-W14-6";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<WeekDate>("1997-W14-6");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_WeekDateSerializeObject_AreEqual()
+    {
+        var input = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_WeekDateSerializeObject_AreEqual()
+    {
+        var input = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void DataContractSerializeDeserialize_WeekDateSerializeObject_AreEqual()
+    {
+        var input = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_MinValue_AreEqual()
+    {
+        var input = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = WeekDate.MinValue,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = WeekDate.MinValue,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+    [Test]
+    public void XmlSerializeDeserialize_Empty_AreEqual()
+    {
+        var input = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = WeekDate.MinValue,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var exp = new WeekDateSerializeObject
+        {
+            Id = 17,
+            Obj = WeekDate.MinValue,
+            Date = new DateTime(1970, 02, 14),
+        };
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    #endregion
+
+    #region IFormattable / ToString tests
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("y#W", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: '1997#14', format: 'y#W'";
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_NullFormatProvider_FormattedString()
+    {
+        using (TestCultures.En_US.Scoped())
+        {
+            var act = TestStruct.ToString(@"y-\WW-d", null);
+            var exp = "1997-W14-6";
+
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void ToString_TestStruct_ComplexPattern()
+    {
+        var act = TestStruct.ToString("");
+        var exp = "1997-W14-6";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_Y1979W3D5FormatWUpper_ComplexPattern()
+    {
+        var act = new WeekDate(1979, 3, 5).ToString(@"y-\WW-d");
+        var exp = "1979-W3-5";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_Y1979W3D5FormatWLower_ComplexPattern()
+    {
+        var act = new WeekDate(1979, 3, 5).ToString(@"y-\Ww-d");
+        var exp = "1979-W03-5";
+        Assert.AreEqual(exp, act);
+    }
+
+    #endregion
+
+    #region IEquatable tests
+
+    /// <summary>GetHash should not fail for WeekDate.Empty.</summary>
+    [Test]
+    public void GetHash_Empty_Hash()
+    {
+        Assert.AreEqual(0, WeekDate.MinValue.GetHashCode());
+    }
+
+    /// <summary>GetHash should not fail for the test struct.</summary>
+    [Test]
+    public void GetHash_TestStruct_Hash()
+    {
+        Assert.AreEqual(2027589483, TestStruct.GetHashCode());
+    }
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        var l = WeekDate.Parse("1997-14-6", CultureInfo.InvariantCulture);
+        var r = WeekDate.Parse("1997-W14-6", CultureInfo.InvariantCulture);
+
+        Assert.IsTrue(l.Equals(r));
+    }
+
+    [Test]
+    public void Equals_TestStructTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructEmpty_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(WeekDate.MinValue));
+    }
+
+    [Test]
+    public void Equals_EmptyTestStruct_IsFalse()
+    {
+        Assert.IsFalse(WeekDate.MinValue.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructObjectTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals((object)TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructNull_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(null));
+    }
+
+    [Test]
+    public void Equals_TestStructObject_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(new object()));
+    }
+
+    [Test]
+    public void OperatorIs_TestStructTestStruct_IsTrue()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsTrue(l == r);
+    }
+
+    [Test]
+    public void OperatorIsNot_TestStructTestStruct_IsFalse()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsFalse(l != r);
+    }
+
+    #endregion
+
+    #region IComparable tests
+
+    /// <summary>Orders a list of week dates ascending.</summary>
+    [Test]
+    public void OrderBy_WeekDate_AreEqual()
+    {
+        var item0 = WeekDate.Parse("2000-W01-3");
+        var item1 = WeekDate.Parse("2000-W11-2");
+        var item2 = WeekDate.Parse("2000-W21-1");
+        var item3 = WeekDate.Parse("2000-W31-7");
+
+        var inp = new List<WeekDate> { WeekDate.MinValue, item3, item2, item0, item1, WeekDate.MinValue };
+        var exp = new List<WeekDate> { WeekDate.MinValue, WeekDate.MinValue, item0, item1, item2, item3 };
+        var act = inp.OrderBy(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Orders a list of week dates descending.</summary>
+    [Test]
+    public void OrderByDescending_WeekDate_AreEqual()
+    {
+        var item0 = WeekDate.Parse("2000-W01-3");
+        var item1 = WeekDate.Parse("2000-W11-2");
+        var item2 = WeekDate.Parse("2000-W21-1");
+        var item3 = WeekDate.Parse("2000-W31-7");
+
+        var inp = new List<WeekDate> { WeekDate.MinValue, item3, item2, item0, item1, WeekDate.MinValue };
+        var exp = new List<WeekDate> { item3, item2, item1, item0, WeekDate.MinValue, WeekDate.MinValue };
+        var act = inp.OrderByDescending(item => item).ToList();
+
+        CollectionAssert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with a to object casted instance should be fine.</summary>
+    [Test]
+    public void CompareTo_ObjectTestStruct_0()
+    {
+        object other = TestStruct;
+
+        var exp = 0;
+        var act = TestStruct.CompareTo(other);
+
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>Compare with null should return 1.</summary>
+    [Test]
+    public void CompareTo_null_1()
+    {
+        object @null = null;
+        Assert.AreEqual(1, TestStruct.CompareTo(@null));
+    }
+
+    /// <summary>Compare with a random object should throw an exception.</summary>
+    [Test]
+    public void CompareTo_newObject_ThrowsArgumentException()
+    {
+        Func<int> compare = () => TestStruct.CompareTo(new object());
+        compare.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void LessThan_17LT19_IsTrue()
+    {
+        WeekDate l = new(1980, 17, 5);
+        WeekDate r = new(1980, 19, 5);
+
+        Assert.IsTrue(l < r);
+    }
+    [Test]
+    public void GreaterThan_21LT19_IsTrue()
+    {
+        WeekDate l = new(1980, 21, 5);
+        WeekDate r = new(1980, 19, 5);
+
+        Assert.IsTrue(l > r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT19_IsTrue()
+    {
+        WeekDate l = new(1980, 17, 5);
+        WeekDate r = new(1980, 19, 5);
+
+        Assert.IsTrue(l <= r);
+    }
+    [Test]
+    public void GreaterThanOrEqual_21LT19_IsTrue()
+    {
+        WeekDate l = new(1980, 21, 5);
+        WeekDate r = new(1980, 19, 5);
+
+        Assert.IsTrue(l >= r);
+    }
+
+    [Test]
+    public void LessThanOrEqual_17LT17_IsTrue()
+    {
+        WeekDate l = new(1980, 17, 5);
+        WeekDate r = new(1980, 17, 5);
+
+        Assert.IsTrue(l <= r);
+    }
+    [Test]
+    public void GreaterThanOrEqual_21LT21_IsTrue()
+    {
+        WeekDate l = new(1980, 21, 5);
+        WeekDate r = new(1980, 21, 5);
+
+        Assert.IsTrue(l >= r);
+    }
+    #endregion
+
+    #region Casting tests
+
+    [Test]
+    public void Explicit_Int32ToWeekDate_AreEqual()
+    {
+        var exp = TestStruct;
+        var act = (WeekDate)new DateTime(1997, 04, 05);
+
+        Assert.AreEqual(exp, act);
+    }
+    [Test]
+    public void Explicit_WeekDateToInt32_AreEqual()
+    {
+        DateTime exp = new(1997, 04, 05);
+        DateTime act = TestStruct;
+
+        Assert.AreEqual(exp, act);
+    }
+    #endregion
+
+    #region Properties
+
+    [Test]
+    public void Date_TestStruct_AreEqual()
+    {
+        var exp = new Date(1997, 04, 05);
+        var act = TestStruct.Date;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Year_MinValue_AreEqual()
+    {
+        var exp = WeekDate.MinValue.Year;
+        var act = 1;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Year_MaxValue_AreEqual()
+    {
+        var exp = WeekDate.MaxValue.Year;
+        var act = 9999;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Year_Y2010W52D7_AreEqual()
+    {
+        var date = new WeekDate(2010, 52, 7);
+        var exp = 2010;
+        var act = date.Year;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Year_Y2020W01D1_AreEqual()
+    {
+        var date = new WeekDate(2020, 01, 1);
+        var exp = 2020;
+        var act = date.Year;
+
+        Assert.AreEqual(exp, act);
+    }
+
+
+
+
+    [Test]
+    public void Day_TestStruct_AreEqual()
+    {
+        var exp = 6;
+        var act = TestStruct.Day;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void Day_Sunday_AreEqual()
+    {
+        var date = new WeekDate(1990, 40, 7);
+        var exp = 7;
+        var act = date.Day;
+
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void DayOfYear_TestStruct_AreEqual()
+    {
+        var exp = 96;
+        var act = TestStruct.DayOfYear;
+
+        Assert.AreEqual(exp, act);
+    }
+
+
+
+    #endregion
+
+    #region IsValid tests
+
+    [Test]
+    public void IsValid_Data_IsFalse()
+    {
+        Assert.IsFalse(WeekDate.IsValid("Complex"), "Complex");
+        Assert.IsFalse(WeekDate.IsValid((String)null), "(String)null");
+        Assert.IsFalse(WeekDate.IsValid(string.Empty), "string.Empty");
+        Assert.IsFalse(WeekDate.IsValid("0000-W12-6"), "0000-W12-6");
+        Assert.IsFalse(WeekDate.IsValid("0001-W12-8"), "0001-W12-8");
+        Assert.IsFalse(WeekDate.IsValid("9999-W53-1"), "9999-W53-1");
+    }
+    [Test]
+    public void IsValid_Data_IsTrue()
+    {
+        Assert.IsTrue(WeekDate.IsValid("1234-50-6"));
+    }
+    #endregion
+}
+
+[Serializable]
+public class WeekDateSerializeObject
+{
+    public int Id { get; set; }
+    public WeekDate Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/Web/InternetMediaType_specs.cs
+++ b/specs/Qowaiv.Specs/Web/InternetMediaType_specs.cs
@@ -43,6 +43,43 @@ public class Supports_type_conversion
     }
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase(null, "")]
+    [TestCase("application/x-chess-pgn", "application/x-chess-pgn")]
+    public void System_Text_JSON_deserialization(InternetMediaType svo, object json)
+    => JsonTester.Read_System_Text_JSON<InternetMediaType>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("application/x-chess-pgn", "application/x-chess-pgn")]
+    public void System_Text_JSON_serialization(object json, InternetMediaType svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(null, "")]
+    [TestCase("application/x-chess-pgn", "application/x-chess-pgn")]
+    public void convention_based_deserialization(InternetMediaType svo, object json)
+        => JsonTester.Read<InternetMediaType>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("application/x-chess-pgn", "application/x-chess-pgn")]
+    public void convention_based_serialization(object json, InternetMediaType svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<InternetMediaType>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+
+    [TestCase("Invalid input")]
+    [TestCase("2017-06-11")]
+    public void FromJson_Invalid_Throws(object json)
+    {
+        Assert.Catch<FormatException>(() => JsonTester.Read<InternetMediaType>(json));
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/Web/InternetMediaType_specs.cs
+++ b/specs/Qowaiv.Specs/Web/InternetMediaType_specs.cs
@@ -45,24 +45,23 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase(null, "")]
+    [TestCase(null, null)]
     [TestCase("application/x-chess-pgn", "application/x-chess-pgn")]
-    public void System_Text_JSON_deserialization(InternetMediaType svo, object json)
-    => JsonTester.Read_System_Text_JSON<InternetMediaType>(json).Should().Be(svo);
+    public void System_Text_JSON_deserialization(object json, InternetMediaType svo)
+        => JsonTester.Read_System_Text_JSON<InternetMediaType>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
     [TestCase("application/x-chess-pgn", "application/x-chess-pgn")]
-    public void System_Text_JSON_serialization(object json, InternetMediaType svo)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
-    [TestCase(null, "")]
-    [TestCase("application/x-chess-pgn", "application/x-chess-pgn")]
-    public void convention_based_deserialization(InternetMediaType svo, object json)
+    public void convention_based_deserialization(object json, InternetMediaType svo)
         => JsonTester.Read<InternetMediaType>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
+    [TestCase(null, null)]
     [TestCase("application/x-chess-pgn", "application/x-chess-pgn")]
-    public void convention_based_serialization(object json, InternetMediaType svo)
+    public void System_Text_JSON_serialization(InternetMediaType svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(null, null)]
+    [TestCase("application/x-chess-pgn", "application/x-chess-pgn")]
+    public void convention_based_serialization(InternetMediaType svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/WeekDate_specs.cs
+++ b/specs/Qowaiv.Specs/WeekDate_specs.cs
@@ -66,6 +66,33 @@ public class Supports_type_conversion
         => Converting.To<LocalDateTime>().From(Svo.WeekDate).Should().Be(new LocalDateTime(2017, 06, 11));
 }
 
+public class Supports_JSON_serialization
+{
+    [TestCase("1997-W14-6", "1997-W14-6")]
+    public void System_Text_JSON_deserialization(WeekDate svo, object json)
+        => JsonTester.Read_System_Text_JSON<WeekDate>(json).Should().Be(svo);
+
+    [TestCase("1997-W14-6", "1997-W14-6")]
+    public void System_Text_JSON_serialization(object json, WeekDate svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("1997-W14-6", "1997-W14-6")]
+    public void convention_based_deserialization(WeekDate svo, object json)
+        => JsonTester.Read<WeekDate>(json).Should().Be(svo);
+
+    [TestCase("1997-W14-6", "1997-W14-6")]
+    public void convention_based_serialization(object json, WeekDate svo)
+        => JsonTester.Write(svo).Should().Be(json);
+
+    [TestCase("Invalid input", typeof(FormatException))]
+    [TestCase("yyyy-06-11", typeof(FormatException))]
+    [TestCase(true, typeof(InvalidOperationException))]
+    public void throws_for_invalid_json(object json, Type exceptionType)
+    {
+        var exception = Assert.Catch(() => JsonTester.Read<WeekDate>(json));
+        Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/WeekDate_specs.cs
+++ b/specs/Qowaiv.Specs/WeekDate_specs.cs
@@ -69,19 +69,19 @@ public class Supports_type_conversion
 public class Supports_JSON_serialization
 {
     [TestCase("1997-W14-6", "1997-W14-6")]
-    public void System_Text_JSON_deserialization(WeekDate svo, object json)
+    public void System_Text_JSON_deserialization(object json, WeekDate svo)
         => JsonTester.Read_System_Text_JSON<WeekDate>(json).Should().Be(svo);
 
     [TestCase("1997-W14-6", "1997-W14-6")]
-    public void System_Text_JSON_serialization(object json, WeekDate svo)
-        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
-
-    [TestCase("1997-W14-6", "1997-W14-6")]
-    public void convention_based_deserialization(WeekDate svo, object json)
+    public void convention_based_deserialization(object json, WeekDate svo)
         => JsonTester.Read<WeekDate>(json).Should().Be(svo);
 
     [TestCase("1997-W14-6", "1997-W14-6")]
-    public void convention_based_serialization(object json, WeekDate svo)
+    public void System_Text_JSON_serialization(WeekDate svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("1997-W14-6", "1997-W14-6")]
+    public void convention_based_serialization(WeekDate svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -468,6 +468,21 @@ public class Supports_JSON_serialization
     [TestCase("?", "unknown")]
     [TestCase(2017, "2017")]
     [TestCase(2017, 2017L)]
+    [TestCase(2017, 2017.0)]
+    public void System_Text_JSON_deserialization(Year svo, object json)
+    => JsonTester.Read_System_Text_JSON<Year>(json).Should().Be(svo);
+
+    [TestCase(null, "")]
+    [TestCase("?", "unknown")]
+    [TestCase(2017L, "2017")]
+    public void System_Text_JSON_serialization(object json, Year svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+
+    [TestCase("?", "unknown")]
+    [TestCase(2017, "2017")]
+    [TestCase(2017, 2017L)]
+    [TestCase(2017, 2017.0)]
     public void convention_based_deserialization(Year expected, object json)
     {
         var actual = JsonTester.Read<Year>(json);

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -465,38 +465,30 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
-    [TestCase("?", "unknown")]
-    [TestCase(2017, "2017")]
-    [TestCase(2017, 2017L)]
-    [TestCase(2017, 2017.0)]
-    public void System_Text_JSON_deserialization(Year svo, object json)
-    => JsonTester.Read_System_Text_JSON<Year>(json).Should().Be(svo);
+    [TestCase("?", "?")]
+    [TestCase(null, null)]
+    [TestCase(2017d, 2017)]
+    [TestCase(2017L, 2017)]
+    [TestCase("2017", 2017)]
+    public void System_Text_JSON_deserialization(object json, Year svo)
+        => JsonTester.Read_System_Text_JSON<Year>(json).Should().Be(svo);
 
-    [TestCase(null, "")]
-    [TestCase("?", "unknown")]
-    [TestCase(2017L, "2017")]
-    public void System_Text_JSON_serialization(object json, Year svo)
+    [TestCase("?", "?")]
+    [TestCase(2017d, 2017)]
+    [TestCase(2017L, 2017)]
+    [TestCase("2017", 2017)]
+    public void convention_based_deserialization(object json, Year svo)
+        => JsonTester.Read<Year>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase(2017, 2017L)]
+    public void System_Text_JSON_serialization(Year svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
-
-    [TestCase("?", "unknown")]
-    [TestCase(2017, "2017")]
+    [TestCase(null, null)]
     [TestCase(2017, 2017L)]
-    [TestCase(2017, 2017.0)]
-    public void convention_based_deserialization(Year expected, object json)
-    {
-        var actual = JsonTester.Read<Year>(json);
-        Assert.AreEqual(expected, actual);
-    }
-
-    [TestCase(null, "")]
-    [TestCase("?", "unknown")]
-    [TestCase(2017L, "2017")]
-    public void convention_based_serialization(object expected, Year svo)
-    {
-        var serialized = JsonTester.Write(svo);
-        Assert.AreEqual(expected, serialized);
-    }
+    public void convention_based_serialization(Year svo, object json)
+        => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]
     [TestCase("2017-06-11", typeof(FormatException))]

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -479,6 +479,25 @@ public class Supports_JSON_serialization
     [TestCase("?", (long)int.MaxValue)]
     [TestCase("?", long.MaxValue)]
     [TestCase("?", "unknown")]
+    public void System_Text_JSON_deserialization(YesNo svo, object json)
+        => JsonTester.Read_System_Text_JSON<YesNo>(json).Should().Be(svo);
+    
+    [TestCase(null, "")]
+    [TestCase("yes", "yes")]
+    public void System_Text_JSON_serialization(object json, YesNo svo)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase("yes", "yes")]
+    [TestCase("yes", true)]
+    [TestCase("no", false)]
+    [TestCase("yes", 1L)]
+    [TestCase("yes", 1.1)]
+    [TestCase("no", 0.0)]
+    [TestCase("?", (long)byte.MaxValue)]
+    [TestCase("?", (long)short.MaxValue)]
+    [TestCase("?", (long)int.MaxValue)]
+    [TestCase("?", long.MaxValue)]
+    [TestCase("?", "unknown")]
     public void convention_based_deserialization(YesNo expected, object json)
     {
         var actual = JsonTester.Read<YesNo>(json);

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -468,49 +468,46 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
+    [TestCase(null, null)]
     [TestCase("yes", "yes")]
-    [TestCase("yes", true)]
-    [TestCase("no", false)]
-    [TestCase("yes", 1L)]
-    [TestCase("yes", 1.1)]
-    [TestCase("no", 0.0)]
-    [TestCase("?", (long)byte.MaxValue)]
-    [TestCase("?", (long)short.MaxValue)]
-    [TestCase("?", (long)int.MaxValue)]
-    [TestCase("?", long.MaxValue)]
-    [TestCase("?", "unknown")]
-    public void System_Text_JSON_deserialization(YesNo svo, object json)
+    [TestCase("no", "no")]
+    [TestCase(true, "yes")]
+    [TestCase(false, "no")]
+    [TestCase(1L, "yes")]
+    [TestCase(1.0, "yes")]
+    [TestCase(0.0, "no")]
+    [TestCase((long)byte.MaxValue, "?")]
+    [TestCase((long)short.MaxValue, "?")]
+    [TestCase((long)int.MaxValue, "?")]
+    [TestCase(long.MaxValue, "?")]
+    [TestCase("?", "?")]
+    public void System_Text_JSON_deserialization(object json, YesNo svo)
         => JsonTester.Read_System_Text_JSON<YesNo>(json).Should().Be(svo);
-    
-    [TestCase(null, "")]
+
     [TestCase("yes", "yes")]
-    public void System_Text_JSON_serialization(object json, YesNo svo)
+    [TestCase("no", "no")]
+    [TestCase(true, "yes")]
+    [TestCase(false, "no")]
+    [TestCase(1L, "yes")]
+    [TestCase(1.0, "yes")]
+    [TestCase(0.0, "no")]
+    [TestCase((long)byte.MaxValue, "?")]
+    [TestCase((long)short.MaxValue, "?")]
+    [TestCase((long)int.MaxValue, "?")]
+    [TestCase(long.MaxValue, "?")]
+    [TestCase("?", "?")]
+    public void convention_based_deserialization(object json, YesNo svo)
+        => JsonTester.Read<YesNo>(json).Should().Be(svo);
+
+    [TestCase(null, null)]
+    [TestCase("yes", "yes")]
+    public void System_Text_JSON_serialization(YesNo svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
 
+    [TestCase(null, null)]
     [TestCase("yes", "yes")]
-    [TestCase("yes", true)]
-    [TestCase("no", false)]
-    [TestCase("yes", 1L)]
-    [TestCase("yes", 1.1)]
-    [TestCase("no", 0.0)]
-    [TestCase("?", (long)byte.MaxValue)]
-    [TestCase("?", (long)short.MaxValue)]
-    [TestCase("?", (long)int.MaxValue)]
-    [TestCase("?", long.MaxValue)]
-    [TestCase("?", "unknown")]
-    public void convention_based_deserialization(YesNo expected, object json)
-    {
-        var actual = JsonTester.Read<YesNo>(json);
-        Assert.AreEqual(expected, actual);
-    }
-
-    [TestCase(null, "")]
-    [TestCase("yes", "yes")]
-    public void convention_based_serialization(object expected, YesNo svo)
-    {
-        var serialized = JsonTester.Write(svo);
-        Assert.AreEqual(expected, serialized);
-    }
+    public void convention_based_serialization(YesNo svo, object json)
+        => JsonTester.Write(svo).Should().Be(json);
 
     [TestCase("Invalid input", typeof(FormatException))]
     [TestCase("2017-06-11", typeof(FormatException))]

--- a/src/Qowaiv.Data.SqlClient/Json/TimestampJsonConverter.cs
+++ b/src/Qowaiv.Data.SqlClient/Json/TimestampJsonConverter.cs
@@ -11,6 +11,14 @@ public sealed class TimestampJsonConverter : SvoJsonConverter<Timestamp>
 
     /// <inheritdoc />
     [Pure]
+    protected override Timestamp FromJson(long json) => Timestamp.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Timestamp FromJson(double json) => Timestamp.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
     protected override object? ToJson(Timestamp svo) => svo.ToJson();
 }
 

--- a/src/Qowaiv.Data.SqlClient/Json/TimestampJsonConverter.cs
+++ b/src/Qowaiv.Data.SqlClient/Json/TimestampJsonConverter.cs
@@ -1,0 +1,17 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Sql.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class TimestampJsonConverter : SvoJsonConverter<Timestamp>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Timestamp FromJson(string? json) => Timestamp.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Timestamp svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv.Data.SqlClient/Json/TimestampJsonConverter.cs
+++ b/src/Qowaiv.Data.SqlClient/Json/TimestampJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Sql.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a timestamp.</summary>
 public sealed class TimestampJsonConverter : SvoJsonConverter<Timestamp>
 {
     /// <inheritdoc />

--- a/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
+++ b/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
@@ -6,6 +6,9 @@
 [OpenApiDataType(description: "SQL Server timestamp notation.", example: "0x00000000000007D9", type: "string", format: "timestamp")]
 [OpenApi.OpenApiDataType(description: "SQL Server timestamp notation.", example: "0x00000000000007D9", type: "string", format: "timestamp")]
 [TypeConverter(typeof(Conversion.Sql.TimestampTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.TimestampJsonConverter))]
+#endif
 public readonly partial struct Timestamp : ISerializable, IXmlSerializable, IFormattable, IEquatable<Timestamp>, IComparable, IComparable<Timestamp>
 {
     /// <summary>Gets the minimum value of a timestamp.</summary>

--- a/src/Qowaiv.TestTools/JsonTester.cs
+++ b/src/Qowaiv.TestTools/JsonTester.cs
@@ -27,7 +27,7 @@ public static class JsonTester
     }
     /// <summary>Writes the JSON using System.Text.Json.</summary>
     /// <remarks>
-    /// <see cref="JsonSerializer.SerializeToElement"/> is only available in .NET 6.0 
+    /// <see cref="JsonSerializer.SerializeToElement(object?, Type, JsonSerializerOptions?)"/> is only available in .NET 6.0 
     /// </remarks>
     [Pure]
     public static object? Write_System_Text_JSON(object? svo)

--- a/src/Qowaiv.TestTools/JsonTester.cs
+++ b/src/Qowaiv.TestTools/JsonTester.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-#if NET6_0_OR_GREATER
+#if NET5_0_OR_GREATER
 using System.Text.Json;
 #endif
 namespace Qowaiv.TestTools;
@@ -7,7 +7,7 @@ namespace Qowaiv.TestTools;
 /// <summary>Helper class for testing JSON conversion.</summary>
 public static class JsonTester
 {
-#if NET6_0_OR_GREATER
+#if NET5_0_OR_GREATER
     /// <summary>
     /// 
     /// </summary>

--- a/src/Qowaiv.TestTools/JsonTester.cs
+++ b/src/Qowaiv.TestTools/JsonTester.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Text.Json;
 #endif
 namespace Qowaiv.TestTools;
@@ -7,10 +7,8 @@ namespace Qowaiv.TestTools;
 /// <summary>Helper class for testing JSON conversion.</summary>
 public static class JsonTester
 {
-#if NET5_0_OR_GREATER
-    /// <summary>
-    /// 
-    /// </summary>
+#if NET6_0_OR_GREATER
+    /// <summary>Reads the JSON using System.Text.Json.</summary>
     [Pure]
     public static T? Read_System_Text_JSON<T>(object? val)
     {
@@ -27,10 +25,10 @@ public static class JsonTester
             };
 
     }
-
-    /// <summary>
-    /// 
-    /// </summary>
+    /// <summary>Writes the JSON using System.Text.Json.</summary>
+    /// <remarks>
+    /// <see cref="JsonSerializer.SerializeToElement"/> is only available in .NET 6.0 
+    /// </remarks>
     [Pure]
     public static object? Write_System_Text_JSON(object? svo)
     {

--- a/src/Qowaiv.TestTools/JsonTester.cs
+++ b/src/Qowaiv.TestTools/JsonTester.cs
@@ -12,16 +12,16 @@ public static class JsonTester
     [Pure]
     public static T? Read_System_Text_JSON<T>(object? val)
     {
-        return JsonSerializer.Deserialize<T>(ToString(val)?? string.Empty);
+        return JsonSerializer.Deserialize<T>(ToString(val));
 
-        static string? ToString(object? val)
+        static string ToString(object? val)
             => val switch
             {
                 string str => @$"""{str}""",
                 bool boolean => boolean ? "true" : "false",
                 IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
                 null => "null",
-                _ => val?.ToString(),
+                _ => val?.ToString() ?? string.Empty,
             };
 
     }

--- a/src/Qowaiv.TestTools/JsonTester.cs
+++ b/src/Qowaiv.TestTools/JsonTester.cs
@@ -1,10 +1,54 @@
 ﻿using System.Reflection;
-
+#if NET6_0_OR_GREATER
+using System.Text.Json;
+#endif
 namespace Qowaiv.TestTools;
 
 /// <summary>Helper class for testing JSON conversion.</summary>
 public static class JsonTester
 {
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// 
+    /// </summary>
+    [Pure]
+    public static T? Read_System_Text_JSON<T>(object? val)
+    {
+        return JsonSerializer.Deserialize<T>(ToString(val)?? string.Empty);
+
+        static string? ToString(object? val)
+            => val switch
+            {
+                string str => @$"""{str}""",
+                bool boolean => boolean ? "true" : "false",
+                IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+                null => "null",
+                _ => val?.ToString(),
+            };
+
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    [Pure]
+    public static object? Write_System_Text_JSON(object? svo)
+    {
+        var json = JsonSerializer.SerializeToElement(svo);
+
+        if (json.ValueKind == JsonValueKind.String) return json.GetString();
+        else if (json.ValueKind == JsonValueKind.Number)
+        {
+            if (json.TryGetInt32(out var int32)) return int32;
+            else if (json.TryGetInt64(out var int64)) return int64;
+            else if (json.TryGetDouble(out var number)) return number;
+            else return null;
+        }
+        else return null;
+    }
+
+#endif
+
     /// <summary>Applies multiple FromJson scenario's.</summary>
     [Pure]
     public static T? Read<T>(object? val)

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -5,8 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.0.0</Version>
+    <Version>6.3.0</Version>
     <PackageReleaseNotes>
+v6.3.0
+- JSON serialization via System.Text.Json does not longer require a custom converter. #259
 v6.0.0
 - Added .NET 6.0 version to the package. #216
 - Added Serialize, SerializeDeserialize, and Converting helpers. #218

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -8,7 +8,7 @@
     <Version>6.3.0</Version>
     <PackageReleaseNotes>
 v6.3.0
-- JSON serialization via System.Text.Json does not longer require a custom converter. #259
+- JSON serialization via System.Text.Json no longer requires a custom converter. #259
 v6.0.0
 - Added .NET 6.0 version to the package. #216
 - Added Serialize, SerializeDeserialize, and Converting helpers. #218

--- a/src/Qowaiv/Chemistry/CasRegistryNumber.cs
+++ b/src/Qowaiv/Chemistry/CasRegistryNumber.cs
@@ -17,6 +17,9 @@ namespace Qowaiv.Chemistry;
 [OpenApiDataType(description: "CAS Registry Number", type: "string", format: "cas-nr", example: "7732-18-5", pattern: "[1-9][0-9]+\\-[0-9]{2}\\-[0-9]", nullable: true)]
 [OpenApi.OpenApiDataType(description: "CAS Registry Number", type: "string", format: "cas-nr", example: "7732-18-5", pattern: "[1-9][0-9]+\\-[0-9]{2}\\-[0-9]", nullable: true)]
 [TypeConverter(typeof(Conversion.Chemistry.CasRegistryNumberTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Chemistry.CasRegistryNumberJsonConverter))]
+#endif
 public readonly partial struct CasRegistryNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<CasRegistryNumber>, IComparable, IComparable<CasRegistryNumber>
 {
     /// <summary>Represents an empty/not set CAS Registry Number.</summary>

--- a/src/Qowaiv/Customization/Svo.cs
+++ b/src/Qowaiv/Customization/Svo.cs
@@ -12,6 +12,9 @@ namespace Qowaiv.Customization;
 [SingleValueObject(SingleValueStaticOptions.All, typeof(string))]
 [OpenApiDataType(description: "Single Value Object", type: "Svo", format: "Svo", example: "ABC")]
 [TypeConverter(typeof(SvoTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Customization.GenericSvoJsonConverter))]
+#endif
 public readonly partial struct Svo<TSvoBehavior> : ISerializable, IXmlSerializable, IFormattable, IEquatable<Svo<TSvoBehavior>>, IComparable, IComparable<Svo<TSvoBehavior>>
     where TSvoBehavior : SvoBehavior, new()
 {

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -6,6 +6,9 @@
 [OpenApiDataType(description: "Full-date notation as defined by RFC 3339, section 5.6.", example: "2017-06-10", type: "string", format: "date")]
 [OpenApi.OpenApiDataType(description: "Full-date notation as defined by RFC 3339, section 5.6.", example: "2017-06-10", type: "string", format: "date")]
 [TypeConverter(typeof(DateTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.DateJsonConverter))]
+#endif
 public readonly partial struct Date : ISerializable, IXmlSerializable, IFormattable, IEquatable<Date>, IComparable, IComparable<Date>
 {
     private const string SerializableFormat = "yyyy-MM-dd";

--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -6,6 +6,9 @@ namespace Qowaiv;
 [OpenApiDataType(description: "Date span, specified in years, months and days.", example: "1Y+10M+16D", type: "string", format: "date-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D")]
 [OpenApi.OpenApiDataType(description: "Date span, specified in years, months and days.", example: "1Y+10M+16D", type: "string", format: "date-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D")]
 [TypeConverter(typeof(DateSpanTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.DateSpanJsonConverter))]
+#endif
 public readonly partial struct DateSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<DateSpan>, IComparable, IComparable<DateSpan>
 {
     /// <summary>Represents the pattern of a (potential) valid year.</summary>

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -12,6 +12,9 @@ namespace Qowaiv;
 [OpenApiDataType(description: "Email notation as defined by RFC 5322.", example: "svo@qowaiv.org", type: "string", format: "email", nullable: true)]
 [OpenApi.OpenApiDataType(description: "Email notation as defined by RFC 5322.", example: "svo@qowaiv.org", type: "string", format: "email", nullable: true)]
 [TypeConverter(typeof(EmailAddressTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.EmailAddressJsonConverter))]
+#endif
 public readonly partial struct EmailAddress : ISerializable, IXmlSerializable, IFormattable, IEquatable<EmailAddress>, IComparable, IComparable<EmailAddress>
 {
     /// <summary>An email address must not exceed 254 characters.</summary>

--- a/src/Qowaiv/EmailAddressCollection.cs
+++ b/src/Qowaiv/EmailAddressCollection.cs
@@ -255,7 +255,7 @@ public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSer
     /// The deserialized email address collection.
     /// </returns>
     [Pure]
-    public static EmailAddressCollection FromJson(string json) => Parse(json, CultureInfo.InvariantCulture);
+    public static EmailAddressCollection FromJson(string? json) => Parse(json, CultureInfo.InvariantCulture);
 
     /// <summary>Serializes the email address collection to a JSON node.</summary>
     /// <returns>

--- a/src/Qowaiv/Extensions/System.Security.Cryptography.HashAlgorithm.cs
+++ b/src/Qowaiv/Extensions/System.Security.Cryptography.HashAlgorithm.cs
@@ -1,6 +1,5 @@
 ﻿using Qowaiv;
 using Qowaiv.Security.Cryptography;
-using System.Diagnostics.Contracts;
 
 namespace System.Security.Cryptography
 {

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -8,6 +8,9 @@ namespace Qowaiv.Financial;
 [OpenApiDataType(description: "Decimal representation of a currency amount.", example: 15.95, type: "number", format: "amount")]
 [OpenApi.OpenApiDataType(description: "Decimal representation of a currency amount.", example: 15.95, type: "number", format: "amount")]
 [TypeConverter(typeof(AmountTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.AmountJsonConverter))]
+#endif
 public readonly partial struct Amount : ISerializable, IXmlSerializable, IFormattable, IEquatable<Amount>, IComparable, IComparable<Amount>
 {
     /// <summary>Represents an Amount of zero.</summary>

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -26,6 +26,9 @@ namespace Qowaiv.Financial;
 [OpenApiDataType(description: "Business Identifier Code, as defined by ISO 9362.", example: "DEUTDEFF", type: "string", format: "bic", nullable: true)]
 [OpenApi.OpenApiDataType(description: "Business Identifier Code, as defined by ISO 9362.", example: "DEUTDEFF", type: "string", format: "bic", nullable: true)]
 [TypeConverter(typeof(BusinessIdentifierCodeTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.BusinessIdentifierCodeJsonConverter))]
+#endif
 public readonly partial struct BusinessIdentifierCode : ISerializable, IXmlSerializable, IFormattable, IEquatable<BusinessIdentifierCode>, IComparable, IComparable<BusinessIdentifierCode>
 {
     /// <remarks>

--- a/src/Qowaiv/Financial/Currency.cs
+++ b/src/Qowaiv/Financial/Currency.cs
@@ -25,6 +25,9 @@ namespace Qowaiv.Financial;
 [OpenApiDataType(description: "Currency notation as defined by ISO 4217.", example: "EUR", type: "string", format: "currency", nullable: true)]
 [OpenApi.OpenApiDataType(description: "Currency notation as defined by ISO 4217.", example: "EUR", type: "string", format: "currency", nullable: true)]
 [TypeConverter(typeof(CurrencyTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.CurrencyJsonConverter))]
+#endif
 public readonly partial struct Currency : ISerializable, IXmlSerializable, IFormattable, IFormatProvider, IEquatable<Currency>, IComparable, IComparable<Currency>
 {
     /// <summary>Represents an empty/not set currency.</summary>

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -21,6 +21,9 @@ namespace Qowaiv.Financial;
 [OpenApiDataType(description: "International Bank Account Number notation as defined by ISO 13616:2007.", example: "BE71096123456769.", type: "string", format: "iban", nullable: true)]
 [OpenApi.OpenApiDataType(description: "International Bank Account Number notation as defined by ISO 13616:2007.", example: "BE71096123456769.", type: "string", format: "iban", nullable: true)]
 [TypeConverter(typeof(InternationalBankAccountNumberTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.InternationalBankAccountNumberJsonConverter))]
+#endif
 public readonly partial struct InternationalBankAccountNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<InternationalBankAccountNumber>, IComparable, IComparable<InternationalBankAccountNumber>
 {
     /// <summary>Represents the pattern of a (potential) valid IBAN.</summary>

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -9,6 +9,9 @@ namespace Qowaiv.Financial;
 [OpenApiDataType(description: "Combined currency and amount notation as defined by ISO 4217.", example: "EUR12.47", type: "string", format: "money", pattern: @"[A-Z]{3} -?[0-9]+(\.[0-9]+)?")]
 [OpenApi.OpenApiDataType(description: "Combined currency and amount notation as defined by ISO 4217.", example: "EUR12.47", type: "string", format: "money", pattern: @"[A-Z]{3} -?[0-9]+(\.[0-9]+)?")]
 [TypeConverter(typeof(MoneyTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.MoneyJsonConverter))]
+#endif
 public readonly partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEquatable<Money>, IComparable, IComparable<Money>
 {
     /// <summary>Represents an Amount of zero.</summary>

--- a/src/Qowaiv/Gender.cs
+++ b/src/Qowaiv/Gender.cs
@@ -24,6 +24,9 @@ namespace Qowaiv;
 [Serializable, SingleValueObject(SingleValueStaticOptions.All, typeof(byte))]
 [OpenApiDataType(description: "Gender as specified by ISO/IEC 5218.", example: "female", type: "string", format: "gender", nullable: true, @enum: "NotKnown,Male,Female,NotApplicable")]
 [TypeConverter(typeof(GenderTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.GenderJsonConverter))]
+#endif
 [Obsolete("Will be dropped in version 7. Use Qowaiv.Sex instead.")]
 public readonly partial struct Gender : ISerializable, IXmlSerializable, IFormattable, IEquatable<Gender>, IComparable, IComparable<Gender>
 {

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -114,7 +114,7 @@ public partial struct Uuid
     /// The deserialized UUID.
     /// </returns>
     [Pure]
-    public static Uuid FromJson(string json) => Parse(json);
+    public static Uuid FromJson(string? json) => Parse(json);
 }
 
 public partial struct Uuid : IXmlSerializable

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -120,7 +120,7 @@ public partial struct InternetMediaType
     /// The deserialized Internet media type.
     /// </returns>
     [Pure]
-    public static InternetMediaType FromJson(string json) => Parse(json);
+    public static InternetMediaType FromJson(string? json) => Parse(json);
 }
 
 public partial struct InternetMediaType : IXmlSerializable

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -16,6 +16,9 @@ namespace Qowaiv.Globalization;
 [OpenApiDataType(description: "Country notation as defined by ISO 3166-1 alpha-2.", example: "NL", type: "string", format: "country", nullable: true)]
 [OpenApi.OpenApiDataType(description: "Country notation as defined by ISO 3166-1 alpha-2.", example: "NL", type: "string", format: "country", nullable: true)]
 [TypeConverter(typeof(CountryTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Globalization.CountryJsonConverter))]
+#endif
 public readonly partial struct Country : ISerializable, IXmlSerializable, IFormattable, IEquatable<Country>, IComparable, IComparable<Country>
 {
     /// <summary>Represents an empty/not set </summary>

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -6,6 +6,9 @@
 [OpenApiDataType(description: "House number notation.", example: "13", type: "string", format: "house-number", nullable: true)]
 [OpenApi.OpenApiDataType(description: "House number notation.", example: "13", type: "string", format: "house-number", nullable: true)]
 [TypeConverter(typeof(HouseNumberTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.HouseNumberJsonConverter))]
+#endif
 public readonly partial struct HouseNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<HouseNumber>, IComparable, IComparable<HouseNumber>
 {
     /// <summary>Represents the pattern of a (potential) valid house number.</summary>

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -17,6 +17,9 @@ namespace Qowaiv.IO;
 [OpenApiDataType(description: "Stream size notation (in byte).", example: 1024, type: "integer", format: "stream-size")]
 [OpenApi.OpenApiDataType(description: "Stream size notation (in byte).", example: 1024, type: "integer", format: "stream-size")]
 [TypeConverter(typeof(StreamSizeTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.IO.StreamSizeJsonConverter))]
+#endif
 public readonly partial struct StreamSize : ISerializable, IXmlSerializable, IFormattable, IEquatable<StreamSize>, IComparable, IComparable<StreamSize>
 {
     /// <summary>Represents an empty/not set stream size.</summary>

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -237,7 +237,7 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Id<TIdentifier> Parse(string s)
+    public static Id<TIdentifier> Parse(string? s)
     {
         return TryParse(s, out Id<TIdentifier> val)
             ? val
@@ -252,7 +252,7 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     /// The identifier if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Id<TIdentifier> TryParse(string s)
+    public static Id<TIdentifier> TryParse(string? s)
     {
         return TryParse(s, out Id<TIdentifier> val) ? val : default;
     }
@@ -269,7 +269,7 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string s, out Id<TIdentifier> result)
+    public static bool TryParse(string? s, out Id<TIdentifier> result)
     {
         result = default;
 
@@ -290,7 +290,7 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     /// The deserialized identifier.
     /// </returns>
     [Pure]
-    public static Id<TIdentifier> FromJson(string json) => Parse(json);
+    public static Id<TIdentifier> FromJson(string? json) => Parse(json);
 
     /// <summary>Deserializes the date from a JSON number.</summary>
     /// <param name="json">

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -16,6 +16,9 @@ namespace Qowaiv.Identifiers;
 [SingleValueObject(SingleValueStaticOptions.AllExcludingCulture ^ SingleValueStaticOptions.HasUnknownValue, typeof(object))]
 [OpenApiDataType(description: "identifier", example: "8a1a8c42-d2ff-e254-e26e-b6abcbf19420", type: "any")]
 [TypeConverter(typeof(IdTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Identifiers.IdJsonConverter))]
+#endif
 public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IFormattable, IEquatable<Id<TIdentifier>>, IComparable, IComparable<Id<TIdentifier>>
     where TIdentifier : IIdentifierBehavior, new()
 {

--- a/src/Qowaiv/Json/Chemistry/CasRegistryNumberJsonConverter.cs
+++ b/src/Qowaiv/Json/Chemistry/CasRegistryNumberJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Chemistry;
 
 namespace Qowaiv.Json.Chemistry;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a CAS registry.</summary>
 public sealed class CasRegistryNumberJsonConverter : SvoJsonConverter<CasRegistryNumber>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Chemistry/CasRegistryNumberJsonConverter.cs
+++ b/src/Qowaiv/Json/Chemistry/CasRegistryNumberJsonConverter.cs
@@ -1,0 +1,23 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Chemistry;
+
+namespace Qowaiv.Json.Chemistry;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class CasRegistryNumberJsonConverter : SvoJsonConverter<CasRegistryNumber>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override CasRegistryNumber FromJson(string? json) => CasRegistryNumber.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override CasRegistryNumber FromJson(long json) => CasRegistryNumber.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(CasRegistryNumber svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Customization/GenericSvoJsonConverter.cs
+++ b/src/Qowaiv/Json/Customization/GenericSvoJsonConverter.cs
@@ -7,64 +7,79 @@ using System.Text.Json.Serialization;
 
 namespace Qowaiv.Json.Customization;
 
-
 /// <summary>A custom <see cref="JsonConverter{T}"/> for <see cref="Svo{TBehavior}"/>'s.</summary>
-public sealed class GenericSvoJsonConverter : JsonConverter<object>
+public sealed class GenericSvoJsonConverter : JsonConverterFactory
 {
     /// <inheritdoc />
     [Pure]
     public override bool CanConvert(Type typeToConvert)
-        => typeToConvert is { IsGenericType: true }
-        && typeToConvert.GetGenericTypeDefinition() == typeof(Svo<>);
+        => Behavior(typeToConvert) is { };
 
     /// <inheritdoc />
     [Pure]
-    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        => Behavior(typeToConvert) is { } behavior
+        ? (JsonConverter?)Activator.CreateInstance(typeof(GenericSvoConverter<>).MakeGenericType(behavior))
+        : null;
+
+    [Pure]
+    private static Type? Behavior(Type type)
+        => type is { IsGenericType: true } && type.GetGenericTypeDefinition() == typeof(Svo<>)
+        ? type.GetGenericArguments().Single()
+        : null;
+
+    /// <summary>A custom <see cref="JsonConverter{T}"/> for <see cref="Svo{TBehavior}"/>'s.</summary>
+    public sealed class GenericSvoConverter<TBehavior> : JsonConverter<Svo<TBehavior>>
+        where TBehavior : SvoBehavior, new()
     {
-        try
+        /// <inheritdoc />
+        [Pure]
+        public override Svo<TBehavior> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return reader.TokenType switch
+            try
             {
-                JsonTokenType.String or 
-                JsonTokenType.True or
-                JsonTokenType.False or
-                JsonTokenType.Number => FromJson(reader.GetString(), typeToConvert),
-                JsonTokenType.Null => Activator.CreateInstance(typeToConvert),
-                _ => throw new JsonException($"Unexpected token parsing {typeToConvert.FullName}. {reader.TokenType} is not supported."),
-            };
+                return reader.TokenType switch
+                {
+                    JsonTokenType.String or
+                    JsonTokenType.True or
+                    JsonTokenType.False or
+                    JsonTokenType.Number => (Svo<TBehavior>)FromJson(reader.GetString(), typeToConvert),
+                    JsonTokenType.Null => default,
+                    _ => throw new JsonException($"Unexpected token parsing {typeToConvert.FullName}. {reader.TokenType} is not supported."),
+                };
+            }
+            catch (Exception x)
+            {
+                if (x is JsonException) throw;
+                else throw new JsonException(x.Message, x);
+            }
         }
-        catch (Exception x)
-        {
-            if (x is JsonException) throw;
-            else throw new JsonException(x.Message, x);
-        }
-    }
 
-    /// <inheritdoc />
-    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
-    {
-        Guard.NotNull(writer, nameof(writer));
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, Svo<TBehavior> value, JsonSerializerOptions options)
+        {
+            Guard.NotNull(writer, nameof(writer));
 
-        string? json = ((dynamic)value).ToJson();
-        if (json is null)
-        {
-            writer.WriteNullValue();
-        }
-        else
-        {
-            writer.WriteStringValue(json);
+            if (value.ToJson() is { } json)
+            {
+                writer.WriteStringValue(json);
+            }
+            else
+            {
+                writer.WriteNullValue();
+            }
         }
     }
 
     [Pure]
-    private object? FromJson(string? str, Type type)
+    private static object FromJson(string? str, Type type)
     {
-        if(!parsers.TryGetValue(type, out var parser))
+        if (!parsers.TryGetValue(type, out var parser))
         {
             parser = type.GetMethod(nameof(FromJson), BindingFlags.Public | BindingFlags.Static)!;
             parsers[type] = parser;
         }
-        return parser.Invoke(null, new object?[] { str });
+        return parser.Invoke(null, new object?[] { str })!;
     }
 
     private static readonly Dictionary<Type, MethodInfo> parsers = new();

--- a/src/Qowaiv/Json/Customization/GenericSvoJsonConverter.cs
+++ b/src/Qowaiv/Json/Customization/GenericSvoJsonConverter.cs
@@ -1,0 +1,71 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Customization;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Qowaiv.Json.Customization;
+
+
+/// <summary>A custom <see cref="JsonConverter{T}"/> for <see cref="Svo{TBehavior}"/>'s.</summary>
+public sealed class GenericSvoJsonConverter : JsonConverter<object>
+{
+    /// <inheritdoc />
+    [Pure]
+    public override bool CanConvert(Type typeToConvert)
+        => typeToConvert is { IsGenericType: true }
+        && typeToConvert.GetGenericTypeDefinition() == typeof(Svo<>);
+
+    /// <inheritdoc />
+    [Pure]
+    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        try
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.String or 
+                JsonTokenType.True or
+                JsonTokenType.False or
+                JsonTokenType.Number => FromJson(reader.GetString(), typeToConvert),
+                JsonTokenType.Null => Activator.CreateInstance(typeToConvert),
+                _ => throw new JsonException($"Unexpected token parsing {typeToConvert.FullName}. {reader.TokenType} is not supported."),
+            };
+        }
+        catch (Exception x)
+        {
+            if (x is JsonException) throw;
+            else throw new JsonException(x.Message, x);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+    {
+        string? json = ((dynamic)value).ToJson();
+        if (json is null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            writer.WriteStringValue(json);
+        }
+    }
+
+    [Pure]
+    private object? FromJson(string? str, Type type)
+    {
+        if(!parsers.TryGetValue(type, out var parser))
+        {
+            parser = type.GetMethod(nameof(FromJson), BindingFlags.Public | BindingFlags.Static)!;
+            parsers[type] = parser;
+        }
+        return parser.Invoke(null, new object?[] { str });
+    }
+
+    private static readonly Dictionary<Type, MethodInfo> parsers = new();
+}
+
+#endif

--- a/src/Qowaiv/Json/Customization/GenericSvoJsonConverter.cs
+++ b/src/Qowaiv/Json/Customization/GenericSvoJsonConverter.cs
@@ -43,6 +43,8 @@ public sealed class GenericSvoJsonConverter : JsonConverter<object>
     /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
     {
+        Guard.NotNull(writer, nameof(writer));
+
         string? json = ((dynamic)value).ToJson();
         if (json is null)
         {

--- a/src/Qowaiv/Json/DateJsonConverter.cs
+++ b/src/Qowaiv/Json/DateJsonConverter.cs
@@ -1,0 +1,22 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class DateJsonConverter : SvoJsonConverter<Date>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Date FromJson(string? json) => Date.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Date FromJson(long json) => Date.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Date svo) => svo.ToJson();
+}
+
+#endif
+

--- a/src/Qowaiv/Json/DateJsonConverter.cs
+++ b/src/Qowaiv/Json/DateJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a date.</summary>
 public sealed class DateJsonConverter : SvoJsonConverter<Date>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/DateSpanJsonConverter.cs
+++ b/src/Qowaiv/Json/DateSpanJsonConverter.cs
@@ -1,0 +1,21 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class DateSpanJsonConverter : SvoJsonConverter<DateSpan>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override DateSpan FromJson(string? json) => DateSpan.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override DateSpan FromJson(long json) => DateSpan.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(DateSpan svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/DateSpanJsonConverter.cs
+++ b/src/Qowaiv/Json/DateSpanJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a date span.</summary>
 public sealed class DateSpanJsonConverter : SvoJsonConverter<DateSpan>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/EmailAddressJsonConverter.cs
+++ b/src/Qowaiv/Json/EmailAddressJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a email address.</summary>
 public sealed class EmailAddressJsonConverter : SvoJsonConverter<EmailAddress>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/EmailAddressJsonConverter.cs
+++ b/src/Qowaiv/Json/EmailAddressJsonConverter.cs
@@ -1,0 +1,17 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class EmailAddressJsonConverter : SvoJsonConverter<EmailAddress>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override EmailAddress FromJson(string? json) => EmailAddress.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(EmailAddress svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Financial/AmountJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/AmountJsonConverter.cs
@@ -1,0 +1,27 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Financial;
+
+namespace Qowaiv.Json.Financial;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class AmountJsonConverter : SvoJsonConverter<Amount>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Amount FromJson(string? json) => Amount.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Amount FromJson(long json) => Amount.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Amount FromJson(double json) => Amount.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Amount svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Financial/AmountJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/AmountJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Financial;
 
 namespace Qowaiv.Json.Financial;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for an amount.</summary>
 public sealed class AmountJsonConverter : SvoJsonConverter<Amount>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Financial/BusinessIdentifierCodeJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/BusinessIdentifierCodeJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Financial;
 
 namespace Qowaiv.Json.Financial;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a BIC.</summary>
 public sealed class BusinessIdentifierCodeJsonConverter : SvoJsonConverter<BusinessIdentifierCode>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Financial/BusinessIdentifierCodeJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/BusinessIdentifierCodeJsonConverter.cs
@@ -1,0 +1,19 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Financial;
+
+namespace Qowaiv.Json.Financial;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class BusinessIdentifierCodeJsonConverter : SvoJsonConverter<BusinessIdentifierCode>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override BusinessIdentifierCode FromJson(string? json) => BusinessIdentifierCode.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(BusinessIdentifierCode svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Financial/CurrencyJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/CurrencyJsonConverter.cs
@@ -1,0 +1,23 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Financial;
+
+namespace Qowaiv.Json.Financial;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class CurrencyJsonConverter : SvoJsonConverter<Currency>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Currency FromJson(string? json) => Currency.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Currency FromJson(long json) => Currency.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Currency svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Financial/CurrencyJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/CurrencyJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Financial;
 
 namespace Qowaiv.Json.Financial;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a currency.</summary>
 public sealed class CurrencyJsonConverter : SvoJsonConverter<Currency>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Financial/InternationalBankAccountNumberJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/InternationalBankAccountNumberJsonConverter.cs
@@ -1,0 +1,19 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Financial;
+
+namespace Qowaiv.Json.Financial;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class InternationalBankAccountNumberJsonConverter : SvoJsonConverter<InternationalBankAccountNumber>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override InternationalBankAccountNumber FromJson(string? json) => InternationalBankAccountNumber.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(InternationalBankAccountNumber svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Financial/InternationalBankAccountNumberJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/InternationalBankAccountNumberJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Financial;
 
 namespace Qowaiv.Json.Financial;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for an IBAN.</summary>
 public sealed class InternationalBankAccountNumberJsonConverter : SvoJsonConverter<InternationalBankAccountNumber>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Financial/MoneyJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/MoneyJsonConverter.cs
@@ -1,0 +1,27 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Financial;
+
+namespace Qowaiv.Json.Financial;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class MoneyJsonConverter : SvoJsonConverter<Money>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Money FromJson(string? json) => Money.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Money FromJson(long json) => Money.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Money FromJson(double json) => Money.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Money svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Financial/MoneyJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/MoneyJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Financial;
 
 namespace Qowaiv.Json.Financial;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for money.</summary>
 public sealed class MoneyJsonConverter : SvoJsonConverter<Money>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/GenderJsonConverter.cs
+++ b/src/Qowaiv/Json/GenderJsonConverter.cs
@@ -1,0 +1,26 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+[Obsolete("Will be dropped in version 7. Use Qowaiv.Sex instead.")]
+public sealed class GenderJsonConverter : SvoJsonConverter<Gender>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Gender FromJson(string? json) => Gender.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Gender FromJson(long json) => Gender.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Gender FromJson(double json) => Gender.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Gender svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/GenderJsonConverter.cs
+++ b/src/Qowaiv/Json/GenderJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a gender.</summary>
 [Obsolete("Will be dropped in version 7. Use Qowaiv.Sex instead.")]
 public sealed class GenderJsonConverter : SvoJsonConverter<Gender>
 {

--- a/src/Qowaiv/Json/Globalization/CountryJsonConverter.cs
+++ b/src/Qowaiv/Json/Globalization/CountryJsonConverter.cs
@@ -1,0 +1,24 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Globalization;
+
+namespace Qowaiv.Json.Globalization;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class CountryJsonConverter : SvoJsonConverter<Country>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Country FromJson(string? json) => Country.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Country FromJson(long json) => Country.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Country svo) => svo.ToJson();
+}
+
+#endif
+

--- a/src/Qowaiv/Json/Globalization/CountryJsonConverter.cs
+++ b/src/Qowaiv/Json/Globalization/CountryJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Globalization;
 
 namespace Qowaiv.Json.Globalization;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a country.</summary>
 public sealed class CountryJsonConverter : SvoJsonConverter<Country>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/HouseNumberJsonConverter.cs
+++ b/src/Qowaiv/Json/HouseNumberJsonConverter.cs
@@ -1,0 +1,25 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class HouseNumberJsonConverter : SvoJsonConverter<HouseNumber>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override HouseNumber FromJson(string? json) => HouseNumber.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override HouseNumber FromJson(long json) => HouseNumber.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override HouseNumber FromJson(double json) => HouseNumber.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(HouseNumber svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/HouseNumberJsonConverter.cs
+++ b/src/Qowaiv/Json/HouseNumberJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a house number.</summary>
 public sealed class HouseNumberJsonConverter : SvoJsonConverter<HouseNumber>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/IO/StreamSizeJsonConverter.cs
+++ b/src/Qowaiv/Json/IO/StreamSizeJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.IO;
 
 namespace Qowaiv.Json.IO;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a stream size.</summary>
 public sealed class StreamSizeJsonConverter : SvoJsonConverter<StreamSize>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/IO/StreamSizeJsonConverter.cs
+++ b/src/Qowaiv/Json/IO/StreamSizeJsonConverter.cs
@@ -1,0 +1,27 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.IO;
+
+namespace Qowaiv.Json.IO;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class StreamSizeJsonConverter : SvoJsonConverter<StreamSize>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override StreamSize FromJson(string? json) => StreamSize.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override StreamSize FromJson(long json) => StreamSize.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override StreamSize FromJson(double json) => StreamSize.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(StreamSize svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
+++ b/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
@@ -7,79 +7,91 @@ using System.Text.Json.Serialization;
 
 namespace Qowaiv.Json.Identifiers;
 
-
 /// <summary>A custom <see cref="JsonConverter{T}"/> for <see cref="Id{TIdentifier}"/>'s.</summary>
-public sealed class IdJsonConverter : JsonConverter<object>
+public sealed class IdJsonConverter : JsonConverterFactory
 {
     /// <inheritdoc />
     [Pure]
-    public override bool CanConvert(Type typeToConvert)
-        => typeToConvert is { IsGenericType: true }
-        && typeToConvert.GetGenericTypeDefinition() == typeof(Id<>);
+    public override bool CanConvert(Type typeToConvert) 
+        => Behavior(typeToConvert) is { };
 
     /// <inheritdoc />
     [Pure]
-    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        => Behavior(typeToConvert) is { } behavior
+        ? (JsonConverter?)Activator.CreateInstance(typeof(IdConverter<>).MakeGenericType(behavior))
+        : null;
+
+    [Pure]
+    private static Type? Behavior(Type type)
+        => type is { IsGenericType: true } && type.GetGenericTypeDefinition() == typeof(Id<>)
+        ? type.GetGenericArguments().Single()
+        : null;
+
+    private sealed class IdConverter<TBehavior> : JsonConverter<Id<TBehavior>>
+        where TBehavior : IIdentifierBehavior, new()
     {
-        try
+        public override Id<TBehavior> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return reader.TokenType switch
+            try
             {
-                JsonTokenType.String or 
-                JsonTokenType.True or
-                JsonTokenType.False => FromJson(reader.GetString(), typeToConvert),
-                JsonTokenType.Number => FromJson(reader.GetInt64(), typeToConvert),
-                JsonTokenType.Null => Activator.CreateInstance(typeToConvert),
-                _ => throw new JsonException($"Unexpected token parsing {typeToConvert.FullName}. {reader.TokenType} is not supported."),
-            };
+                return reader.TokenType switch
+                {
+                    JsonTokenType.String or
+                    JsonTokenType.True or
+                    JsonTokenType.False => (Id<TBehavior>)FromJson(reader.GetString(), typeToConvert),
+                    JsonTokenType.Number => (Id<TBehavior>)FromJson(reader.GetInt64(), typeToConvert),
+                    JsonTokenType.Null => default,
+                    _ => throw new JsonException($"Unexpected token parsing {typeToConvert.FullName}. {reader.TokenType} is not supported."),
+                };
+            }
+            catch (Exception x)
+            {
+                if (x is JsonException) throw;
+                else throw new JsonException(x.Message, x);
+            }
         }
-        catch (Exception x)
-        {
-            if (x is JsonException) throw;
-            else throw new JsonException(x.Message, x);
-        }
-    }
 
-    /// <inheritdoc />
-    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
-    {
-        Guard.NotNull(writer, nameof(writer));
+        public override void Write(Utf8JsonWriter writer, Id<TBehavior> value, JsonSerializerOptions options)
+        {
+            Guard.NotNull(writer, nameof(writer));
 
-        object? obj = ((dynamic)value).ToJson();
-        
-        if (obj is null)
-        {
-            writer.WriteNullValue();
-        }
-        else if (obj is long int64)
-        {
-            writer.WriteNumberValue(int64);
-        }
-        else if (obj is int int32)
-        {
-            writer.WriteNumberValue(int32);
-        }
-        else
-        {
-            writer.WriteStringValue(obj.ToString());
+            object? obj = value.ToJson();
+
+            if (obj is null)
+            {
+                writer.WriteNullValue();
+            }
+            else if (obj is long int64)
+            {
+                writer.WriteNumberValue(int64);
+            }
+            else if (obj is int int32)
+            {
+                writer.WriteNumberValue(int32);
+            }
+            else
+            {
+                writer.WriteStringValue(obj.ToString());
+            }
         }
     }
 
     [Pure]
-    private object? FromJson(string? str, Type type)
+    private static object FromJson(string? str, Type type)
     {
-        if(!stringParsers.TryGetValue(type, out var parser))
+        if (!stringParsers.TryGetValue(type, out var parser))
         {
             parser = type.GetMethods(BindingFlags.Public | BindingFlags.Static)
                 .Single(m => m.Name == nameof(FromJson) && m.GetParameters()[0].ParameterType == typeof(string));
 
             stringParsers[type] = parser;
         }
-        return parser.Invoke(null, new object?[] { str });
+        return parser.Invoke(null, new object?[] { str })!;
     }
 
     [Pure]
-    private object? FromJson(long number, Type type)
+    private static object FromJson(long number, Type type)
     {
         if (!int64Parsers.TryGetValue(type, out var parser))
         {
@@ -88,7 +100,7 @@ public sealed class IdJsonConverter : JsonConverter<object>
 
             int64Parsers[type] = parser;
         }
-        return parser.Invoke(null, new object?[] { number });
+        return parser.Invoke(null, new object?[] { number })!;
     }
 
     private static readonly Dictionary<Type, MethodInfo> stringParsers = new();

--- a/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
+++ b/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
@@ -1,0 +1,96 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Identifiers;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Qowaiv.Json.Identifiers;
+
+
+/// <summary>A custom <see cref="JsonConverter{T}"/> for <see cref="Id{TIdentifier}"/>'s.</summary>
+public sealed class IdJsonConverter : JsonConverter<object>
+{
+    /// <inheritdoc />
+    [Pure]
+    public override bool CanConvert(Type typeToConvert)
+        => typeToConvert is { IsGenericType: true }
+        && typeToConvert.GetGenericTypeDefinition() == typeof(Id<>);
+
+    /// <inheritdoc />
+    [Pure]
+    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        try
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.String or 
+                JsonTokenType.True or
+                JsonTokenType.False => FromJson(reader.GetString(), typeToConvert),
+                JsonTokenType.Number => FromJson(reader.GetInt64(), typeToConvert),
+                JsonTokenType.Null => Activator.CreateInstance(typeToConvert),
+                _ => throw new JsonException($"Unexpected token parsing {typeToConvert.FullName}. {reader.TokenType} is not supported."),
+            };
+        }
+        catch (Exception x)
+        {
+            if (x is JsonException) throw;
+            else throw new JsonException(x.Message, x);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+    {
+        object? obj = ((dynamic)value).ToJson();
+        
+        if (obj is null)
+        {
+            writer.WriteNullValue();
+        }
+        else if (obj is long int64)
+        {
+            writer.WriteNumberValue(int64);
+        }
+        else if (obj is int int32)
+        {
+            writer.WriteNumberValue(int32);
+        }
+        else
+        {
+            writer.WriteStringValue(obj.ToString());
+        }
+    }
+
+    [Pure]
+    private object? FromJson(string? str, Type type)
+    {
+        if(!stringParsers.TryGetValue(type, out var parser))
+        {
+            parser = type.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Single(m => m.Name == nameof(FromJson) && m.GetParameters()[0].ParameterType == typeof(string));
+
+            stringParsers[type] = parser;
+        }
+        return parser.Invoke(null, new object?[] { str });
+    }
+
+    [Pure]
+    private object? FromJson(long number, Type type)
+    {
+        if (!int64Parsers.TryGetValue(type, out var parser))
+        {
+            parser = type.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Single(m => m.Name == nameof(FromJson) && m.GetParameters()[0].ParameterType == typeof(long));
+
+            int64Parsers[type] = parser;
+        }
+        return parser.Invoke(null, new object?[] { number });
+    }
+
+    private static readonly Dictionary<Type, MethodInfo> stringParsers = new();
+    private static readonly Dictionary<Type, MethodInfo> int64Parsers = new();
+}
+
+#endif

--- a/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
+++ b/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
@@ -43,6 +43,8 @@ public sealed class IdJsonConverter : JsonConverter<object>
     /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
     {
+        Guard.NotNull(writer, nameof(writer));
+
         object? obj = ((dynamic)value).ToJson();
         
         if (obj is null)

--- a/src/Qowaiv/Json/LocalDateTimeJsonConverter.cs
+++ b/src/Qowaiv/Json/LocalDateTimeJsonConverter.cs
@@ -1,0 +1,21 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class LocalDateTimeJsonConverter : SvoJsonConverter<LocalDateTime>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override LocalDateTime FromJson(string? json) => LocalDateTime.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override LocalDateTime FromJson(long json) => LocalDateTime.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(LocalDateTime svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/LocalDateTimeJsonConverter.cs
+++ b/src/Qowaiv/Json/LocalDateTimeJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a local date time.</summary>
 public sealed class LocalDateTimeJsonConverter : SvoJsonConverter<LocalDateTime>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Mathematics/FractionJsonConverter.cs
+++ b/src/Qowaiv/Json/Mathematics/FractionJsonConverter.cs
@@ -1,0 +1,27 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Mathematics;
+
+namespace Qowaiv.Json.Mathematics;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class FractionJsonConverter : SvoJsonConverter<Fraction>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Fraction FromJson(string? json) => Fraction.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Fraction FromJson(long json) => Fraction.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Fraction FromJson(double json) => Fraction.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Fraction svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Mathematics/FractionJsonConverter.cs
+++ b/src/Qowaiv/Json/Mathematics/FractionJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Mathematics;
 
 namespace Qowaiv.Json.Mathematics;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a fraction.</summary>
 public sealed class FractionJsonConverter : SvoJsonConverter<Fraction>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/MonthJsonConverter.cs
+++ b/src/Qowaiv/Json/MonthJsonConverter.cs
@@ -1,0 +1,25 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class MonthJsonConverter : SvoJsonConverter<Month>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Month FromJson(string? json) => Month.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Month FromJson(long json) => Month.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Month FromJson(double json) => Month.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Month svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/MonthJsonConverter.cs
+++ b/src/Qowaiv/Json/MonthJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a month.</summary>
 public sealed class MonthJsonConverter : SvoJsonConverter<Month>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/MonthSpanJsonConverter.cs
+++ b/src/Qowaiv/Json/MonthSpanJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a month span.</summary>
 public sealed class MonthSpanJsonConverter : SvoJsonConverter<MonthSpan>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/MonthSpanJsonConverter.cs
+++ b/src/Qowaiv/Json/MonthSpanJsonConverter.cs
@@ -1,0 +1,21 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class MonthSpanJsonConverter : SvoJsonConverter<MonthSpan>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override MonthSpan FromJson(string? json) => MonthSpan.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override MonthSpan FromJson(long json) => MonthSpan.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(MonthSpan svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/PercentageJsonConverter.cs
+++ b/src/Qowaiv/Json/PercentageJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a percentage.</summary>
 public sealed class PercentageJsonConverter : SvoJsonConverter<Percentage>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/PercentageJsonConverter.cs
+++ b/src/Qowaiv/Json/PercentageJsonConverter.cs
@@ -1,0 +1,25 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class PercentageJsonConverter : SvoJsonConverter<Percentage>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Percentage FromJson(string? json) => Percentage.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Percentage FromJson(long json) => Percentage.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Percentage FromJson(double json) => Percentage.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Percentage svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/PostalCodeJsonConverter.cs
+++ b/src/Qowaiv/Json/PostalCodeJsonConverter.cs
@@ -1,9 +1,17 @@
-﻿namespace Qowaiv.Json;
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a postal code.</summary>
 public sealed class PostalCodeJsonConverter : SvoJsonConverter<PostalCode>
 {
-    /// <summary>Creates a new instance of the <see cref="PostalCodeJsonConverter"/>.</summary>
-    public PostalCodeJsonConverter()
-        : base((svo) => svo.ToJson(), PostalCode.FromJson) { }
+    /// <inheritdoc />
+    [Pure]
+    protected override PostalCode FromJson(string? json) => PostalCode.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(PostalCode svo) => svo.ToJson();
 }
+
+#endif

--- a/src/Qowaiv/Json/PostalCodeJsonConverter.cs
+++ b/src/Qowaiv/Json/PostalCodeJsonConverter.cs
@@ -1,0 +1,9 @@
+﻿namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class PostalCodeJsonConverter : SvoJsonConverter<PostalCode>
+{
+    /// <summary>Creates a new instance of the <see cref="PostalCodeJsonConverter"/>.</summary>
+    public PostalCodeJsonConverter()
+        : base((svo) => svo.ToJson(), PostalCode.FromJson) { }
+}

--- a/src/Qowaiv/Json/Security/Cryptography/CryptographicSeedJsonConverter.cs
+++ b/src/Qowaiv/Json/Security/Cryptography/CryptographicSeedJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Security.Cryptography;
 
 namespace Qowaiv.Json.Security.Cryptography;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a cryptographic seed.</summary>
 public sealed class CryptographicSeedJsonConverter : SvoJsonConverter<CryptographicSeed>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Security/Cryptography/CryptographicSeedJsonConverter.cs
+++ b/src/Qowaiv/Json/Security/Cryptography/CryptographicSeedJsonConverter.cs
@@ -1,0 +1,19 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Security.Cryptography;
+
+namespace Qowaiv.Json.Security.Cryptography;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class CryptographicSeedJsonConverter : SvoJsonConverter<CryptographicSeed>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override CryptographicSeed FromJson(string? json) => CryptographicSeed.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(CryptographicSeed svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Security/MonthSpanJsonConverter.cs
+++ b/src/Qowaiv/Json/Security/MonthSpanJsonConverter.cs
@@ -1,0 +1,17 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json.Security;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class SecretJsonConverter : SvoJsonConverter<Secret>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Secret FromJson(string? json) => Secret.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Secret svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Security/SecretJsonConverter.cs
+++ b/src/Qowaiv/Json/Security/SecretJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json.Security;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a secret.</summary>
 public sealed class SecretJsonConverter : SvoJsonConverter<Secret>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/SexJsonConverter.cs
+++ b/src/Qowaiv/Json/SexJsonConverter.cs
@@ -1,0 +1,25 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class SexJsonConverter : SvoJsonConverter<Sex>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Sex FromJson(string? json) => Sex.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Sex FromJson(long json) => Sex.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Sex FromJson(double json) => Sex.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Sex svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/SexJsonConverter.cs
+++ b/src/Qowaiv/Json/SexJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a sex.</summary>
 public sealed class SexJsonConverter : SvoJsonConverter<Sex>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Statistics/EloJsonConverter.cs
+++ b/src/Qowaiv/Json/Statistics/EloJsonConverter.cs
@@ -1,0 +1,27 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Statistics;
+
+namespace Qowaiv.Json.Statistics;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class EloJsonConverter : SvoJsonConverter<Elo>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Elo FromJson(string? json) => Elo.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Elo FromJson(long json) => Elo.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Elo FromJson(double json) => Elo.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Elo svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/Statistics/EloJsonConverter.cs
+++ b/src/Qowaiv/Json/Statistics/EloJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Statistics;
 
 namespace Qowaiv.Json.Statistics;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for an Elo.</summary>
 public sealed class EloJsonConverter : SvoJsonConverter<Elo>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/SvoJsonConverter.cs
+++ b/src/Qowaiv/Json/SvoJsonConverter.cs
@@ -11,26 +11,6 @@ namespace Qowaiv.Json;
 /// </typeparam>
 public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo: struct
 {
-    /// <summary>Represent the SVO as a JSON node.</summary>
-    [Pure]
-    protected abstract object? ToJson(TSvo svo);
-
-    /// <summary>Creates the SVO based on its JSON string representation.</summary>
-    [Pure]
-    protected abstract TSvo FromJson(string? json);
-
-    /// <summary>Creates the SVO based on its JSON (long) number representation.</summary>
-    [Pure]
-    protected virtual TSvo FromJson(long json) => FromJson(json.ToString(CultureInfo.InvariantCulture));
-
-    /// <summary>Creates the SVO based on its JSON (double) number representation.</summary>
-    [Pure]
-    protected virtual TSvo FromJson(double json) => FromJson(json.ToString(CultureInfo.InvariantCulture));
-
-    /// <summary>Creates the SVO based on its JSON boolean representation.</summary>
-    [Pure]
-    protected virtual TSvo FromJson(bool json) => FromJson(json ? "true" : "false");
-
     /// <inheritdoc />
     public sealed override TSvo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -51,21 +31,8 @@ public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo: s
             if (x is JsonException) throw;
             else throw new JsonException(x.Message, x);
         }
-
-        TSvo ReadNumber(ref Utf8JsonReader reader)
-        {
-            if (reader.TryGetInt64(out long num))
-            {
-                return FromJson(num);
-            }
-            else if (reader.TryGetDouble(out double dec))
-            {
-                return FromJson(dec);
-            }
-            else throw new JsonException($"QowaivJsonConverter does not support writing from {reader.GetString()}.");
-        }
     }
-   
+
     /// <inheritdoc />
     public sealed override void Write(Utf8JsonWriter writer, TSvo value, JsonSerializerOptions options)
     {
@@ -113,6 +80,39 @@ public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo: s
         {
             writer.WriteStringValue(obj.ToString());
         }
+    }
+
+    /// <summary>Represent the SVO as a JSON node.</summary>
+    [Pure]
+    protected abstract object? ToJson(TSvo svo);
+
+    /// <summary>Creates the SVO based on its JSON string representation.</summary>
+    [Pure]
+    protected abstract TSvo FromJson(string? json);
+
+    /// <summary>Creates the SVO based on its JSON (long) number representation.</summary>
+    [Pure]
+    protected virtual TSvo FromJson(long json) => FromJson(json.ToString(CultureInfo.InvariantCulture));
+
+    /// <summary>Creates the SVO based on its JSON (double) number representation.</summary>
+    [Pure]
+    protected virtual TSvo FromJson(double json) => FromJson(json.ToString(CultureInfo.InvariantCulture));
+
+    /// <summary>Creates the SVO based on its JSON boolean representation.</summary>
+    [Pure]
+    protected virtual TSvo FromJson(bool json) => FromJson(json ? "true" : "false");
+
+    private TSvo ReadNumber(ref Utf8JsonReader reader)
+    {
+        if (reader.TryGetInt64(out long num))
+        {
+            return FromJson(num);
+        }
+        else if (reader.TryGetDouble(out double dec))
+        {
+            return FromJson(dec);
+        }
+        else throw new JsonException($"QowaivJsonConverter does not support writing from {reader.GetString()}.");
     }
 }
 #endif

--- a/src/Qowaiv/Json/SvoJsonConverter.cs
+++ b/src/Qowaiv/Json/SvoJsonConverter.cs
@@ -43,7 +43,7 @@ public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo: s
                 JsonTokenType.False => FromJson(false),
                 JsonTokenType.Number => ReadNumber(ref reader),
                 JsonTokenType.Null => default,
-                _ => throw new JsonException($"Unexpected token parsing {typeToConvert.FullName}. {reader.TokenType} is not supported."),
+                _ => throw new JsonException($"Unexpected token parsing {typeToConvert?.FullName}. {reader.TokenType} is not supported."),
             };
         }
         catch (Exception x)

--- a/src/Qowaiv/Json/SvoJsonConverter.cs
+++ b/src/Qowaiv/Json/SvoJsonConverter.cs
@@ -69,6 +69,8 @@ public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo: s
     /// <inheritdoc />
     public sealed override void Write(Utf8JsonWriter writer, TSvo value, JsonSerializerOptions options)
     {
+        Guard.NotNull(writer, nameof(writer));
+
         var obj = ToJson(value);
 
         if (obj is null)

--- a/src/Qowaiv/Json/SvoJsonConverter.cs
+++ b/src/Qowaiv/Json/SvoJsonConverter.cs
@@ -1,0 +1,129 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Qowaiv.Json;
+
+/// <summary>A custom <see cref="JsonConverter{T}"/> for SVO's.</summary>
+/// <typeparam name="TSvo">
+/// The type of SVO.
+/// </typeparam>
+public class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo: struct
+{
+    private readonly Func<TSvo, object?> ToJson;
+    private readonly Func<string?, TSvo> FromJson;
+    private readonly Func<long, TSvo> FromInt64;
+    private readonly Func<double, TSvo> FromDouble;
+    private readonly Func<bool, TSvo> FromBoolean;
+
+    /// <summary>Creates a new instance of the <see cref="SvoJsonConverter{TSvo}"/>.</summary>
+    /// <param name="toJson">
+    /// Represents the SVO as JSON node.
+    /// </param>
+    /// <param name="fromString">
+    /// Creates the SVO from a JSON string.
+    /// </param>
+    /// <param name="fromInt64">
+    /// Creates the SVO from a JSON number (optional).
+    /// </param>
+    /// <param name="fromDouble">
+    /// Creates the SVO from a JSON number (optional).
+    /// </param>
+    /// <param name="fromBoolean">
+    /// Creates the SVO form a JSON boolean. (optional)
+    /// </param>
+    protected SvoJsonConverter(
+        Func<TSvo, object?> toJson,
+        Func<string?, TSvo> fromString,
+        Func<long, TSvo>? fromInt64 = null,
+        Func<double, TSvo>? fromDouble = null,
+        Func<bool, TSvo>? fromBoolean = null)
+    {
+        ToJson = Guard.NotNull(toJson, nameof(toJson));
+        FromJson = Guard.NotNull(fromString, nameof(fromString));
+        FromInt64 = fromInt64 ?? ((n) => fromString(n.ToString(CultureInfo.InvariantCulture)));
+        FromDouble = fromDouble ?? ((n) => fromString(n.ToString(CultureInfo.InvariantCulture)));
+        FromBoolean = fromBoolean ?? ((n) => fromString(n.ToString(CultureInfo.InvariantCulture)));
+    }
+
+    /// <inheritdoc />
+    public sealed override TSvo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        try
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.String => FromJson(reader.GetString()),
+                JsonTokenType.True => FromBoolean(true),
+                JsonTokenType.False => FromBoolean(false),
+                JsonTokenType.Number => ReadNumber(ref reader),
+                JsonTokenType.Null => default,
+                _ => throw new JsonException($"Unexpected token parsing {typeToConvert.FullName}. {reader.TokenType} is not supported."),
+            };
+        }
+        catch (Exception x)
+        {
+            if (x is JsonException) throw;
+            else throw new JsonException(x.Message, x);
+        }
+
+        TSvo ReadNumber(ref Utf8JsonReader reader)
+        {
+            if (reader.TryGetInt64(out long num))
+            {
+                return FromInt64(num);
+            }
+            else if (reader.TryGetDouble(out double dec))
+            {
+                return FromDouble(dec);
+            }
+            else throw new JsonException($"QowaivJsonConverter does not support writing from {reader.GetString()}.");
+        }
+    }
+   
+    /// <inheritdoc />
+    public sealed override void Write(Utf8JsonWriter writer, TSvo value, JsonSerializerOptions options)
+    {
+        var obj = ToJson(value);
+
+        if (obj is null)
+        {
+            writer.WriteNullValue();
+        }
+        else if (obj is string str)
+        {
+            writer.WriteStringValue(str);
+        }
+        else if (obj is decimal dec)
+        {
+            writer.WriteNumberValue(dec);
+        }
+        else if (obj is double dbl)
+        {
+            writer.WriteNumberValue(dbl);
+        }
+        else if (obj is long num)
+        {
+            writer.WriteNumberValue(num);
+        }
+        else if (obj is int int_)
+        {
+            writer.WriteNumberValue(int_);
+        }
+        else if (obj is bool b)
+        {
+            writer.WriteBooleanValue(b);
+        }
+        else if (obj is DateTime dt)
+        {
+            writer.WriteStringValue(dt);
+        }
+        else if (obj is IFormattable f)
+        {
+            writer.WriteStringValue(f.ToString(null, CultureInfo.InvariantCulture));
+        }
+        else
+        {
+            writer.WriteStringValue(obj.ToString());
+        }
+    }
+}

--- a/src/Qowaiv/Json/UuidJsonConverter.cs
+++ b/src/Qowaiv/Json/UuidJsonConverter.cs
@@ -1,0 +1,17 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class UuidJsonConverter : SvoJsonConverter<Uuid>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Uuid FromJson(string? json) => Uuid.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Uuid svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/UuidJsonConverter.cs
+++ b/src/Qowaiv/Json/UuidJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a UUID.</summary>
 public sealed class UuidJsonConverter : SvoJsonConverter<Uuid>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Web/InternetMediaTypeJsonConverter.cs
+++ b/src/Qowaiv/Json/Web/InternetMediaTypeJsonConverter.cs
@@ -4,7 +4,7 @@ using Qowaiv.Web;
 
 namespace Qowaiv.Json.Web;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for an Internet media type.</summary>
 public sealed class InternetMediaTypeJsonConverter : SvoJsonConverter<InternetMediaType>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Web/InternetMediaTypeJsonConverter.cs
+++ b/src/Qowaiv/Json/Web/InternetMediaTypeJsonConverter.cs
@@ -1,0 +1,19 @@
+﻿#if NET5_0_OR_GREATER
+
+using Qowaiv.Web;
+
+namespace Qowaiv.Json.Web;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class InternetMediaTypeJsonConverter : SvoJsonConverter<InternetMediaType>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override InternetMediaType FromJson(string? json) => InternetMediaType.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(InternetMediaType svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/WeekDateJsonConverter.cs
+++ b/src/Qowaiv/Json/WeekDateJsonConverter.cs
@@ -1,0 +1,17 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class WeekDateJsonConverter : SvoJsonConverter<WeekDate>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override WeekDate FromJson(string? json) => WeekDate.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(WeekDate svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/WeekDateJsonConverter.cs
+++ b/src/Qowaiv/Json/WeekDateJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a week date.</summary>
 public sealed class WeekDateJsonConverter : SvoJsonConverter<WeekDate>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/YearJsonConverter.cs
+++ b/src/Qowaiv/Json/YearJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a year.</summary>
 public sealed class YearJsonConverter : SvoJsonConverter<Year>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/YearJsonConverter.cs
+++ b/src/Qowaiv/Json/YearJsonConverter.cs
@@ -1,0 +1,25 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class YearJsonConverter : SvoJsonConverter<Year>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override Year FromJson(string? json) => Year.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Year FromJson(long json) => Year.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override Year FromJson(double json) => Year.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(Year svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/Json/YesNoJsonConverter.cs
+++ b/src/Qowaiv/Json/YesNoJsonConverter.cs
@@ -2,7 +2,7 @@
 
 namespace Qowaiv.Json;
 
-/// <summary>Provides a JSON conversion for a postal code.</summary>
+/// <summary>Provides a JSON conversion for a yes-no.</summary>
 public sealed class YesNoJsonConverter : SvoJsonConverter<YesNo>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/YesNoJsonConverter.cs
+++ b/src/Qowaiv/Json/YesNoJsonConverter.cs
@@ -1,0 +1,29 @@
+﻿#if NET5_0_OR_GREATER
+
+namespace Qowaiv.Json;
+
+/// <summary>Provides a JSON conversion for a postal code.</summary>
+public sealed class YesNoJsonConverter : SvoJsonConverter<YesNo>
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override YesNo FromJson(string? json) => YesNo.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override YesNo FromJson(long json) => YesNo.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override YesNo FromJson(double json) => YesNo.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override YesNo FromJson(bool json) => YesNo.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
+    protected override object? ToJson(YesNo svo) => svo.ToJson();
+}
+
+#endif

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -6,6 +6,9 @@
 [OpenApiDataType(description: "Date-time notation as defined by RFC 3339, without time zone information.", example: "2017-06-10 15:00", type: "string", format: "local-date-time")]
 [OpenApi.OpenApiDataType(description: "Date-time notation as defined by RFC 3339, without time zone information.", example: "2017-06-10 15:00", type: "string", format: "local-date-time")]
 [TypeConverter(typeof(LocalDateTimeTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.LocalDateTimeJsonConverter))]
+#endif
 public readonly partial struct LocalDateTime : ISerializable, IXmlSerializable, IFormattable, IEquatable<LocalDateTime>, IComparable, IComparable<LocalDateTime>
 {
     private const string SerializableFormat = @"yyyy-MM-dd HH:mm:ss.FFFFFFF";

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -10,6 +10,9 @@ namespace Qowaiv.Mathematics;
 [OpenApiDataType(description: "Faction", type: "string", format: "faction", pattern: "-?[0-9]+(/[0-9]+)?", example: "13/42")]
 [OpenApi.OpenApiDataType(description: "Faction", type: "string", format: "faction", pattern: "-?[0-9]+(/[0-9]+)?", example: "13/42")]
 [TypeConverter(typeof(FractionTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Mathematics.FractionJsonConverter))]
+#endif
 [StructLayout(LayoutKind.Sequential)]
 public readonly partial struct Fraction : ISerializable, IXmlSerializable, IFormattable, IEquatable<Fraction>, IComparable, IComparable<Fraction>
 {

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -8,6 +8,9 @@ namespace Qowaiv;
 [OpenApiDataType(description: "Month(-only) notation.", example: "Jun", type: "string", format: "month", nullable: true, @enum: "Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec,?")]
 [OpenApi.OpenApiDataType(description: "Month(-only) notation.", example: "Jun", type: "string", format: "month", nullable: true, @enum: "Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec,?")]
 [TypeConverter(typeof(MonthTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.MonthJsonConverter))]
+#endif
 public readonly partial struct Month : ISerializable, IXmlSerializable, IFormattable, IEquatable<Month>, IComparable, IComparable<Month>
 {
     /// <summary>Represents an empty/not set month.</summary>

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -7,6 +7,9 @@
 [OpenApiDataType(description: "Month span, specified in years and months.", example: "1Y+10M", type: "string", format: "month-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M")]
 [OpenApi.OpenApiDataType(description: "Month span, specified in years and months.", example: "1Y+10M", type: "string", format: "month-span", pattern: @"[+-]?[0-9]+Y[+-][0-9]+M")]
 [TypeConverter(typeof(MonthSpanTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.MonthSpanJsonConverter))]
+#endif
 public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<MonthSpan>, IComparable, IComparable<MonthSpan>
 {
     /// <summary>Represents a month span with a zero duration.</summary>

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -6,6 +6,9 @@
 [OpenApiDataType(description: "Ratio expressed as a fraction of 100 denoted using the percent sign '%'.", example: "13.76%", type: "string", format: "percentage", pattern: @"-?[0-9]+(\.[0-9]+)?%")]
 [OpenApi.OpenApiDataType(description: "Ratio expressed as a fraction of 100 denoted using the percent sign '%'.", example: "13.76%", type: "string", format: "percentage", pattern: @"-?[0-9]+(\.[0-9]+)?%")]
 [TypeConverter(typeof(PercentageTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.PercentageJsonConverter))]
+#endif
 public readonly partial struct Percentage : ISerializable, IXmlSerializable, IFormattable, IEquatable<Percentage>, IComparable, IComparable<Percentage>
 {
     /// <summary>The percentage symbol (%).</summary>

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -12,6 +12,9 @@ namespace Qowaiv;
 [OpenApiDataType(description: "Postal code notation.", example: "2624DP", type: "string", format: "postal-code", nullable: true)]
 [OpenApi.OpenApiDataType(description: "Postal code notation.", example: "2624DP", type: "string", format: "postal-code", nullable: true)]
 [TypeConverter(typeof(PostalCodeTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(PostalCodeJsonConverter))]
+#endif
 public readonly partial struct PostalCode : ISerializable, IXmlSerializable, IFormattable, IEquatable<PostalCode>, IComparable, IComparable<PostalCode>
 {
     /// <summary>Represents the pattern of a (potential) valid postal code.</summary>

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,8 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.2.2</Version>
+    <Version>6.3.0</Version>
     <PackageReleaseNotes>
+v6.3.0
+- JSON serialization via System.Text.Json does not longer require a custom converter. #259
 v6.2.2
 - Introduction of CasRegistryNumber. #258
 v6.2.1

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -53,10 +53,6 @@ v5.1.2
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="Json\*Converter.cs" Condition="'$(TargetFramework)'=='netstandard2.0'" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" Condition="'$(TargetFramework)'=='netstandard2.0'" />
   </ItemGroup>
 

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -12,7 +12,7 @@ v6.2.2
 v6.2.1
 - Prevent implicit casting by introducing obsolete operator overloads. #257 (fix)
 v6.2.0
--  Introduction of Svo&lt;SvoBehavior&gt; as a generic for string based SVO's. #248 
+-  Introduction of Svo&lt;SvoBehavior&gt; as a generic for string based SVO's. #248
 v6.1.2
 - Sums on empty collections should not throw. #251
 v6.1.1
@@ -22,7 +22,7 @@ v6.1.0
 v6.0.2
 - Extend Open API support for ID&lt;T&gt;. #239
 v6.0.1
-- Int64 based id serializes to a JSON string #236 
+- Int64 based id serializes to a JSON string #236
 - Percentage.MaxValue representable as a string #235
 v6.0.0
 - Added .NET 6.0 version to the package. #216
@@ -50,6 +50,10 @@ v5.1.2
   <ItemGroup>
     <Compile Include="..\..\shared\Guard.cs" Link="Guard.cs" />
     <Compile Include="..\..\shared\Not.cs" Link="Diagnostics\Not.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Json\*Converter.cs" Condition="'$(TargetFramework)'=='netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -8,7 +8,7 @@
     <Version>6.3.0</Version>
     <PackageReleaseNotes>
 v6.3.0
-- JSON serialization via System.Text.Json does not longer require a custom converter. #259
+- JSON serialization via System.Text.Json no longer requires a custom converter. #259
 v6.2.2
 - Introduction of CasRegistryNumber. #258
 v6.2.1

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -79,7 +79,7 @@ public readonly struct CryptographicSeed : IEquatable<CryptographicSeed>
     /// A cryptographic seed describing a cryptographic seed.
     /// </param >
     [Pure]
-    public static CryptographicSeed Parse(string str)
+    public static CryptographicSeed Parse(string? str)
         => TryParse(str, out var seed)
         ? seed
         : throw new FormatException(QowaivMessages.FormatExceptionCryptographicSeed);
@@ -96,10 +96,10 @@ public readonly struct CryptographicSeed : IEquatable<CryptographicSeed>
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string s, out CryptographicSeed result)
+    public static bool TryParse(string? s, out CryptographicSeed result)
     {
         result = Empty;
-        if (string.IsNullOrEmpty(s)) return true;
+        if (s is not { Length: > 0 }) return true;
         else if (Base64.TryGetBytes(s, out byte[] bytes))
         {
             result = Create(bytes);
@@ -120,5 +120,5 @@ public readonly struct CryptographicSeed : IEquatable<CryptographicSeed>
 
     /// <summary>Creates a cryptographic seed from a JSON string node.</summary>
     [Pure]
-    public static CryptographicSeed FromJson(string json) => Parse(json);
+    public static CryptographicSeed FromJson(string? json) => Parse(json);
 }

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -5,6 +5,9 @@ namespace Qowaiv.Security.Cryptography;
 /// <summary>Represents a cryptographic seed.</summary>
 [TypeConverter(typeof(CryptographicSeedTypeConverter))]
 [DebuggerDisplay("{DebuggerDisplay}")]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Security.Cryptography.CryptographicSeedJsonConverter))]
+#endif
 public readonly struct CryptographicSeed : IEquatable<CryptographicSeed>
 {
     /// <summary>Represents an empty/not set cryptographic seed.</summary>

--- a/src/Qowaiv/Security/Secret.cs
+++ b/src/Qowaiv/Security/Secret.cs
@@ -76,12 +76,12 @@ public readonly struct Secret : IEquatable<Secret>
     /// A secret describing a cryptographic seed.
     /// </param >
     [Pure]
-    public static Secret Parse(string str)
-        => string.IsNullOrEmpty(str)
+    public static Secret Parse(string? str)
+        => str is not { Length: > 0 }
         ? Empty
         : new(str);
 
     /// <summary>Creates a secret from a JSON string node.</summary>
     [Pure]
-    public static Secret FromJson(string json) => Parse(json);
+    public static Secret FromJson(string? json) => Parse(json);
 }

--- a/src/Qowaiv/Security/Secret.cs
+++ b/src/Qowaiv/Security/Secret.cs
@@ -7,6 +7,9 @@ namespace Qowaiv.Security;
 /// <summary>Represents a secret.</summary>
 [TypeConverter(typeof(SecretTypeConverter))]
 [DebuggerDisplay("{DebuggerDisplay}")]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Security.SecretJsonConverter))]
+#endif
 public readonly struct Secret : IEquatable<Secret>
 {
     /// <summary>Represents an empty/not set secret.</summary>

--- a/src/Qowaiv/Sex.cs
+++ b/src/Qowaiv/Sex.cs
@@ -27,6 +27,9 @@ namespace Qowaiv;
 [OpenApiDataType(description: "Sex as specified by ISO/IEC 5218.", example: "female", type: "string", format: "sex", nullable: true, @enum: "NotKnown,Male,Female,NotApplicable")]
 [OpenApi.OpenApiDataType(description: "Sex as specified by ISO/IEC 5218.", example: "female", type: "string", format: "sex", nullable: true, @enum: "NotKnown,Male,Female,NotApplicable")]
 [TypeConverter(typeof(SexTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.SexJsonConverter))]
+#endif
 public readonly partial struct Sex : ISerializable, IXmlSerializable, IFormattable, IEquatable<Sex>, IComparable, IComparable<Sex>
 {
     /// <summary>Represents an empty/not set Sex.</summary>

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -19,6 +19,9 @@ namespace Qowaiv.Statistics;
 [OpenApiDataType(description: "Elo rating system notation.", example: 1600, type: "number", format: "elo")]
 [OpenApi.OpenApiDataType(description: "Elo rating system notation.", example: 1600d, type: "number", format: "elo")]
 [TypeConverter(typeof(EloTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Statistics.EloJsonConverter))]
+#endif
 public readonly partial struct Elo : ISerializable, IXmlSerializable, IFormattable, IEquatable<Elo>, IComparable, IComparable<Elo>
 {
     /// <summary>Represents the zero value of an Elo.</summary>

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -22,6 +22,9 @@ namespace Qowaiv;
 [OpenApiDataType(description: "Universally unique identifier, Base64 encoded.", example: "lmZO_haEOTCwGsCcbIZFFg", type: "string", format: "uuid-base64", nullable: true)]
 [OpenApi.OpenApiDataType(description: "Universally unique identifier, Base64 encoded.", example: "lmZO_haEOTCwGsCcbIZFFg", type: "string", format: "uuid-base64", nullable: true)]
 [TypeConverter(typeof(UuidTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.UuidJsonConverter))]
+#endif
 public readonly partial struct Uuid : ISerializable, IXmlSerializable, IFormattable, IEquatable<Uuid>, IComparable, IComparable<Uuid>
 {
     private static readonly UuidBehavior behavior = UuidBehavior.Instance;

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -41,6 +41,9 @@ namespace Qowaiv.Web;
 [OpenApiDataType(description: "Media type notation as defined by RFC 6838.", example: "text/html", type: "string", format: "internet-media-type", nullable: true)]
 [OpenApi.OpenApiDataType(description: "Media type notation as defined by RFC 6838.", example: "text/html", type: "string", format: "internet-media-type", nullable: true)]
 [TypeConverter(typeof(InternetMediaTypeTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.Web.InternetMediaTypeJsonConverter))]
+#endif
 public readonly partial struct InternetMediaType : ISerializable, IXmlSerializable, IFormattable, IEquatable<InternetMediaType>, IComparable, IComparable<InternetMediaType>
 {
     /// <summary>Represents the pattern of a (potential) valid Internet media type.</summary>

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -32,6 +32,9 @@
 [OpenApiDataType(description: "Full-date notation as defined by ISO 8601.", example: "1997-W14-6", type: "string", format: "date-weekbased")]
 [OpenApi.OpenApiDataType(description: "Full-date notation as defined by ISO 8601.", example: "1997-W14-6", type: "string", format: "date-weekbased")]
 [TypeConverter(typeof(WeekDateTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.WeekDateJsonConverter))]
+#endif
 public readonly partial struct WeekDate : ISerializable, IXmlSerializable, IFormattable, IEquatable<WeekDate>, IComparable, IComparable<WeekDate>
 {
     /// <summary>Represents the pattern of a (potential) valid week date.</summary>

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -6,6 +6,9 @@
 [OpenApiDataType(description: "Year(-only) notation.", example: 1983, type: "integer", format: "year", nullable: true)]
 [OpenApi.OpenApiDataType(description: "Year(-only) notation.", example: 1983, type: "integer", format: "year", nullable: true)]
 [TypeConverter(typeof(YearTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.YearJsonConverter))]
+#endif
 public readonly partial struct Year : ISerializable, IXmlSerializable, IFormattable, IEquatable<Year>, IComparable, IComparable<Year>
 {
     /// <summary>Represents the pattern of a (potential) valid year.</summary>

--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -18,6 +18,9 @@ namespace Qowaiv;
 [OpenApiDataType(description: "Yes-No notation.", example: "yes", type: "string", format: "yes-no", nullable: true, @enum: "yes,no,?")]
 [OpenApi.OpenApiDataType(description: "Yes-No notation.", example: "yes", type: "string", format: "yes-no", nullable: true, @enum: "yes,no,?")]
 [TypeConverter(typeof(YesNoTypeConverter))]
+#if NET5_0_OR_GREATER
+[System.Text.Json.Serialization.JsonConverter(typeof(Json.YesNoJsonConverter))]
+#endif
 public readonly partial struct YesNo : ISerializable, IXmlSerializable, IFormattable, IEquatable<YesNo>, IComparable, IComparable<YesNo>
 {
     /// <summary>Represents an empty/not set yes-no.</summary>


### PR DESCRIPTION
Now that System.Text.Json is widely adopted, and not require an extra dependency (the reason for the existence of the convention based serializers) it is time to support System.Text.Json based seralization out-of-the-box. The biggest challenge might be supporting `Id<>` and `Svo<>`.