### PR TITLE
Add .NET 7.0 static contracts

### DIFF
--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -22,7 +22,7 @@ public partial struct Timestamp
 
 public partial struct Timestamp : IEquatable<Timestamp>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Timestamp, Timestamp, bool>
+    , IEqualityOperators<Timestamp, Timestamp, bool>
 #endif
 {
     /// <inheritdoc />
@@ -51,7 +51,7 @@ public partial struct Timestamp : IEquatable<Timestamp>
 
 public partial struct Timestamp : IComparable, IComparable<Timestamp>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<Timestamp, Timestamp, bool>
+    , IComparisonOperators<Timestamp, Timestamp, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -22,7 +22,7 @@ public partial struct Timestamp
 
 public partial struct Timestamp : IEquatable<Timestamp>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Timestamp,Timestamp,bool>
+    , System.Numerics.IEqualityOperators<Timestamp, Timestamp, bool>
 #endif
 {
     /// <inheritdoc />
@@ -50,6 +50,9 @@ public partial struct Timestamp : IEquatable<Timestamp>
 }
 
 public partial struct Timestamp : IComparable, IComparable<Timestamp>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<Timestamp, Timestamp, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Sql;
@@ -20,6 +21,9 @@ public partial struct Timestamp
 }
 
 public partial struct Timestamp : IEquatable<Timestamp>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Timestamp,Timestamp,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -243,4 +247,3 @@ public partial struct Timestamp
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv.Data.SqlClient/Properties/GlobalUsings.cs
+++ b/src/Qowaiv.Data.SqlClient/Properties/GlobalUsings.cs
@@ -12,6 +12,7 @@ global using System.Diagnostics.CodeAnalysis;
 global using System.Diagnostics.Contracts;
 global using System.Globalization;
 global using System.Linq;
+global using System.Numerics;
 global using System.Resources;
 global using System.Runtime.Serialization;
 global using System.Xml;

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -10,6 +10,9 @@
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.DateJsonConverter))]
 #endif
 public readonly partial struct Date : ISerializable, IXmlSerializable, IFormattable, IEquatable<Date>, IComparable, IComparable<Date>
+#if NET7_0_OR_GREATER
+    , IIncrementOperators<Date>, IDecrementOperators<Date>
+#endif
 {
     private const string SerializableFormat = "yyyy-MM-dd";
 

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -12,6 +12,9 @@
 public readonly partial struct Date : ISerializable, IXmlSerializable, IFormattable, IEquatable<Date>, IComparable, IComparable<Date>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Date>, IDecrementOperators<Date>
+    , IAdditionOperators<Date, TimeSpan, Date>, ISubtractionOperators<Date, TimeSpan, Date>
+    , IAdditionOperators<Date, MonthSpan, Date>, ISubtractionOperators<Date, MonthSpan, Date>
+    , ISubtractionOperators<Date, Date, TimeSpan>
 #endif
 {
     private const string SerializableFormat = "yyyy-MM-dd";

--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -11,6 +11,7 @@ namespace Qowaiv;
 #endif
 public readonly partial struct DateSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<DateSpan>, IComparable, IComparable<DateSpan>
 #if NET7_0_OR_GREATER
+    , IUnaryPlusOperators<DateSpan, DateSpan>, IUnaryNegationOperators<DateSpan, DateSpan>
     , IAdditionOperators<DateSpan, DateSpan, DateSpan>, ISubtractionOperators<DateSpan, DateSpan, DateSpan>
 #endif
 {

--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -10,6 +10,9 @@ namespace Qowaiv;
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.DateSpanJsonConverter))]
 #endif
 public readonly partial struct DateSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<DateSpan>, IComparable, IComparable<DateSpan>
+#if NET7_0_OR_GREATER
+    , IAdditionOperators<DateSpan, DateSpan, DateSpan>, ISubtractionOperators<DateSpan, DateSpan, DateSpan>
+#endif
 {
     /// <summary>Represents the pattern of a (potential) valid year.</summary>
     private static readonly Regex Pattern = new(@"^(?<Years>([+-]?[0-9]{1,4}))Y(?<Months>([+-][0-9]{1,6}))M((?<Days>([+-][0-9]{1,7}))D)?$", RegOptions.IgnoreCase, RegOptions.Timeout);

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -14,6 +14,8 @@ namespace Qowaiv.Financial;
 public readonly partial struct Amount : ISerializable, IXmlSerializable, IFormattable, IEquatable<Amount>, IComparable, IComparable<Amount>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Amount>, IDecrementOperators<Amount>
+    , IAdditionOperators<Amount, Amount, Amount>, ISubtractionOperators<Amount, Amount, Amount>
+    , IAdditionOperators<Amount, Percentage, Amount>, ISubtractionOperators<Amount, Percentage, Amount>
 #endif
 {
     /// <summary>Represents an Amount of zero.</summary>

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -14,6 +14,7 @@ namespace Qowaiv.Financial;
 public readonly partial struct Amount : ISerializable, IXmlSerializable, IFormattable, IEquatable<Amount>, IComparable, IComparable<Amount>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Amount>, IDecrementOperators<Amount>
+    , IUnaryPlusOperators<Amount, Amount>, IUnaryNegationOperators<Amount, Amount>
     , IAdditionOperators<Amount, Amount, Amount>, ISubtractionOperators<Amount, Amount, Amount>
     , IAdditionOperators<Amount, Percentage, Amount>, ISubtractionOperators<Amount, Percentage, Amount>
 #endif

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -17,6 +17,15 @@ public readonly partial struct Amount : ISerializable, IXmlSerializable, IFormat
     , IUnaryPlusOperators<Amount, Amount>, IUnaryNegationOperators<Amount, Amount>
     , IAdditionOperators<Amount, Amount, Amount>, ISubtractionOperators<Amount, Amount, Amount>
     , IAdditionOperators<Amount, Percentage, Amount>, ISubtractionOperators<Amount, Percentage, Amount>
+    , IMultiplyOperators<Amount, Percentage, Amount>, IDivisionOperators<Amount, Percentage, Amount>
+    , IMultiplyOperators<Amount, decimal, Amount>, IDivisionOperators<Amount, decimal, Amount>
+    , IMultiplyOperators<Amount, double, Amount>, IDivisionOperators<Amount, double, Amount>
+    , IMultiplyOperators<Amount, long, Amount>, IDivisionOperators<Amount, long, Amount>
+    , IMultiplyOperators<Amount, int, Amount>, IDivisionOperators<Amount, int, Amount>
+    , IMultiplyOperators<Amount, short, Amount>, IDivisionOperators<Amount, short, Amount>
+    , IMultiplyOperators<Amount, ulong, Amount>, IDivisionOperators<Amount, ulong, Amount>
+    , IMultiplyOperators<Amount, uint, Amount>, IDivisionOperators<Amount, uint, Amount>
+    , IMultiplyOperators<Amount, ushort, Amount>, IDivisionOperators<Amount, ushort, Amount>
 #endif
 {
     /// <summary>Represents an Amount of zero.</summary>

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -12,6 +12,9 @@ namespace Qowaiv.Financial;
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.AmountJsonConverter))]
 #endif
 public readonly partial struct Amount : ISerializable, IXmlSerializable, IFormattable, IEquatable<Amount>, IComparable, IComparable<Amount>
