### PR TITLE
Add System.IParseble<TSvo> to all Single Value Objects

### DIFF
--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -160,6 +160,9 @@ public partial struct Timestamp : IXmlSerializable
 }
 
 public partial struct Timestamp
+#if NET7_0_OR_GREATER
+    : IParsable<Timestamp>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/EmailAddressCollection.cs
+++ b/src/Qowaiv/EmailAddressCollection.cs
@@ -8,6 +8,9 @@
 [OpenApiDataType(description: "Comma separated list of email addresses defined by RFC 5322.", example: "info@qowaiv.org,test@test.com", type: "string", format: "email-collection", nullable: true)]
 [OpenApi.OpenApiDataType(description: "Comma separated list of email addresses defined by RFC 5322.", example: "info@qowaiv.org,test@test.com", type: "string", format: "email-collection", nullable: true)]
 public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSerializable, IFormattable
+#if NET7_0_OR_GREATER
+    , IParsable<EmailAddressCollection>
+#endif
 {
     /// <summary>The email address separator is a comma.</summary>
     /// <remarks>

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -155,6 +155,9 @@ public partial struct CasRegistryNumber : IXmlSerializable
 }
 
 public partial struct CasRegistryNumber
+#if NET7_0_OR_GREATER
+    : IParsable<CasRegistryNumber>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="CasRegistryNumber"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -151,6 +151,9 @@ public partial struct Date : IXmlSerializable
 }
 
 public partial struct Date
+#if NET7_0_OR_GREATER
+    : IParsable<Date>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -146,6 +146,9 @@ public partial struct DateSpan : IXmlSerializable
 }
 
 public partial struct DateSpan
+#if NET7_0_OR_GREATER
+    : IParsable<DateSpan>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -155,6 +155,9 @@ public partial struct EmailAddress : IXmlSerializable
 }
 
 public partial struct EmailAddress
+#if NET7_0_OR_GREATER
+    : IParsable<EmailAddress>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -160,6 +160,9 @@ public partial struct Amount : IXmlSerializable
 }
 
 public partial struct Amount
+#if NET7_0_OR_GREATER
+    : IParsable<Amount>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -155,6 +155,9 @@ public partial struct BusinessIdentifierCode : IXmlSerializable
 }
 
 public partial struct BusinessIdentifierCode
+#if NET7_0_OR_GREATER
+    : IParsable<BusinessIdentifierCode>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -155,6 +155,9 @@ public partial struct Currency : IXmlSerializable
 }
 
 public partial struct Currency
+#if NET7_0_OR_GREATER
+    : IParsable<Currency>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -155,6 +155,9 @@ public partial struct InternationalBankAccountNumber : IXmlSerializable
 }
 
 public partial struct InternationalBankAccountNumber
+#if NET7_0_OR_GREATER
+    : IParsable<InternationalBankAccountNumber>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -119,6 +119,9 @@ public partial struct Money : IXmlSerializable
 }
 
 public partial struct Money
+#if NET7_0_OR_GREATER
+    : IParsable<Money>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -155,6 +155,9 @@ public partial struct Gender : IXmlSerializable
 }
 
 public partial struct Gender
+#if NET7_0_OR_GREATER
+    : IParsable<Gender>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Gender"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -155,6 +155,9 @@ public partial struct Country : IXmlSerializable
 }
 
 public partial struct Country
+#if NET7_0_OR_GREATER
+    : IParsable<Country>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -169,6 +169,9 @@ public partial struct HouseNumber : IXmlSerializable
 }
 
 public partial struct HouseNumber
+#if NET7_0_OR_GREATER
+    : IParsable<HouseNumber>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -130,6 +130,9 @@ public partial struct StreamSize : IXmlSerializable
 }
 
 public partial struct StreamSize
+#if NET7_0_OR_GREATER
+    : IParsable<StreamSize>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -151,6 +151,9 @@ public partial struct LocalDateTime : IXmlSerializable
 }
 
 public partial struct LocalDateTime
+#if NET7_0_OR_GREATER
+    : IParsable<LocalDateTime>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -119,6 +119,9 @@ public partial struct Fraction : IXmlSerializable
 }
 
 public partial struct Fraction
+#if NET7_0_OR_GREATER
+    : IParsable<Fraction>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -155,6 +155,9 @@ public partial struct Month : IXmlSerializable
 }
 
 public partial struct Month
+#if NET7_0_OR_GREATER
+    : IParsable<Month>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -160,6 +160,9 @@ public partial struct MonthSpan : IXmlSerializable
 }
 
 public partial struct MonthSpan
+#if NET7_0_OR_GREATER
+    : IParsable<MonthSpan>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -160,6 +160,9 @@ public partial struct Percentage : IXmlSerializable
 }
 
 public partial struct Percentage
+#if NET7_0_OR_GREATER
+    : IParsable<Percentage>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -155,6 +155,9 @@ public partial struct PostalCode : IXmlSerializable
 }
 
 public partial struct PostalCode
+#if NET7_0_OR_GREATER
+    : IParsable<PostalCode>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -155,6 +155,9 @@ public partial struct Sex : IXmlSerializable
 }
 
 public partial struct Sex
+#if NET7_0_OR_GREATER
+    : IParsable<Sex>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -160,6 +160,9 @@ public partial struct Elo : IXmlSerializable
 }
 
 public partial struct Elo
+#if NET7_0_OR_GREATER
+    : IParsable<Elo>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -149,6 +149,9 @@ public partial struct Uuid : IXmlSerializable
 }
 
 public partial struct Uuid
+#if NET7_0_OR_GREATER
+    : IParsable<Uuid>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
     /// <param name="s">
