### PR TITLE
Use .NET 7.0 for build and unit tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Setup .NET 6.0
+      - name: Setup .NET 7.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.100
+          dotnet-version: 7.0.100
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,10 +11,10 @@ jobs:
  
     steps:
       - uses: actions/checkout@v1
-      - name: Setup .NET 6.0
+      - name: Setup .NET 7.0
         uses: actions/setup-dotnet@v1
         with:
-           dotnet-version: 6.0.100
+           dotnet-version: 7.0.100
       - name: Generate coverage report
         run: dotnet test /p:CollectCoverage=true /p:ThresholdType=branch /p:CoverletOutputFormat=lcov
       - name: Publish coverage report to coveralls.io

--- a/props/common.props
+++ b/props/common.props
@@ -9,6 +9,8 @@
     <Company>Qowaiv community</Company>
     <Copyright>Copyright © Qowaiv community 2013-current</Copyright>
     <LangVersion>latest</LangVersion>
+    <!-- We ship package version for obsolete versions too -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/props/common.props
+++ b/props/common.props
@@ -8,7 +8,7 @@
     <PackageTags>qowaiv domain model</PackageTags>
     <Company>Qowaiv community</Company>
     <Copyright>Copyright © Qowaiv community 2013-current</Copyright>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <!-- We ship package version for obsolete versions too -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\nopackage.props" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As a prerequisite for enabling .NET 7.0 and C# 11 features, first, the build has to be adjusted.  