### PR TITLE
Seal classes that should not be inheritable

### DIFF
--- a/props/package.props
+++ b/props/package.props
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Qowaiv.Analyzers.CSharp" Version="0.0.3.1">
+    <PackageReference Include="Qowaiv.Analyzers.CSharp" Version="0.0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/specs/Qowaiv.Specs/Obsolete_code.cs
+++ b/specs/Qowaiv.Specs/Obsolete_code.cs
@@ -28,3 +28,26 @@ public class Will_be_dropped
 
 [Obsolete("Will become private when the next major version is released.")]
 public class Will_become_private { }
+
+public class Will_seal
+{
+    [Test]
+    public void _2_types()
+    {
+        var decorated = typeof(Qowaiv.Date).Assembly.GetTypes().Concat(
+        typeof(Qowaiv.Data.SvoParameter).Assembly.GetTypes())
+        .Where(tp => tp.GetCustomAttributes<WillBeSealedAttribute>().Any())
+        .OrderBy(tp => tp.FullName);
+
+        foreach (var tp in decorated)
+        {
+            Console.WriteLine($"typeof({tp.FullName}),");
+        }
+
+        decorated.Should().BeEquivalentTo(new[]
+        {
+            typeof(Qowaiv.Conversion.Security.Cryptography.CryptographicSeedTypeConverter),
+            typeof(Qowaiv.Conversion.Security.SecretTypeConverter),
+        });
+    }
+}

--- a/src/Qowaiv.Data.SqlClient/Conversion/Sql/TimestampTypeConverter.cs
+++ b/src/Qowaiv.Data.SqlClient/Conversion/Sql/TimestampTypeConverter.cs
@@ -4,6 +4,7 @@ namespace Qowaiv.Conversion.Sql;
 
 /// <summary>Provides a conversion for a time stamp.</summary>
 [CLSCompliant(false /* based on the non compliant UInt64. */)]
+[Inheritable]
 public class TimestampTypeConverter : NumericTypeConverter<Timestamp, ulong>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv.Data.SqlClient/Properties/GlobalUsings.cs
+++ b/src/Qowaiv.Data.SqlClient/Properties/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using Qowaiv.Formatting;
+﻿global using Qowaiv.Diagnostics.Contracts;
+global using Qowaiv.Formatting;
 global using Qowaiv.Hashing;
 global using Qowaiv.Json;
 global using System;

--- a/src/Qowaiv.TestTools/FormatProvider.cs
+++ b/src/Qowaiv.TestTools/FormatProvider.cs
@@ -16,7 +16,7 @@ public static class FormatProvider
     public static readonly IFormatProvider Empty = new EmptyFormatProvider();
 
     /// <summary>Represents a format provider, that contains no format types.</summary>
-    private class EmptyFormatProvider : IFormatProvider
+    private sealed class EmptyFormatProvider : IFormatProvider
     {
         /// <summary>Always returns null.</summary>
         [Pure]
@@ -24,7 +24,7 @@ public static class FormatProvider
     }
 
     /// <summary>Represents the unit test format provider.</summary>