@@ -161,7 +164,23 @@ public partial struct Uuid
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Uuid Parse(string? s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionUuid);
+    public static Uuid Parse(string? s) => Parse(s, null);
+
+    /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
+    /// <param name="s">
+    /// A string containing the UUID to convert.
+    /// </param>
+    /// <param name="formatProvider">
+    /// The specified format provider.
+    /// </param>
+    /// <returns>
+    /// The parsed UUID.
+    /// </returns>
+    /// <exception cref="FormatException">
+    /// <paramref name="s"/> is not in the correct format.
+    /// </exception>
+    [Pure]
+    public static Uuid Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionUuid);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
     /// <param name="s">
@@ -171,7 +190,38 @@ public partial struct Uuid
     /// The UUID if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Uuid? TryParse(string? s) => TryParse(s, out var val) ? val : default(Uuid?);
+    public static Uuid? TryParse(string? s) => TryParse(s, null);
+
+    /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
+    /// <param name="s">
+    /// A string containing the UUID to convert.
+    /// </param>
+    /// <param name="formatProvider">
+    /// The specified format provider.
+    /// </param>
+    /// <returns>
+    /// The UUID if the string was converted successfully, otherwise default.
+    /// </returns>
+    [Pure]
+    public static Uuid? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Uuid?);
+
+    /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.
+    /// A return value indicates whether the conversion succeeded.
+    /// </summary>
+    /// <param name="s">
+    /// A string containing the UUID to convert.
+    /// </param>
+    /// <param name="provider">
+    /// The specified format provider.
+    /// </param>
+    /// <param name="result">
+    /// The result of the parsing.
+    /// </param>
+    /// <returns>
+    /// True if the string was converted successfully, otherwise false.
+    /// </returns>
+    [Pure]
+    public static bool TryParse(string? s, IFormatProvider? provider, out Uuid result) => TryParse(s, null, out result);
 }
 
 public partial struct Uuid

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -155,6 +155,9 @@ public partial struct InternetMediaType : IXmlSerializable
 }
 
 public partial struct InternetMediaType
+#if NET7_0_OR_GREATER
+    : IParsable<InternetMediaType>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
     /// <param name="s">
@@ -167,7 +170,23 @@ public partial struct InternetMediaType
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static InternetMediaType Parse(string? s) => TryParse(s) ?? throw new FormatException(QowaivMessages.FormatExceptionInternetMediaType);
+    public static InternetMediaType Parse(string? s) => Parse(s, null);
+
+    /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
+    /// <param name="s">
+    /// A string containing the Internet media type to convert.
+    /// </param>
+    /// <param name="formatProvider">
+    /// The specified format provider.
+    /// </param>
+    /// <returns>
+    /// The parsed Internet media type.
+    /// </returns>
+    /// <exception cref="FormatException">
+    /// <paramref name="s"/> is not in the correct format.
+    /// </exception>
+    [Pure]
+    public static InternetMediaType Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionInternetMediaType);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
     /// <param name="s">
@@ -177,7 +196,35 @@ public partial struct InternetMediaType
     /// The Internet media type if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static InternetMediaType? TryParse(string? s) => TryParse(s, out var val) ? val : default(InternetMediaType?);
+    public static InternetMediaType? TryParse(string? s) => TryParse(s, null);
+
+    /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
+    /// <param name="s">
+    /// A string containing the Internet media type to convert.
+    /// </param>
+    /// <param name="formatProvider">
+    /// The specified format provider.
+    /// </param>
+    /// <returns>
+    /// The Internet media type if the string was converted successfully, otherwise default.
+    /// </returns>
+    [Pure]
+    public static InternetMediaType? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(InternetMediaType?);
+
+    /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.
+    /// A return value indicates whether the conversion succeeded.
+    /// </summary>
+    /// <param name="s">
+    /// A string containing the Internet media type to convert.
+    /// </param>
+    /// <param name="result">
+    /// The result of the parsing.
+    /// </param>
+    /// <returns>
+    /// True if the string was converted successfully, otherwise false.
+    /// </returns>
+    [Pure]
+    public static bool TryParse(string? s, out InternetMediaType result) => TryParse(s, null, out result);
 }
 
 public partial struct InternetMediaType

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -133,6 +133,9 @@ public partial struct WeekDate : IXmlSerializable
 }
 
 public partial struct WeekDate
+#if NET7_0_OR_GREATER
+    : IParsable<WeekDate>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -155,6 +155,9 @@ public partial struct Year : IXmlSerializable
 }
 
 public partial struct Year
+#if NET7_0_OR_GREATER
+    : IParsable<Year>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -155,6 +155,9 @@ public partial struct YesNo : IXmlSerializable
 }
 
 public partial struct YesNo
+#if NET7_0_OR_GREATER
+    : IParsable<YesNo>
+#endif
 {
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -145,20 +145,23 @@ public readonly partial struct InternetMediaType : ISerializable, IXmlSerializab
     /// <param name="s">
     /// A string containing an Internet media type to convert.
     /// </param>
+    /// <param name="provider">
+    /// The specified format provider.
+    /// </param>
     /// <param name="result">
     /// The result of the parsing.
     /// </param>
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, out InternetMediaType result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out InternetMediaType result)
     {
         result = default;
         if (s is not { Length: > 0})
         {
             return true;
         }
-        else if (Qowaiv.Unknown.IsUnknown(s, CultureInfo.InvariantCulture))
+        else if (Qowaiv.Unknown.IsUnknown(s, provider as CultureInfo))
         {
             result = Unknown;
             return true;


### PR DESCRIPTION
De facto, all (but `UUID` and `Web.InternetMediaType`) implemented this interface already. But now (for .NET 7.0 and up) the interface is also there.

Note that there is a naming issue, that will be solved when moving to Qowaiv 7.* (see #273 )