+#if NET7_0_OR_GREATER
+    , IIncrementOperators<Amount>, IDecrementOperators<Amount>
+#endif
 {
     /// <summary>Represents an Amount of zero.</summary>
     public static readonly Amount Zero;

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -18,6 +18,15 @@ public readonly partial struct Money : ISerializable, IXmlSerializable, IFormatt
     , IUnaryPlusOperators<Money, Money>, IUnaryNegationOperators<Money, Money>
     , IAdditionOperators<Money, Money, Money>, ISubtractionOperators<Money, Money, Money>
     , IAdditionOperators<Money, Percentage, Money>, ISubtractionOperators<Money, Percentage, Money>
+    , IMultiplyOperators<Money, Percentage, Money>, IDivisionOperators<Money, Percentage, Money>
+    , IMultiplyOperators<Money, decimal, Money>, IDivisionOperators<Money, decimal, Money>
+    , IMultiplyOperators<Money, double, Money>, IDivisionOperators<Money, double, Money>
+    , IMultiplyOperators<Money, long, Money>, IDivisionOperators<Money, long, Money>
+    , IMultiplyOperators<Money, int, Money>, IDivisionOperators<Money, int, Money>
+    , IMultiplyOperators<Money, short, Money>, IDivisionOperators<Money, short, Money>
+    , IMultiplyOperators<Money, ulong, Money>, IDivisionOperators<Money, ulong, Money>
+    , IMultiplyOperators<Money, uint, Money>, IDivisionOperators<Money, uint, Money>
+    , IMultiplyOperators<Money, ushort, Money>, IDivisionOperators<Money, ushort, Money>
 #endif
 {
     /// <summary>Represents an Amount of zero.</summary>

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -13,6 +13,9 @@ namespace Qowaiv.Financial;
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.MoneyJsonConverter))]
 #endif
 public readonly partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEquatable<Money>, IComparable, IComparable<Money>
+#if NET7_0_OR_GREATER
+    , IIncrementOperators<Money>, IDecrementOperators<Money>
+#endif
 {
     /// <summary>Represents an Amount of zero.</summary>
     public static readonly Money Zero;

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -15,6 +15,7 @@ namespace Qowaiv.Financial;
 public readonly partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEquatable<Money>, IComparable, IComparable<Money>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Money>, IDecrementOperators<Money>
+    , IUnaryPlusOperators<Money, Money>, IUnaryNegationOperators<Money, Money>
     , IAdditionOperators<Money, Money, Money>, ISubtractionOperators<Money, Money, Money>
     , IAdditionOperators<Money, Percentage, Money>, ISubtractionOperators<Money, Percentage, Money>
 #endif

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -15,6 +15,8 @@ namespace Qowaiv.Financial;
 public readonly partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEquatable<Money>, IComparable, IComparable<Money>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Money>, IDecrementOperators<Money>
+    , IAdditionOperators<Money, Money, Money>, ISubtractionOperators<Money, Money, Money>
+    , IAdditionOperators<Money, Percentage, Money>, ISubtractionOperators<Money, Percentage, Money>
 #endif
 {
     /// <summary>Represents an Amount of zero.</summary>

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -31,7 +31,7 @@ public partial struct CasRegistryNumber
 
 public partial struct CasRegistryNumber : IEquatable<CasRegistryNumber>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<CasRegistryNumber,CasRegistryNumber,bool>
+    , System.Numerics.IEqualityOperators<CasRegistryNumber, CasRegistryNumber, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -31,7 +31,7 @@ public partial struct CasRegistryNumber
 
 public partial struct CasRegistryNumber : IEquatable<CasRegistryNumber>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<CasRegistryNumber, CasRegistryNumber, bool>
+    , IEqualityOperators<CasRegistryNumber, CasRegistryNumber, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Chemistry;
@@ -29,6 +30,9 @@ public partial struct CasRegistryNumber
 }
 
 public partial struct CasRegistryNumber : IEquatable<CasRegistryNumber>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<CasRegistryNumber,CasRegistryNumber,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct CasRegistryNumber
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv;
 
 public partial struct Date : IEquatable<Date>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Date, Date, bool>
+    , IEqualityOperators<Date, Date, bool>
 #endif
 {
     /// <inheritdoc />
@@ -42,7 +42,7 @@ public partial struct Date : IEquatable<Date>
 
 public partial struct Date : IComparable, IComparable<Date>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<Date, Date, bool>
+    , IComparisonOperators<Date, Date, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv;
 
 public partial struct Date : IEquatable<Date>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Date,Date,bool>
+    , System.Numerics.IEqualityOperators<Date, Date, bool>
 #endif
 {
     /// <inheritdoc />
@@ -41,6 +41,9 @@ public partial struct Date : IEquatable<Date>
 }
 
 public partial struct Date : IComparable, IComparable<Date>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<Date, Date, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -6,11 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
 
 public partial struct Date : IEquatable<Date>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Date,Date,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -234,4 +238,3 @@ public partial struct Date
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -20,6 +21,9 @@ public partial struct DateSpan
 }
 
 public partial struct DateSpan : IEquatable<DateSpan>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<DateSpan,DateSpan,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -229,4 +233,3 @@ public partial struct DateSpan
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -22,7 +22,7 @@ public partial struct DateSpan
 
 public partial struct DateSpan : IEquatable<DateSpan>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<DateSpan, DateSpan, bool>
+    , IEqualityOperators<DateSpan, DateSpan, bool>
 #endif
 {
     /// <inheritdoc />
@@ -42,7 +42,7 @@ public partial struct DateSpan : IEquatable<DateSpan>
 
 public partial struct DateSpan : IComparable, IComparable<DateSpan>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<DateSpan, DateSpan, bool>
+    , IComparisonOperators<DateSpan, DateSpan, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -22,7 +22,7 @@ public partial struct DateSpan
 
 public partial struct DateSpan : IEquatable<DateSpan>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<DateSpan,DateSpan,bool>
+    , System.Numerics.IEqualityOperators<DateSpan, DateSpan, bool>
 #endif
 {
     /// <inheritdoc />
@@ -41,6 +41,9 @@ public partial struct DateSpan : IEquatable<DateSpan>
 }
 
 public partial struct DateSpan : IComparable, IComparable<DateSpan>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<DateSpan, DateSpan, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -31,7 +31,7 @@ public partial struct EmailAddress
 
 public partial struct EmailAddress : IEquatable<EmailAddress>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<EmailAddress,EmailAddress,bool>
+    , System.Numerics.IEqualityOperators<EmailAddress, EmailAddress, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -29,6 +30,9 @@ public partial struct EmailAddress
 }
 
 public partial struct EmailAddress : IEquatable<EmailAddress>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<EmailAddress,EmailAddress,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct EmailAddress
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -31,7 +31,7 @@ public partial struct EmailAddress
 
 public partial struct EmailAddress : IEquatable<EmailAddress>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<EmailAddress, EmailAddress, bool>
+    , IEqualityOperators<EmailAddress, EmailAddress, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Financial;
@@ -20,6 +21,9 @@ public partial struct Amount
 }
 
 public partial struct Amount : IEquatable<Amount>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Amount,Amount,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -243,4 +247,3 @@ public partial struct Amount
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -22,7 +22,7 @@ public partial struct Amount
 
 public partial struct Amount : IEquatable<Amount>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Amount,Amount,bool>