-    private class CustomFormatProvider: IFormatProvider, ICustomFormatter
+    private sealed class CustomFormatProvider: IFormatProvider, ICustomFormatter
     {
         /// <summary>Returns an object that provides formatting services for the specified type.</summary>
         /// <param name="formatType">

--- a/src/Qowaiv.TestTools/SerializationWrapper.cs
+++ b/src/Qowaiv.TestTools/SerializationWrapper.cs
@@ -4,7 +4,7 @@
 /// and <see cref="SerializeDeserialize.Xml{T}(T)"/>.
 /// </summary>
 [Serializable, XmlRoot("Wrapper")]
-public class SerializationWrapper<T>
+public sealed class SerializationWrapper<T>
 {
     /// <summary>The generic part of the wrapper.</summary>
     public T? Value { get; set; }

--- a/src/Qowaiv/Conversion/Chemistry/CasRegistryNumberTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Chemistry/CasRegistryNumberTypeConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Conversion.Chemistry;
 
 /// <summary>Provides a conversion for a house number.</summary>
-public sealed class CasRegistryNumberTypeConverter : NumericTypeConverter<CasRegistryNumber, long>
+[Inheritable]
+public class CasRegistryNumberTypeConverter : NumericTypeConverter<CasRegistryNumber, long>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Conversion/DateSpanTypeConverter.cs
+++ b/src/Qowaiv/Conversion/DateSpanTypeConverter.cs
@@ -1,6 +1,7 @@
 namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a date span.</summary>
+[Inheritable]
 public class DateSpanTypeConverter : TypeConverter
 {
     /// <summary>Returns whether this converter can convert an string to

--- a/src/Qowaiv/Conversion/DateTypeConverter.cs
+++ b/src/Qowaiv/Conversion/DateTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a Date.</summary>
+[Inheritable]
 public class DateTypeConverter : DateTypeConverter<Date>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/EmailAddressTypeConverter.cs
+++ b/src/Qowaiv/Conversion/EmailAddressTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for an email address.</summary>
+[Inheritable]
 public class EmailAddressTypeConverter : SvoTypeConverter<EmailAddress>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/Financial/AmountTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Financial/AmountTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Financial;
 
 /// <summary>Provides a conversion for an Amount.</summary>
+[Inheritable]
 public class AmountTypeConverter : NumericTypeConverter<Amount, decimal>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/Financial/BusinessIdentifierCodeTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Financial/BusinessIdentifierCodeTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Financial;
 
 /// <summary>Provides a conversion for a BIC.</summary>
+[Inheritable]
 public class BusinessIdentifierCodeTypeConverter : SvoTypeConverter<BusinessIdentifierCode>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/Financial/CurrencyTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Financial/CurrencyTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Financial;
 
 /// <summary>Provides a conversion for a currency.</summary>
+[Inheritable]
 public class CurrencyTypeConverter : SvoTypeConverter<Currency>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/Financial/InternationalBankAccountNumberTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Financial/InternationalBankAccountNumberTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Financial;
 
 /// <summary>Provides a conversion for an IBAN.</summary>
+[Inheritable]
 public class InternationalBankAccountNumberTypeConverter : SvoTypeConverter<InternationalBankAccountNumber>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/Financial/MoneyTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Financial/MoneyTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Financial;
 
 /// <summary>Provides a conversion for Money.</summary>
+[Inheritable]
 public class MoneyTypeConverter : SvoTypeConverter<Money>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/Globalization/CountryTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Globalization/CountryTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Globalization;
 
 /// <summary>Provides a conversion for a Country.</summary>
+[Inheritable]
 public class CountryTypeConverter : SvoTypeConverter<Country>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/HouseNumberTypeConverter.cs
+++ b/src/Qowaiv/Conversion/HouseNumberTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a house number.</summary>
+[Inheritable]
 public class HouseNumberTypeConverter : NumericTypeConverter<HouseNumber, int>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/IO/FileSizeTypeConverter.cs
+++ b/src/Qowaiv/Conversion/IO/FileSizeTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.IO;
 
 /// <summary>Provides a conversion for a stream size.</summary>
+[Inheritable]
 public class StreamSizeTypeConverter : NumericTypeConverter<StreamSize, long>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/LocalDateTimeTypeConverter.cs
+++ b/src/Qowaiv/Conversion/LocalDateTimeTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a local date time.</summary>
+[Inheritable]
 public class LocalDateTimeTypeConverter : DateTypeConverter<LocalDateTime>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/Mathematics/FractionTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Mathematics/FractionTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Mathematics;
 
 /// <summary>Provides a conversion for an email address.</summary>
+[Inheritable]
 public class FractionTypeConverter : SvoTypeConverter<Fraction>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/MonthSpanTypeConverter.cs
+++ b/src/Qowaiv/Conversion/MonthSpanTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a month span.</summary>
+[Inheritable]
 public class MonthSpanTypeConverter : NumericTypeConverter<MonthSpan, int>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/MonthTypeConverter.cs
+++ b/src/Qowaiv/Conversion/MonthTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a month.</summary>
+[Inheritable]
 public class MonthTypeConverter : NumericTypeConverter<Month, byte>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/PercentageTypeConverter.cs
+++ b/src/Qowaiv/Conversion/PercentageTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a Percentage.</summary>
+[Inheritable]
 public class PercentageTypeConverter : NumericTypeConverter<Percentage, decimal>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/PostalCodeTypeConverter.cs
+++ b/src/Qowaiv/Conversion/PostalCodeTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a postal code.</summary>
+[Inheritable]
 public class PostalCodeTypeConverter : SvoTypeConverter<PostalCode>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/Security/Cryptography/CryptographicSeedTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Security/Cryptography/CryptographicSeedTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Security.Cryptography;
 
 /// <summary>Provides a conversion for a cryptographic seed.</summary>
+[WillBeSealed]
 public class CryptographicSeedTypeConverter : TypeConverter
 {
     /// <summary>A secret can only be converted from a string.</summary>

--- a/src/Qowaiv/Conversion/Security/SecretTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Security/SecretTypeConverter.cs
@@ -1,8 +1,7 @@
-﻿using Qowaiv.Security;
-
-namespace Qowaiv.Conversion.Security;
+﻿namespace Qowaiv.Conversion.Security;
 
 /// <summary>Provides a conversion for a cryptographic seed.</summary>
+[WillBeSealed]
 public class SecretTypeConverter : TypeConverter
 {
     /// <summary>A secret can only be converted from a string.</summary>

--- a/src/Qowaiv/Conversion/SexTypeConverter.cs
+++ b/src/Qowaiv/Conversion/SexTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a Sex.</summary>
+[Inheritable]
 public class SexTypeConverter : SvoTypeConverter<Sex>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/Statistics/EloTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Statistics/EloTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Statistics;
 
 /// <summary>Provides a conversion for an Elo.</summary>
+[Inheritable]
 public class EloTypeConverter : NumericTypeConverter<Elo, double>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/UuidTypeConverter.cs
+++ b/src/Qowaiv/Conversion/UuidTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a GUID.</summary>
+[Inheritable]
 public class UuidTypeConverter : SvoTypeConverter<Uuid, Guid>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/Web/InternetMediaTypeTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Web/InternetMediaTypeTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Conversion.Web;
 
 /// <summary>Provides a conversion for an Internet media type.</summary>
+[Inheritable]
 public class InternetMediaTypeTypeConverter : SvoTypeConverter<InternetMediaType>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/WeekDateTypeConverter.cs
+++ b/src/Qowaiv/Conversion/WeekDateTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a week date.</summary>
+[Inheritable]
 public class WeekDateTypeConverter : DateTypeConverter<WeekDate>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/YearTypeConverter.cs
+++ b/src/Qowaiv/Conversion/YearTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a year.</summary>
+[Inheritable]
 public class YearTypeConverter : NumericTypeConverter<Year, int>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Conversion/YesNoTypeConverter.cs
+++ b/src/Qowaiv/Conversion/YesNoTypeConverter.cs
@@ -1,6 +1,7 @@
 namespace Qowaiv.Conversion;
 
 /// <summary>Provides a conversion for a Yes-no.</summary>
+[Inheritable]
 public class YesNoTypeConverter : SvoTypeConverter<YesNo>
 {
     /// <inheritdoc/>

--- a/src/Qowaiv/Diagnostics/Contracts/InheritableAttribute.cs
+++ b/src/Qowaiv/Diagnostics/Contracts/InheritableAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace Qowaiv.Diagnostics.Contracts;
+
+/// <summary>Indicates the a class is designed to be inheritable.</summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+[Conditional("CONTRACTS_FULL")]
+public class InheritableAttribute : Attribute
+{
+    /// <summary>Creates a new instance of the <see cref="InheritableAttribute"/> class.</summary>
+    public InheritableAttribute(string? message = null) => _ = message;
+}

--- a/src/Qowaiv/Diagnostics/Contracts/WillBeSealedAttribute.cs
+++ b/src/Qowaiv/Diagnostics/Contracts/WillBeSealedAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace Qowaiv.Diagnostics.Contracts;
+
+/// <summary>Indicates the class will be sealed with the next major change.</summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+[Conditional("CONTRACTS_FULL")]
+public sealed class WillBeSealedAttribute : InheritableAttribute { }

--- a/src/Qowaiv/Json/Chemistry/CasRegistryNumberJsonConverter.cs
+++ b/src/Qowaiv/Json/Chemistry/CasRegistryNumberJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.Chemistry;
 namespace Qowaiv.Json.Chemistry;
 
 /// <summary>Provides a JSON conversion for a CAS registry.</summary>
-public sealed class CasRegistryNumberJsonConverter : SvoJsonConverter<CasRegistryNumber>
+[Inheritable]
+public class CasRegistryNumberJsonConverter : SvoJsonConverter<CasRegistryNumber>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/DateJsonConverter.cs
+++ b/src/Qowaiv/Json/DateJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a date.</summary>
-public sealed class DateJsonConverter : SvoJsonConverter<Date>
+[Inheritable]
+public class DateJsonConverter : SvoJsonConverter<Date>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/DateSpanJsonConverter.cs
+++ b/src/Qowaiv/Json/DateSpanJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a date span.</summary>
-public sealed class DateSpanJsonConverter : SvoJsonConverter<DateSpan>
+[Inheritable]
+public class DateSpanJsonConverter : SvoJsonConverter<DateSpan>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/EmailAddressJsonConverter.cs
+++ b/src/Qowaiv/Json/EmailAddressJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a email address.</summary>
-public sealed class EmailAddressJsonConverter : SvoJsonConverter<EmailAddress>
+[Inheritable]
+public class EmailAddressJsonConverter : SvoJsonConverter<EmailAddress>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/Financial/AmountJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/AmountJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.Financial;
 namespace Qowaiv.Json.Financial;
 
 /// <summary>Provides a JSON conversion for an amount.</summary>
-public sealed class AmountJsonConverter : SvoJsonConverter<Amount>
+[Inheritable]
+public class AmountJsonConverter : SvoJsonConverter<Amount>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/Financial/BusinessIdentifierCodeJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/BusinessIdentifierCodeJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.Financial;
 namespace Qowaiv.Json.Financial;
 
 /// <summary>Provides a JSON conversion for a BIC.</summary>
-public sealed class BusinessIdentifierCodeJsonConverter : SvoJsonConverter<BusinessIdentifierCode>
+[Inheritable]
+public class BusinessIdentifierCodeJsonConverter : SvoJsonConverter<BusinessIdentifierCode>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/Financial/CurrencyJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/CurrencyJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.Financial;
 namespace Qowaiv.Json.Financial;
 
 /// <summary>Provides a JSON conversion for a currency.</summary>
-public sealed class CurrencyJsonConverter : SvoJsonConverter<Currency>
+[Inheritable]
+public class CurrencyJsonConverter : SvoJsonConverter<Currency>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/Financial/InternationalBankAccountNumberJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/InternationalBankAccountNumberJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.Financial;
 namespace Qowaiv.Json.Financial;
 
 /// <summary>Provides a JSON conversion for an IBAN.</summary>
-public sealed class InternationalBankAccountNumberJsonConverter : SvoJsonConverter<InternationalBankAccountNumber>
+[Inheritable]
+public class InternationalBankAccountNumberJsonConverter : SvoJsonConverter<InternationalBankAccountNumber>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/Financial/MoneyJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/MoneyJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.Financial;
 namespace Qowaiv.Json.Financial;
 
 /// <summary>Provides a JSON conversion for money.</summary>
-public sealed class MoneyJsonConverter : SvoJsonConverter<Money>
+[Inheritable]
+public class MoneyJsonConverter : SvoJsonConverter<Money>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/Globalization/CountryJsonConverter.cs
+++ b/src/Qowaiv/Json/Globalization/CountryJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.Globalization;
 namespace Qowaiv.Json.Globalization;
 
 /// <summary>Provides a JSON conversion for a country.</summary>
-public sealed class CountryJsonConverter : SvoJsonConverter<Country>
+[Inheritable]
+public class CountryJsonConverter : SvoJsonConverter<Country>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/HouseNumberJsonConverter.cs
+++ b/src/Qowaiv/Json/HouseNumberJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a house number.</summary>
-public sealed class HouseNumberJsonConverter : SvoJsonConverter<HouseNumber>
+[Inheritable]
+public class HouseNumberJsonConverter : SvoJsonConverter<HouseNumber>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/IO/StreamSizeJsonConverter.cs
+++ b/src/Qowaiv/Json/IO/StreamSizeJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.IO;
 namespace Qowaiv.Json.IO;
 
 /// <summary>Provides a JSON conversion for a stream size.</summary>
-public sealed class StreamSizeJsonConverter : SvoJsonConverter<StreamSize>
+[Inheritable]
+public class StreamSizeJsonConverter : SvoJsonConverter<StreamSize>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/LocalDateTimeJsonConverter.cs
+++ b/src/Qowaiv/Json/LocalDateTimeJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a local date time.</summary>
-public sealed class LocalDateTimeJsonConverter : SvoJsonConverter<LocalDateTime>
+[Inheritable]
+public class LocalDateTimeJsonConverter : SvoJsonConverter<LocalDateTime>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/Mathematics/FractionJsonConverter.cs
+++ b/src/Qowaiv/Json/Mathematics/FractionJsonConverter.cs
@@ -5,6 +5,7 @@ using Qowaiv.Mathematics;
 namespace Qowaiv.Json.Mathematics;
 
 /// <summary>Provides a JSON conversion for a fraction.</summary>
+[Inheritable]
 public sealed class FractionJsonConverter : SvoJsonConverter<Fraction>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/MonthJsonConverter.cs
+++ b/src/Qowaiv/Json/MonthJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a month.</summary>
-public sealed class MonthJsonConverter : SvoJsonConverter<Month>
+[Inheritable]
+public class MonthJsonConverter : SvoJsonConverter<Month>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/MonthSpanJsonConverter.cs
+++ b/src/Qowaiv/Json/MonthSpanJsonConverter.cs
@@ -3,6 +3,7 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a month span.</summary>
+[Inheritable]
 public sealed class MonthSpanJsonConverter : SvoJsonConverter<MonthSpan>
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Json/PercentageJsonConverter.cs
+++ b/src/Qowaiv/Json/PercentageJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a percentage.</summary>
-public sealed class PercentageJsonConverter : SvoJsonConverter<Percentage>
+[Inheritable]
+public class PercentageJsonConverter : SvoJsonConverter<Percentage>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/PostalCodeJsonConverter.cs
+++ b/src/Qowaiv/Json/PostalCodeJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a postal code.</summary>
-public sealed class PostalCodeJsonConverter : SvoJsonConverter<PostalCode>
+[Inheritable]
+public class PostalCodeJsonConverter : SvoJsonConverter<PostalCode>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/SexJsonConverter.cs
+++ b/src/Qowaiv/Json/SexJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a sex.</summary>
-public sealed class SexJsonConverter : SvoJsonConverter<Sex>
+[Inheritable]
+public class SexJsonConverter : SvoJsonConverter<Sex>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/Statistics/EloJsonConverter.cs
+++ b/src/Qowaiv/Json/Statistics/EloJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.Statistics;
 namespace Qowaiv.Json.Statistics;
 
 /// <summary>Provides a JSON conversion for an Elo.</summary>
-public sealed class EloJsonConverter : SvoJsonConverter<Elo>
+[Inheritable]
+public class EloJsonConverter : SvoJsonConverter<Elo>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/UuidJsonConverter.cs
+++ b/src/Qowaiv/Json/UuidJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a UUID.</summary>
-public sealed class UuidJsonConverter : SvoJsonConverter<Uuid>
+[Inheritable]
+public class UuidJsonConverter : SvoJsonConverter<Uuid>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/Web/InternetMediaTypeJsonConverter.cs
+++ b/src/Qowaiv/Json/Web/InternetMediaTypeJsonConverter.cs
@@ -5,7 +5,8 @@ using Qowaiv.Web;
 namespace Qowaiv.Json.Web;
 
 /// <summary>Provides a JSON conversion for an Internet media type.</summary>
-public sealed class InternetMediaTypeJsonConverter : SvoJsonConverter<InternetMediaType>
+[Inheritable]
+public class InternetMediaTypeJsonConverter : SvoJsonConverter<InternetMediaType>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/WeekDateJsonConverter.cs
+++ b/src/Qowaiv/Json/WeekDateJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a week date.</summary>
-public sealed class WeekDateJsonConverter : SvoJsonConverter<WeekDate>
+[Inheritable]
+public class WeekDateJsonConverter : SvoJsonConverter<WeekDate>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/YearJsonConverter.cs
+++ b/src/Qowaiv/Json/YearJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a year.</summary>
-public sealed class YearJsonConverter : SvoJsonConverter<Year>
+[Inheritable]
+public class YearJsonConverter : SvoJsonConverter<Year>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Json/YesNoJsonConverter.cs
+++ b/src/Qowaiv/Json/YesNoJsonConverter.cs
@@ -3,7 +3,8 @@
 namespace Qowaiv.Json;
 
 /// <summary>Provides a JSON conversion for a yes-no.</summary>
-public sealed class YesNoJsonConverter : SvoJsonConverter<YesNo>
+[Inheritable]
+public class YesNoJsonConverter : SvoJsonConverter<YesNo>
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/UuidDefaultComparer.cs
+++ b/src/Qowaiv/UuidDefaultComparer.cs
@@ -1,7 +1,7 @@
 ﻿namespace Qowaiv;
 
 /// <summary>The default implementation of the <see cref="UuidComparer"/>.</summary>
-internal class UuidDefaultComparer : UuidComparer
+internal sealed class UuidDefaultComparer : UuidComparer
 {
     /// <inheritdoc/>
     /// <remarks>

--- a/src/Qowaiv/UuidMongoDbComparer.cs
+++ b/src/Qowaiv/UuidMongoDbComparer.cs
@@ -1,7 +1,7 @@
 ﻿namespace Qowaiv;
 
 /// <summary>Implements the <see cref="UuidComparer"/> for SQL Server.</summary>
-internal class UuidMongoDbComparer : UuidComparer
+internal sealed class UuidMongoDbComparer : UuidComparer
 {
     /// <inheritdoc/>
     public override IReadOnlyList<int> Priority { get; } = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };

--- a/src/Qowaiv/UuidSqlServerComparer.cs
+++ b/src/Qowaiv/UuidSqlServerComparer.cs
@@ -1,7 +1,7 @@
 ﻿namespace Qowaiv;
 
 /// <summary>Implements the <see cref="UuidComparer"/> for SQL Server.</summary>
-internal class UuidSqlServerComparer : UuidComparer
+internal sealed class UuidSqlServerComparer : UuidComparer
 {
     /// <inheritdoc/>
     /// <remarks>


### PR DESCRIPTION
Thanks to the [Seal concrete classes unless designed for inheritance](https://github.com/Qowaiv/qowaiv-analyzers/blob/main/rules/QW0005.md) it is easier to discover classes that should have been sealed.

Most converters will be decorated (as it is perfectly fine to reuse them), some others will be sealed in the next major release.