### PR TITLE
Extend Month Span operators

### DIFF
--- a/specs/Qowaiv.Specs/MonthSpan_specs.cs
+++ b/specs/Qowaiv.Specs/MonthSpan_specs.cs
@@ -48,7 +48,7 @@ public class Is_equal_by_value
 public class Can_be_transformed
 {
     [Test]
-    public void negatd() => (-Svo.MonthSpan).Should().Be(MonthSpan.FromMonths(-69));
+    public void negate() => (-Svo.MonthSpan).Should().Be(MonthSpan.FromMonths(-69));
 
     [Test]
     public void increment()
@@ -69,6 +69,9 @@ public class Can_be_transformed
     public void multiply_by_int() => (Svo.MonthSpan * 3).Should().Be(MonthSpan.FromMonths(207));
 
     [Test]
+    public void multiply_by_short() => (Svo.MonthSpan * (short)3).Should().Be(MonthSpan.FromMonths(207));
+
+    [Test]
     public void multiply_by_double() => (Svo.MonthSpan * 0.60869).Should().Be(MonthSpan.FromMonths(42));
     
     [Test]
@@ -76,6 +79,9 @@ public class Can_be_transformed
 
     [Test]
     public void divide_by_int() => (Svo.MonthSpan / 3).Should().Be(MonthSpan.FromMonths(23));
+
+    [Test]
+    public void divide_by_short() => (Svo.MonthSpan / (short)3).Should().Be(MonthSpan.FromMonths(23));
 
     [Test]
     public void divide_by_double() => (Svo.MonthSpan / 4.0588).Should().Be(MonthSpan.FromMonths(17));

--- a/specs/Qowaiv.Specs/MonthSpan_specs.cs
+++ b/specs/Qowaiv.Specs/MonthSpan_specs.cs
@@ -45,6 +45,46 @@ public class Is_equal_by_value
     }
 }
 
+public class Can_be_transformed
+{
+    [Test]
+    public void negatd() => (-Svo.MonthSpan).Should().Be(MonthSpan.FromMonths(-69));
+
+    [Test]
+    public void increment()
+    {
+        var span = Svo.MonthSpan;
+        span++;
+        span.Should().Be(MonthSpan.FromMonths(70));
+    }
+    [Test]
+    public void decrement()
+    {
+        var span = Svo.MonthSpan;
+        span--;
+        span.Should().Be(MonthSpan.FromMonths(68));
+    }
+
+    [Test]
+    public void multiply_by_int() => (Svo.MonthSpan * 3).Should().Be(MonthSpan.FromMonths(207));
+
+    [Test]
+    public void multiply_by_double() => (Svo.MonthSpan * 0.60869).Should().Be(MonthSpan.FromMonths(42));
+    
+    [Test]
+    public void multiply_by_decimal() => (Svo.MonthSpan * 0.60869m).Should().Be(MonthSpan.FromMonths(42));
+
+    [Test]
+    public void divide_by_int() => (Svo.MonthSpan / 3).Should().Be(MonthSpan.FromMonths(23));
+
+    [Test]
+    public void divide_by_double() => (Svo.MonthSpan / 4.0588).Should().Be(MonthSpan.FromMonths(17));
+    
+    [Test]
+    public void divide_by_decimal() => (Svo.MonthSpan / 4.0588m).Should().Be(MonthSpan.FromMonths(17));
+
+}
+
 public class Supports_type_conversion
 {
     [Test]

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -322,9 +322,7 @@ public class Can_be_created_sequential
         {
             using (Clock.SetTimeForCurrentThread(() => date))
             {
-                var id = Uuid.NewSequential(comparer);
-                Console.WriteLine(ToString(id, comparer));
-                ids.Add(id);
+                ids.Add(Uuid.NewSequential(comparer));
             }
         }
         CollectionAssert.IsOrdered(ids, comparer);

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -295,48 +295,6 @@ public class MonthSpanTest
         Assert.AreEqual(new DateTime(2016, 09, 11), added);
     }
 
-    [Test]
-    public void Multiply_5MonthsWith3_15Months()
-    {
-        var multiplied = MonthSpan.FromMonths(5) * 3;
-        Assert.AreEqual(MonthSpan.FromMonths(15), multiplied);
-    }
-
-    [Test]
-    public void Multiply_5MonthsWith3Dot3m_16Months()
-    {
-        var multiplied = MonthSpan.FromMonths(5) * 3.3m;
-        Assert.AreEqual(MonthSpan.FromMonths(16), multiplied);
-    }
-
-    [Test]
-    public void Multiply_5MonthsWith3Dot3_16Months()
-    {
-        var multiplied = MonthSpan.FromMonths(5) * 3.3;
-        Assert.AreEqual(MonthSpan.FromMonths(16), multiplied);
-    }
-
-    [Test]
-    public void Divide_16MonthsWith3_5Months()
-    {
-        var multiplied = MonthSpan.FromMonths(16) / 3;
-        Assert.AreEqual(MonthSpan.FromMonths(5), multiplied);
-    }
-
-    [Test]
-    public void Divide_16MonthsWith3Dot4_4Months()
-    {
-        var multiplied = MonthSpan.FromMonths(16) / 3.4;
-        Assert.AreEqual(MonthSpan.FromMonths(4), multiplied);
-    }
-
-    [Test]
-    public void Divide_16MonthsWith3Dot4m_4Months()
-    {
-        var multiplied = MonthSpan.FromMonths(16) / 3.4m;
-        Assert.AreEqual(MonthSpan.FromMonths(4), multiplied);
-    }
-
     [TestCase(0, "2020-04-30", "2020-04-01")]
     [TestCase(1, "2020-04-30", "2020-03-31")]
     [TestCase(11, "2020-01-01", "2019-01-02")]

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -160,10 +160,10 @@ public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFor
     public static MonthSpan operator -(MonthSpan span) => span.Negate();
 
     /// <summary>Increases the month span with one month.</summary>