+    , System.Numerics.IEqualityOperators<Amount, Amount, bool>
 #endif
 {
     /// <inheritdoc />
@@ -50,6 +50,9 @@ public partial struct Amount : IEquatable<Amount>
 }
 
 public partial struct Amount : IComparable, IComparable<Amount>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<Amount, Amount, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -22,7 +22,7 @@ public partial struct Amount
 
 public partial struct Amount : IEquatable<Amount>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Amount, Amount, bool>
+    , IEqualityOperators<Amount, Amount, bool>
 #endif
 {
     /// <inheritdoc />
@@ -51,7 +51,7 @@ public partial struct Amount : IEquatable<Amount>
 
 public partial struct Amount : IComparable, IComparable<Amount>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<Amount, Amount, bool>
+    , IComparisonOperators<Amount, Amount, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Financial;
@@ -29,6 +30,9 @@ public partial struct BusinessIdentifierCode
 }
 
 public partial struct BusinessIdentifierCode : IEquatable<BusinessIdentifierCode>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<BusinessIdentifierCode,BusinessIdentifierCode,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct BusinessIdentifierCode
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -31,7 +31,7 @@ public partial struct BusinessIdentifierCode
 
 public partial struct BusinessIdentifierCode : IEquatable<BusinessIdentifierCode>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<BusinessIdentifierCode,BusinessIdentifierCode,bool>
+    , System.Numerics.IEqualityOperators<BusinessIdentifierCode, BusinessIdentifierCode, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -31,7 +31,7 @@ public partial struct BusinessIdentifierCode
 
 public partial struct BusinessIdentifierCode : IEquatable<BusinessIdentifierCode>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<BusinessIdentifierCode, BusinessIdentifierCode, bool>
+    , IEqualityOperators<BusinessIdentifierCode, BusinessIdentifierCode, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -31,7 +31,7 @@ public partial struct Currency
 
 public partial struct Currency : IEquatable<Currency>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Currency,Currency,bool>
+    , System.Numerics.IEqualityOperators<Currency, Currency, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Financial;
@@ -29,6 +30,9 @@ public partial struct Currency
 }
 
 public partial struct Currency : IEquatable<Currency>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Currency,Currency,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct Currency
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -31,7 +31,7 @@ public partial struct Currency
 
 public partial struct Currency : IEquatable<Currency>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Currency, Currency, bool>
+    , IEqualityOperators<Currency, Currency, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Financial;
@@ -29,6 +30,9 @@ public partial struct InternationalBankAccountNumber
 }
 
 public partial struct InternationalBankAccountNumber : IEquatable<InternationalBankAccountNumber>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<InternationalBankAccountNumber,InternationalBankAccountNumber,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct InternationalBankAccountNumber
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -31,7 +31,7 @@ public partial struct InternationalBankAccountNumber
 
 public partial struct InternationalBankAccountNumber : IEquatable<InternationalBankAccountNumber>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<InternationalBankAccountNumber,InternationalBankAccountNumber,bool>
+    , System.Numerics.IEqualityOperators<InternationalBankAccountNumber, InternationalBankAccountNumber, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -31,7 +31,7 @@ public partial struct InternationalBankAccountNumber
 
 public partial struct InternationalBankAccountNumber : IEquatable<InternationalBankAccountNumber>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<InternationalBankAccountNumber, InternationalBankAccountNumber, bool>
+    , IEqualityOperators<InternationalBankAccountNumber, InternationalBankAccountNumber, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -6,11 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Financial;
 
 public partial struct Money : IEquatable<Money>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Money,Money,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -202,4 +206,3 @@ public partial struct Money
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv.Financial;
 
 public partial struct Money : IEquatable<Money>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Money, Money, bool>
+    , IEqualityOperators<Money, Money, bool>
 #endif
 {
     /// <inheritdoc />
@@ -33,7 +33,7 @@ public partial struct Money : IEquatable<Money>
 
 public partial struct Money : IComparable, IComparable<Money>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<Money, Money, bool>
+    , IComparisonOperators<Money, Money, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv.Financial;
 
 public partial struct Money : IEquatable<Money>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Money,Money,bool>
+    , System.Numerics.IEqualityOperators<Money, Money, bool>
 #endif
 {
     /// <inheritdoc />
@@ -32,6 +32,9 @@ public partial struct Money : IEquatable<Money>
 }
 
 public partial struct Money : IComparable, IComparable<Money>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<Money, Money, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -31,7 +31,7 @@ public partial struct Gender
 
 public partial struct Gender : IEquatable<Gender>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Gender, Gender, bool>
+    , IEqualityOperators<Gender, Gender, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -31,7 +31,7 @@ public partial struct Gender
 
 public partial struct Gender : IEquatable<Gender>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Gender,Gender,bool>
+    , System.Numerics.IEqualityOperators<Gender, Gender, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -29,6 +30,9 @@ public partial struct Gender
 }
 
 public partial struct Gender : IEquatable<Gender>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Gender,Gender,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct Gender
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -31,7 +31,7 @@ public partial struct Country
 
 public partial struct Country : IEquatable<Country>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Country, Country, bool>
+    , IEqualityOperators<Country, Country, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -31,7 +31,7 @@ public partial struct Country
 
 public partial struct Country : IEquatable<Country>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Country,Country,bool>