-    public static MonthSpan operator ++(MonthSpan amount) => amount.Increment();
+    public static MonthSpan operator ++(MonthSpan span) => span.Increment();
 
     /// <summary>Decreases the monthspan with one month.</summary>
-    public static MonthSpan operator --(MonthSpan amount) => amount.Decrement();
+    public static MonthSpan operator --(MonthSpan span) => span.Decrement();
 
     /// <summary>Adds two month spans.</summary>
     public static MonthSpan operator +(MonthSpan l, MonthSpan r) => l.Add(r);

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -12,11 +12,13 @@
 #endif
 public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<MonthSpan>, IComparable, IComparable<MonthSpan>
 #if NET7_0_OR_GREATER
+    , IIncrementOperators<MonthSpan>, IDecrementOperators<MonthSpan>
     , IUnaryPlusOperators<MonthSpan, MonthSpan>, IUnaryNegationOperators<MonthSpan, MonthSpan>
     , IAdditionOperators<MonthSpan, MonthSpan, MonthSpan>, ISubtractionOperators<MonthSpan, MonthSpan, MonthSpan>
     , IMultiplyOperators<MonthSpan, decimal, MonthSpan>, IDivisionOperators<MonthSpan, decimal, MonthSpan>
     , IMultiplyOperators<MonthSpan, double, MonthSpan>, IDivisionOperators<MonthSpan, double, MonthSpan>
     , IMultiplyOperators<MonthSpan, int, MonthSpan>, IDivisionOperators<MonthSpan, int, MonthSpan>
+    , IMultiplyOperators<MonthSpan, short, MonthSpan>, IDivisionOperators<MonthSpan, short, MonthSpan>
 #endif
 {
     /// <summary>Represents a month span with a zero duration.</summary>
@@ -62,6 +64,14 @@ public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFor
     /// <summary>Negates the month span.</summary>
     [Pure]
     public MonthSpan Negate() => new(-m_Value);
+
+    /// <summary>Increases the month span with one month.</summary>
+    [Pure]
+    private MonthSpan Increment() => new(m_Value + 1);
+
+    /// <summary>Decreases the month span with one month.</summary>
+    [Pure]
+    private MonthSpan Decrement() => new(m_Value - 1);
 
     /// <summary>Returns a new month span whose value is the sum of the specified month span and this instance.</summary>
     ///<param name="other">
@@ -143,12 +153,17 @@ public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFor
     [Pure]
     public MonthSpan Divide(double factor) => Divide(Cast.ToDecimal<MonthSpan>(factor));
 
-
     /// <summary>Unary plus the month span.</summary>
     public static MonthSpan operator +(MonthSpan span) => span.Plus();
 
     /// <summary>Negates the month span.</summary>
     public static MonthSpan operator -(MonthSpan span) => span.Negate();
+
+    /// <summary>Increases the month span with one month.</summary>
+    public static MonthSpan operator ++(MonthSpan amount) => amount.Increment();
+
+    /// <summary>Decreases the monthspan with one month.</summary>
+    public static MonthSpan operator --(MonthSpan amount) => amount.Decrement();
 
     /// <summary>Adds two month spans.</summary>
     public static MonthSpan operator +(MonthSpan l, MonthSpan r) => l.Add(r);
@@ -160,6 +175,9 @@ public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFor
     public static MonthSpan operator *(MonthSpan span, int factor) => span.Multiply(factor);
 
     /// <summary>Multiplies the month span with a factor.</summary>
+    public static MonthSpan operator *(MonthSpan span, short factor) => span.Multiply(factor);
+
+    /// <summary>Multiplies the month span with a factor.</summary>
     public static MonthSpan operator *(MonthSpan span, decimal factor) => span.Multiply(factor);
 
     /// <summary>Multiplies the month span with a factor.</summary>
@@ -167,6 +185,9 @@ public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFor
 
     /// <summary>Divides the month span by a factor.</summary>
     public static MonthSpan operator /(MonthSpan span, int factor) => span.Divide(factor);
+
+    /// <summary>Divides the month span by a factor.</summary>
+    public static MonthSpan operator /(MonthSpan span, short factor) => span.Divide(factor);
 
     /// <summary>Divides the month span by a factor.</summary>
     public static MonthSpan operator /(MonthSpan span, decimal factor) => span.Divide(factor);


### PR DESCRIPTION
The `++`, `--`, where not implemented. And the mutiply and divide operators did not support int and short.