+    , System.Numerics.IEqualityOperators<Country, Country, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Globalization;
@@ -29,6 +30,9 @@ public partial struct Country
 }
 
 public partial struct Country : IEquatable<Country>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Country,Country,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct Country
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -29,6 +30,9 @@ public partial struct HouseNumber
 }
 
 public partial struct HouseNumber : IEquatable<HouseNumber>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<HouseNumber,HouseNumber,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -252,4 +256,3 @@ public partial struct HouseNumber
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -31,7 +31,7 @@ public partial struct HouseNumber
 
 public partial struct HouseNumber : IEquatable<HouseNumber>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<HouseNumber, HouseNumber, bool>
+    , IEqualityOperators<HouseNumber, HouseNumber, bool>
 #endif
 {
     /// <inheritdoc />
@@ -60,7 +60,7 @@ public partial struct HouseNumber : IEquatable<HouseNumber>
 
 public partial struct HouseNumber : IComparable, IComparable<HouseNumber>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<HouseNumber, HouseNumber, bool>
+    , IComparisonOperators<HouseNumber, HouseNumber, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -31,7 +31,7 @@ public partial struct HouseNumber
 
 public partial struct HouseNumber : IEquatable<HouseNumber>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<HouseNumber,HouseNumber,bool>
+    , System.Numerics.IEqualityOperators<HouseNumber, HouseNumber, bool>
 #endif
 {
     /// <inheritdoc />
@@ -59,6 +59,9 @@ public partial struct HouseNumber : IEquatable<HouseNumber>
 }
 
 public partial struct HouseNumber : IComparable, IComparable<HouseNumber>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<HouseNumber, HouseNumber, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv.IO;
 
 public partial struct StreamSize : IEquatable<StreamSize>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<StreamSize, StreamSize, bool>
+    , IEqualityOperators<StreamSize, StreamSize, bool>
 #endif
 {
     /// <inheritdoc />
@@ -42,7 +42,7 @@ public partial struct StreamSize : IEquatable<StreamSize>
 
 public partial struct StreamSize : IComparable, IComparable<StreamSize>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<StreamSize, StreamSize, bool>
+    , IComparisonOperators<StreamSize, StreamSize, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -6,11 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.IO;
 
 public partial struct StreamSize : IEquatable<StreamSize>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<StreamSize,StreamSize,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -213,4 +217,3 @@ public partial struct StreamSize
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv.IO;
 
 public partial struct StreamSize : IEquatable<StreamSize>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<StreamSize,StreamSize,bool>
+    , System.Numerics.IEqualityOperators<StreamSize, StreamSize, bool>
 #endif
 {
     /// <inheritdoc />
@@ -41,6 +41,9 @@ public partial struct StreamSize : IEquatable<StreamSize>
 }
 
 public partial struct StreamSize : IComparable, IComparable<StreamSize>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<StreamSize, StreamSize, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv;
 
 public partial struct LocalDateTime : IEquatable<LocalDateTime>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<LocalDateTime,LocalDateTime,bool>
+    , System.Numerics.IEqualityOperators<LocalDateTime, LocalDateTime, bool>
 #endif
 {
     /// <inheritdoc />
@@ -41,6 +41,9 @@ public partial struct LocalDateTime : IEquatable<LocalDateTime>
 }
 
 public partial struct LocalDateTime : IComparable, IComparable<LocalDateTime>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<LocalDateTime, LocalDateTime, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv;
 
 public partial struct LocalDateTime : IEquatable<LocalDateTime>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<LocalDateTime, LocalDateTime, bool>
+    , IEqualityOperators<LocalDateTime, LocalDateTime, bool>
 #endif
 {
     /// <inheritdoc />
@@ -42,7 +42,7 @@ public partial struct LocalDateTime : IEquatable<LocalDateTime>
 
 public partial struct LocalDateTime : IComparable, IComparable<LocalDateTime>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<LocalDateTime, LocalDateTime, bool>
+    , IComparisonOperators<LocalDateTime, LocalDateTime, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -6,11 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
 
 public partial struct LocalDateTime : IEquatable<LocalDateTime>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<LocalDateTime,LocalDateTime,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -234,4 +238,3 @@ public partial struct LocalDateTime
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -6,11 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Mathematics;
 
 public partial struct Fraction : IEquatable<Fraction>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Fraction,Fraction,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -202,4 +206,3 @@ public partial struct Fraction
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv.Mathematics;
 
 public partial struct Fraction : IEquatable<Fraction>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Fraction, Fraction, bool>
+    , IEqualityOperators<Fraction, Fraction, bool>
 #endif
 {
     /// <inheritdoc />
@@ -33,7 +33,7 @@ public partial struct Fraction : IEquatable<Fraction>
 
 public partial struct Fraction : IComparable, IComparable<Fraction>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<Fraction, Fraction, bool>
+    , IComparisonOperators<Fraction, Fraction, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv.Mathematics;
 
 public partial struct Fraction : IEquatable<Fraction>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Fraction,Fraction,bool>
+    , System.Numerics.IEqualityOperators<Fraction, Fraction, bool>
 #endif
 {
     /// <inheritdoc />
@@ -32,6 +32,9 @@ public partial struct Fraction : IEquatable<Fraction>
 }
 
 public partial struct Fraction : IComparable, IComparable<Fraction>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<Fraction, Fraction, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -31,7 +31,7 @@ public partial struct Month
 
 public partial struct Month : IEquatable<Month>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Month, Month, bool>
+    , IEqualityOperators<Month, Month, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -29,6 +30,9 @@ public partial struct Month
 }
 
 public partial struct Month : IEquatable<Month>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Month,Month,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct Month
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -31,7 +31,7 @@ public partial struct Month
 
 public partial struct Month : IEquatable<Month>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Month,Month,bool>
+    , System.Numerics.IEqualityOperators<Month, Month, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -20,6 +21,9 @@ public partial struct MonthSpan
 }
 
 public partial struct MonthSpan : IEquatable<MonthSpan>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<MonthSpan,MonthSpan,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -243,4 +247,3 @@ public partial struct MonthSpan
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -22,7 +22,7 @@ public partial struct MonthSpan
 
 public partial struct MonthSpan : IEquatable<MonthSpan>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<MonthSpan,MonthSpan,bool>
+    , System.Numerics.IEqualityOperators<MonthSpan, MonthSpan, bool>
 #endif
 {
     /// <inheritdoc />
@@ -50,6 +50,9 @@ public partial struct MonthSpan : IEquatable<MonthSpan>
 }
 
 public partial struct MonthSpan : IComparable, IComparable<MonthSpan>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<MonthSpan, MonthSpan, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -22,7 +22,7 @@ public partial struct MonthSpan
 
 public partial struct MonthSpan : IEquatable<MonthSpan>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<MonthSpan, MonthSpan, bool>
+    , IEqualityOperators<MonthSpan, MonthSpan, bool>
 #endif
 {
     /// <inheritdoc />
@@ -51,7 +51,7 @@ public partial struct MonthSpan : IEquatable<MonthSpan>
 
 public partial struct MonthSpan : IComparable, IComparable<MonthSpan>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<MonthSpan, MonthSpan, bool>
+    , IComparisonOperators<MonthSpan, MonthSpan, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -22,7 +22,7 @@ public partial struct Percentage
 
 public partial struct Percentage : IEquatable<Percentage>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Percentage, Percentage, bool>
+    , IEqualityOperators<Percentage, Percentage, bool>
 #endif
 {
     /// <inheritdoc />
@@ -51,7 +51,7 @@ public partial struct Percentage : IEquatable<Percentage>
 
 public partial struct Percentage : IComparable, IComparable<Percentage>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<Percentage, Percentage, bool>
+    , IComparisonOperators<Percentage, Percentage, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -22,7 +22,7 @@ public partial struct Percentage
 
 public partial struct Percentage : IEquatable<Percentage>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Percentage,Percentage,bool>
+    , System.Numerics.IEqualityOperators<Percentage, Percentage, bool>
 #endif
 {
     /// <inheritdoc />
@@ -50,6 +50,9 @@ public partial struct Percentage : IEquatable<Percentage>
 }
 
 public partial struct Percentage : IComparable, IComparable<Percentage>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<Percentage, Percentage, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -20,6 +21,9 @@ public partial struct Percentage
 }
 
 public partial struct Percentage : IEquatable<Percentage>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Percentage,Percentage,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -243,4 +247,3 @@ public partial struct Percentage
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -29,6 +30,9 @@ public partial struct PostalCode
 }
 
 public partial struct PostalCode : IEquatable<PostalCode>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<PostalCode,PostalCode,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct PostalCode
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -31,7 +31,7 @@ public partial struct PostalCode
 
 public partial struct PostalCode : IEquatable<PostalCode>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<PostalCode,PostalCode,bool>
+    , System.Numerics.IEqualityOperators<PostalCode, PostalCode, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -31,7 +31,7 @@ public partial struct PostalCode
 
 public partial struct PostalCode : IEquatable<PostalCode>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<PostalCode, PostalCode, bool>
+    , IEqualityOperators<PostalCode, PostalCode, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -31,7 +31,7 @@ public partial struct Sex
 
 public partial struct Sex : IEquatable<Sex>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Sex,Sex,bool>
+    , System.Numerics.IEqualityOperators<Sex, Sex, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -31,7 +31,7 @@ public partial struct Sex
 
 public partial struct Sex : IEquatable<Sex>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Sex, Sex, bool>
+    , IEqualityOperators<Sex, Sex, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -29,6 +30,9 @@ public partial struct Sex
 }
 
 public partial struct Sex : IEquatable<Sex>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Sex,Sex,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct Sex
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -22,7 +22,7 @@ public partial struct Elo
 
 public partial struct Elo : IEquatable<Elo>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Elo,Elo,bool>
+    , System.Numerics.IEqualityOperators<Elo, Elo, bool>
 #endif
 {
     /// <inheritdoc />
@@ -50,6 +50,9 @@ public partial struct Elo : IEquatable<Elo>
 }
 
 public partial struct Elo : IComparable, IComparable<Elo>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<Elo, Elo, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -22,7 +22,7 @@ public partial struct Elo
 
 public partial struct Elo : IEquatable<Elo>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Elo, Elo, bool>
+    , IEqualityOperators<Elo, Elo, bool>
 #endif
 {
     /// <inheritdoc />
@@ -51,7 +51,7 @@ public partial struct Elo : IEquatable<Elo>
 
 public partial struct Elo : IComparable, IComparable<Elo>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<Elo, Elo, bool>
+    , IComparisonOperators<Elo, Elo, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Statistics;
@@ -20,6 +21,9 @@ public partial struct Elo
 }
 
 public partial struct Elo : IEquatable<Elo>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Elo,Elo,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -243,4 +247,3 @@ public partial struct Elo
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -25,7 +25,7 @@ public partial struct Uuid
 
 public partial struct Uuid : IEquatable<Uuid>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Uuid,Uuid,bool>
+    , System.Numerics.IEqualityOperators<Uuid, Uuid, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -23,6 +24,9 @@ public partial struct Uuid
 }
 
 public partial struct Uuid : IEquatable<Uuid>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Uuid,Uuid,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -114,7 +118,7 @@ public partial struct Uuid
     /// The deserialized UUID.
     /// </returns>
     [Pure]
-    public static Uuid FromJson(string? json) => Parse(json);
+    public static Uuid FromJson(string json) => Parse(json);
 }
 
 public partial struct Uuid : IXmlSerializable
@@ -181,4 +185,3 @@ public partial struct Uuid
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, out _);
 }
-

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -25,7 +25,7 @@ public partial struct Uuid
 
 public partial struct Uuid : IEquatable<Uuid>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Uuid, Uuid, bool>
+    , IEqualityOperators<Uuid, Uuid, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -31,7 +31,7 @@ public partial struct InternetMediaType
 
 public partial struct InternetMediaType : IEquatable<InternetMediaType>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<InternetMediaType, InternetMediaType, bool>
+    , IEqualityOperators<InternetMediaType, InternetMediaType, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv.Web;
@@ -29,6 +30,9 @@ public partial struct InternetMediaType
 }
 
 public partial struct InternetMediaType : IEquatable<InternetMediaType>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<InternetMediaType,InternetMediaType,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -120,7 +124,7 @@ public partial struct InternetMediaType
     /// The deserialized Internet media type.
     /// </returns>
     [Pure]
-    public static InternetMediaType FromJson(string? json) => Parse(json);
+    public static InternetMediaType FromJson(string json) => Parse(json);
 }
 
 public partial struct InternetMediaType : IXmlSerializable
@@ -187,4 +191,3 @@ public partial struct InternetMediaType
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, out _);
 }
-

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -31,7 +31,7 @@ public partial struct InternetMediaType
 
 public partial struct InternetMediaType : IEquatable<InternetMediaType>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<InternetMediaType,InternetMediaType,bool>
+    , System.Numerics.IEqualityOperators<InternetMediaType, InternetMediaType, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv;
 
 public partial struct WeekDate : IEquatable<WeekDate>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<WeekDate,WeekDate,bool>
+    , System.Numerics.IEqualityOperators<WeekDate, WeekDate, bool>
 #endif
 {
     /// <inheritdoc />
@@ -41,6 +41,9 @@ public partial struct WeekDate : IEquatable<WeekDate>
 }
 
 public partial struct WeekDate : IComparable, IComparable<WeekDate>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IComparisonOperators<WeekDate, WeekDate, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -6,11 +6,15 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
 
 public partial struct WeekDate : IEquatable<WeekDate>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<WeekDate,WeekDate,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -49,7 +53,7 @@ public partial struct WeekDate : IComparable, IComparable<WeekDate>
     /// <inheritdoc />
     [Pure]
 #nullable disable
-    public int CompareTo(WeekDate other) => Comparer<Qowaiv.Date>.Default.Compare(m_Value, other.m_Value);
+    public int CompareTo(WeekDate other) => Comparer<Date>.Default.Compare(m_Value, other.m_Value);
 #nullable enable
     /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
     public static bool operator <(WeekDate l, WeekDate r) => l.CompareTo(r) < 0;
@@ -216,4 +220,3 @@ public partial struct WeekDate
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -13,7 +13,7 @@ namespace Qowaiv;
 
 public partial struct WeekDate : IEquatable<WeekDate>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<WeekDate, WeekDate, bool>
+    , IEqualityOperators<WeekDate, WeekDate, bool>
 #endif
 {
     /// <inheritdoc />
@@ -42,7 +42,7 @@ public partial struct WeekDate : IEquatable<WeekDate>
 
 public partial struct WeekDate : IComparable, IComparable<WeekDate>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IComparisonOperators<WeekDate, WeekDate, bool>
+    , IComparisonOperators<WeekDate, WeekDate, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -29,6 +30,9 @@ public partial struct Year
 }
 
 public partial struct Year : IEquatable<Year>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<Year,Year,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct Year
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -31,7 +31,7 @@ public partial struct Year
 
 public partial struct Year : IEquatable<Year>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Year,Year,bool>
+    , System.Numerics.IEqualityOperators<Year, Year, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -31,7 +31,7 @@ public partial struct Year
 
 public partial struct Year : IEquatable<Year>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<Year, Year, bool>
+    , IEqualityOperators<Year, Year, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -31,7 +31,7 @@ public partial struct YesNo
 
 public partial struct YesNo : IEquatable<YesNo>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<YesNo, YesNo, bool>
+    , IEqualityOperators<YesNo, YesNo, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -31,7 +31,7 @@ public partial struct YesNo
 
 public partial struct YesNo : IEquatable<YesNo>
 #if NET7_0_OR_GREATER
-    , System.Numerics.IEqualityOperators<YesNo,YesNo,bool>
+    , System.Numerics.IEqualityOperators<YesNo, YesNo, bool>
 #endif
 {
     /// <inheritdoc />

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -6,6 +6,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
+
 #nullable enable
 
 namespace Qowaiv;
@@ -29,6 +30,9 @@ public partial struct YesNo
 }
 
 public partial struct YesNo : IEquatable<YesNo>
+#if NET7_0_OR_GREATER
+    , System.Numerics.IEqualityOperators<YesNo,YesNo,bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -241,4 +245,3 @@ public partial struct YesNo
         => !string.IsNullOrWhiteSpace(val)
         && TryParse(val, formatProvider, out _);
 }
-

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -21,6 +21,9 @@ namespace Qowaiv.IO;
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.IO.StreamSizeJsonConverter))]
 #endif
 public readonly partial struct StreamSize : ISerializable, IXmlSerializable, IFormattable, IEquatable<StreamSize>, IComparable, IComparable<StreamSize>
+#if NET7_0_OR_GREATER
+    , IIncrementOperators<StreamSize>, IDecrementOperators<StreamSize>
+#endif
 {
     /// <summary>Represents an empty/not set stream size.</summary>
     public static readonly StreamSize Zero;

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -23,6 +23,8 @@ namespace Qowaiv.IO;
 public readonly partial struct StreamSize : ISerializable, IXmlSerializable, IFormattable, IEquatable<StreamSize>, IComparable, IComparable<StreamSize>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<StreamSize>, IDecrementOperators<StreamSize>
+    , IAdditionOperators<StreamSize, StreamSize, StreamSize>, ISubtractionOperators<StreamSize, StreamSize, StreamSize>
+    , IAdditionOperators<StreamSize, Percentage, StreamSize>, ISubtractionOperators<StreamSize, Percentage, StreamSize>
 #endif
 {
     /// <summary>Represents an empty/not set stream size.</summary>

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -23,6 +23,7 @@ namespace Qowaiv.IO;
 public readonly partial struct StreamSize : ISerializable, IXmlSerializable, IFormattable, IEquatable<StreamSize>, IComparable, IComparable<StreamSize>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<StreamSize>, IDecrementOperators<StreamSize>
+    , IUnaryPlusOperators<StreamSize, StreamSize>, IUnaryNegationOperators<StreamSize, StreamSize>
     , IAdditionOperators<StreamSize, StreamSize, StreamSize>, ISubtractionOperators<StreamSize, StreamSize, StreamSize>
     , IAdditionOperators<StreamSize, Percentage, StreamSize>, ISubtractionOperators<StreamSize, Percentage, StreamSize>
 #endif

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -26,6 +26,15 @@ public readonly partial struct StreamSize : ISerializable, IXmlSerializable, IFo
     , IUnaryPlusOperators<StreamSize, StreamSize>, IUnaryNegationOperators<StreamSize, StreamSize>
     , IAdditionOperators<StreamSize, StreamSize, StreamSize>, ISubtractionOperators<StreamSize, StreamSize, StreamSize>
     , IAdditionOperators<StreamSize, Percentage, StreamSize>, ISubtractionOperators<StreamSize, Percentage, StreamSize>
+    , IMultiplyOperators<StreamSize, Percentage, StreamSize>, IDivisionOperators<StreamSize, Percentage, StreamSize>
+    , IMultiplyOperators<StreamSize, decimal, StreamSize>, IDivisionOperators<StreamSize, decimal, StreamSize>
+    , IMultiplyOperators<StreamSize, double, StreamSize>, IDivisionOperators<StreamSize, double, StreamSize>
+    , IMultiplyOperators<StreamSize, long, StreamSize>, IDivisionOperators<StreamSize, long, StreamSize>
+    , IMultiplyOperators<StreamSize, int, StreamSize>, IDivisionOperators<StreamSize, int, StreamSize>
+    , IMultiplyOperators<StreamSize, short, StreamSize>, IDivisionOperators<StreamSize, short, StreamSize>
+    , IMultiplyOperators<StreamSize, ulong, StreamSize>, IDivisionOperators<StreamSize, ulong, StreamSize>
+    , IMultiplyOperators<StreamSize, uint, StreamSize>, IDivisionOperators<StreamSize, uint, StreamSize>
+    , IMultiplyOperators<StreamSize, ushort, StreamSize>, IDivisionOperators<StreamSize, ushort, StreamSize>
 #endif
 {
     /// <summary>Represents an empty/not set stream size.</summary>

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -14,6 +14,9 @@ namespace Qowaiv;
 public readonly partial struct LocalDateTime : ISerializable, IXmlSerializable, IFormattable, IEquatable<LocalDateTime>, IComparable, IComparable<LocalDateTime>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<LocalDateTime>, IDecrementOperators<LocalDateTime>
+    , IAdditionOperators<LocalDateTime, TimeSpan, LocalDateTime>, ISubtractionOperators<LocalDateTime, TimeSpan, LocalDateTime>
+    , IAdditionOperators<LocalDateTime, MonthSpan, LocalDateTime>, ISubtractionOperators<LocalDateTime, MonthSpan, LocalDateTime>
+    , ISubtractionOperators<LocalDateTime, LocalDateTime, TimeSpan>
 #endif
 {
     private const string SerializableFormat = @"yyyy-MM-dd HH:mm:ss.FFFFFFF";

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -1,4 +1,6 @@
-﻿namespace Qowaiv;
+﻿using System.Numerics;
+
+namespace Qowaiv;
 
 /// <summary>Represents a local date time.</summary>
 [DebuggerDisplay("{DebuggerDisplay}")]
@@ -10,6 +12,9 @@
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.LocalDateTimeJsonConverter))]
 #endif
 public readonly partial struct LocalDateTime : ISerializable, IXmlSerializable, IFormattable, IEquatable<LocalDateTime>, IComparable, IComparable<LocalDateTime>
+#if NET7_0_OR_GREATER
+    , IIncrementOperators<LocalDateTime>, IDecrementOperators<LocalDateTime>
+#endif
 {
     private const string SerializableFormat = @"yyyy-MM-dd HH:mm:ss.FFFFFFF";
 

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -20,6 +20,8 @@ public readonly partial struct Fraction : ISerializable, IXmlSerializable, IForm
     , IUnaryPlusOperators<Fraction, Fraction>, IUnaryNegationOperators<Fraction, Fraction>
     , IAdditionOperators<Fraction, long, Fraction>, ISubtractionOperators<Fraction, long, Fraction>
     , IAdditionOperators<Fraction, int, Fraction>, ISubtractionOperators<Fraction, int, Fraction>
+    , IMultiplyOperators<Fraction, long, Fraction>, IDivisionOperators<Fraction, long, Fraction>
+    , IMultiplyOperators<Fraction, int, Fraction>, IDivisionOperators<Fraction, int, Fraction>
 #endif
 {
     /// <summary>Represents the zero (0) <see cref="Fraction"/> value.</summary>

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -17,6 +17,7 @@ namespace Qowaiv.Mathematics;
 public readonly partial struct Fraction : ISerializable, IXmlSerializable, IFormattable, IEquatable<Fraction>, IComparable, IComparable<Fraction>
 #if NET7_0_OR_GREATER
     , IAdditionOperators<Fraction, Fraction, Fraction>, ISubtractionOperators<Fraction, Fraction, Fraction>
+    , IUnaryPlusOperators<Fraction, Fraction>, IUnaryNegationOperators<Fraction, Fraction>
     , IAdditionOperators<Fraction, long, Fraction>, ISubtractionOperators<Fraction, long, Fraction>
     , IAdditionOperators<Fraction, int, Fraction>, ISubtractionOperators<Fraction, int, Fraction>
 #endif

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -15,6 +15,11 @@ namespace Qowaiv.Mathematics;
 #endif
 [StructLayout(LayoutKind.Sequential)]
 public readonly partial struct Fraction : ISerializable, IXmlSerializable, IFormattable, IEquatable<Fraction>, IComparable, IComparable<Fraction>
+#if NET7_0_OR_GREATER
+    , IAdditionOperators<Fraction, Fraction, Fraction>, ISubtractionOperators<Fraction, Fraction, Fraction>
+    , IAdditionOperators<Fraction, long, Fraction>, ISubtractionOperators<Fraction, long, Fraction>
+    , IAdditionOperators<Fraction, int, Fraction>, ISubtractionOperators<Fraction, int, Fraction>
+#endif
 {
     /// <summary>Represents the zero (0) <see cref="Fraction"/> value.</summary>
     /// <remarks>

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -12,6 +12,7 @@
 #endif
 public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<MonthSpan>, IComparable, IComparable<MonthSpan>
 #if NET7_0_OR_GREATER
+    , IUnaryPlusOperators<MonthSpan, MonthSpan>, IUnaryNegationOperators<MonthSpan, MonthSpan>
     , IAdditionOperators<MonthSpan, MonthSpan, MonthSpan>, ISubtractionOperators<MonthSpan, MonthSpan, MonthSpan>
 #endif
 {

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -14,6 +14,9 @@ public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFor
 #if NET7_0_OR_GREATER
     , IUnaryPlusOperators<MonthSpan, MonthSpan>, IUnaryNegationOperators<MonthSpan, MonthSpan>
     , IAdditionOperators<MonthSpan, MonthSpan, MonthSpan>, ISubtractionOperators<MonthSpan, MonthSpan, MonthSpan>
+    , IMultiplyOperators<MonthSpan, decimal, MonthSpan>, IDivisionOperators<MonthSpan, decimal, MonthSpan>
+    , IMultiplyOperators<MonthSpan, double, MonthSpan>, IDivisionOperators<MonthSpan, double, MonthSpan>
+    , IMultiplyOperators<MonthSpan, int, MonthSpan>, IDivisionOperators<MonthSpan, int, MonthSpan>
 #endif
 {
     /// <summary>Represents a month span with a zero duration.</summary>

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -11,6 +11,9 @@
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.MonthSpanJsonConverter))]
 #endif
 public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<MonthSpan>, IComparable, IComparable<MonthSpan>
+#if NET7_0_OR_GREATER
+    , IAdditionOperators<MonthSpan, MonthSpan, MonthSpan>, ISubtractionOperators<MonthSpan, MonthSpan, MonthSpan>
+#endif
 {
     /// <summary>Represents a month span with a zero duration.</summary>
     public static readonly MonthSpan Zero;

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -14,6 +14,15 @@ public readonly partial struct Percentage : ISerializable, IXmlSerializable, IFo
     , IIncrementOperators<Percentage>, IDecrementOperators<Percentage>
     , IUnaryPlusOperators<Percentage, Percentage>, IUnaryNegationOperators<Percentage, Percentage>
     , IAdditionOperators<Percentage, Percentage, Percentage>, ISubtractionOperators<Percentage, Percentage, Percentage>
+    , IMultiplyOperators<Percentage, Percentage, Percentage>, IDivisionOperators<Percentage, Percentage, Percentage>
+    , IMultiplyOperators<Percentage, decimal, Percentage>, IDivisionOperators<Percentage, decimal, Percentage>
+    , IMultiplyOperators<Percentage, double, Percentage>, IDivisionOperators<Percentage, double, Percentage>
+    , IMultiplyOperators<Percentage, long, Percentage>, IDivisionOperators<Percentage, long, Percentage>
+    , IMultiplyOperators<Percentage, int, Percentage>, IDivisionOperators<Percentage, int, Percentage>
+    , IMultiplyOperators<Percentage, short, Percentage>, IDivisionOperators<Percentage, short, Percentage>
+    , IMultiplyOperators<Percentage, ulong, Percentage>, IDivisionOperators<Percentage, ulong, Percentage>
+    , IMultiplyOperators<Percentage, uint, Percentage>, IDivisionOperators<Percentage, uint, Percentage>
+    , IMultiplyOperators<Percentage, ushort, Percentage>, IDivisionOperators<Percentage, ushort, Percentage>
 #endif
 {
     /// <summary>The percentage symbol (%).</summary>

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -12,6 +12,7 @@
 public readonly partial struct Percentage : ISerializable, IXmlSerializable, IFormattable, IEquatable<Percentage>, IComparable, IComparable<Percentage>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Percentage>, IDecrementOperators<Percentage>
+    , IUnaryPlusOperators<Percentage, Percentage>, IUnaryNegationOperators<Percentage, Percentage>
     , IAdditionOperators<Percentage, Percentage, Percentage>, ISubtractionOperators<Percentage, Percentage, Percentage>
 #endif
 {

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -12,6 +12,7 @@
 public readonly partial struct Percentage : ISerializable, IXmlSerializable, IFormattable, IEquatable<Percentage>, IComparable, IComparable<Percentage>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Percentage>, IDecrementOperators<Percentage>
+    , IAdditionOperators<Percentage, Percentage, Percentage>, ISubtractionOperators<Percentage, Percentage, Percentage>
 #endif
 {
     /// <summary>The percentage symbol (%).</summary>

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -10,6 +10,9 @@
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.PercentageJsonConverter))]
 #endif
 public readonly partial struct Percentage : ISerializable, IXmlSerializable, IFormattable, IEquatable<Percentage>, IComparable, IComparable<Percentage>
+#if NET7_0_OR_GREATER
+    , IIncrementOperators<Percentage>, IDecrementOperators<Percentage>
+#endif
 {
     /// <summary>The percentage symbol (%).</summary>
     public static readonly string PercentSymbol = "%";

--- a/src/Qowaiv/Properties/GlobalUsings.cs
+++ b/src/Qowaiv/Properties/GlobalUsings.cs
@@ -15,6 +15,7 @@ global using System.Diagnostics.CodeAnalysis;
 global using System.Diagnostics.Contracts;
 global using System.Globalization;
 global using System.Linq;
+global using System.Numerics;
 global using System.Resources;
 global using System.Runtime.Serialization;
 global using System.Text;

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -27,6 +27,7 @@ public readonly partial struct Elo : ISerializable, IXmlSerializable, IFormattab
     , IIncrementOperators<Elo>, IDecrementOperators<Elo>
     , IUnaryPlusOperators<Elo, Elo>, IUnaryNegationOperators<Elo, Elo>
     , IAdditionOperators<Elo, Elo, Elo>, ISubtractionOperators<Elo, Elo, Elo>
+    , IMultiplyOperators<Elo, double, Elo>, IDivisionOperators<Elo, double, Elo>
 #endif
 {
     /// <summary>Represents the zero value of an Elo.</summary>
@@ -104,20 +105,25 @@ public readonly partial struct Elo : ISerializable, IXmlSerializable, IFormattab
 
     /// <summary>Increases the Elo with one.</summary>
     public static Elo operator ++(Elo elo) => elo.Increment();
+    
     /// <summary>Decreases the Elo with one.</summary>
     public static Elo operator --(Elo elo) => elo.Decrement();
 
     /// <summary>Unitary plusses the Elo.</summary>
     public static Elo operator +(Elo elo) => elo.Plus();
+    
     /// <summary>Negates the Elo.</summary>
     public static Elo operator -(Elo elo) => elo.Negate();
 
     /// <summary>Multiplies the Elo with the factor.</summary>
     public static Elo operator *(Elo elo, double factor) => elo.Multiply(factor);
+    
     /// <summary>Divides the Elo by the factor.</summary>
     public static Elo operator /(Elo elo, double factor) => elo.Divide(factor);
+    
     /// <summary>Adds the left and the right Elo.</summary>
     public static Elo operator +(Elo l, Elo r) => l.Add(r);
+    
     /// <summary>Subtracts the right from the left Elo.</summary>
     public static Elo operator -(Elo l, Elo r) => l.Subtract(r);
 

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -23,6 +23,9 @@ namespace Qowaiv.Statistics;
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Statistics.EloJsonConverter))]
 #endif
 public readonly partial struct Elo : ISerializable, IXmlSerializable, IFormattable, IEquatable<Elo>, IComparable, IComparable<Elo>
+#if NET7_0_OR_GREATER
+    , IIncrementOperators<Elo>, IDecrementOperators<Elo>
+#endif
 {
     /// <summary>Represents the zero value of an Elo.</summary>
     public static readonly Elo Zero;

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -25,6 +25,7 @@ namespace Qowaiv.Statistics;
 public readonly partial struct Elo : ISerializable, IXmlSerializable, IFormattable, IEquatable<Elo>, IComparable, IComparable<Elo>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Elo>, IDecrementOperators<Elo>
+    , IAdditionOperators<Elo, Elo, Elo>, ISubtractionOperators<Elo, Elo, Elo>
 #endif
 {
     /// <summary>Represents the zero value of an Elo.</summary>

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -25,6 +25,7 @@ namespace Qowaiv.Statistics;
 public readonly partial struct Elo : ISerializable, IXmlSerializable, IFormattable, IEquatable<Elo>, IComparable, IComparable<Elo>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Elo>, IDecrementOperators<Elo>
+    , IUnaryPlusOperators<Elo, Elo>, IUnaryNegationOperators<Elo, Elo>
     , IAdditionOperators<Elo, Elo, Elo>, ISubtractionOperators<Elo, Elo, Elo>
 #endif
 {


### PR DESCRIPTION
All applicable static contracts that are introduced in `System.Numerics`.

See: https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Numerics/IAdditionOperators.cs