### PR TITLE
Fix circular reference in UUID.TryParse()

### DIFF
--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -118,7 +118,7 @@ public partial struct Uuid
     /// The deserialized UUID.
     /// </returns>
     [Pure]
-    public static Uuid FromJson(string? json) => Parse(json);
+    public static Uuid FromJson(string? json) => Parse(json, CultureInfo.InvariantCulture);
 }
 
 public partial struct Uuid : IXmlSerializable
@@ -136,7 +136,7 @@ public partial struct Uuid : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml);
+        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the UUID to an <see href="XmlWriter" />.</summary>
@@ -211,9 +211,6 @@ public partial struct Uuid
     /// <param name="s">
     /// A string containing the UUID to convert.
     /// </param>
-    /// <param name="provider">
-    /// The specified format provider.
-    /// </param>
     /// <param name="result">
     /// The result of the parsing.
     /// </param>
@@ -221,7 +218,7 @@ public partial struct Uuid
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
     [Pure]
-    public static bool TryParse(string? s, IFormatProvider? provider, out Uuid result) => TryParse(s, null, out result);
+    public static bool TryParse(string? s, out Uuid result) => TryParse(s, null, out result);
 }
 
 public partial struct Uuid
@@ -231,7 +228,17 @@ public partial struct Uuid
     /// The <see cref="string"/> to validate.
     /// </param>
     [Pure]
-    public static bool IsValid(string val)
+    public static bool IsValid(string? val) => IsValid(val, (IFormatProvider?)null);
+
+    /// <summary>Returns true if the value represents a valid UUID.</summary>
+    /// <param name="val">
+    /// The <see cref="string"/> to validate.
+    /// </param>
+    /// <param name="formatProvider">
+    /// The <see cref="IFormatProvider"/> to interpret the <see cref="string"/> value with.
+    /// </param>
+    [Pure]
+    public static bool IsValid(string? val, IFormatProvider? formatProvider)
         => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
+        && TryParse(val, formatProvider, out _);
 }

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -124,7 +124,7 @@ public partial struct InternetMediaType
     /// The deserialized Internet media type.
     /// </returns>
     [Pure]
-    public static InternetMediaType FromJson(string? json) => Parse(json);
+    public static InternetMediaType FromJson(string? json) => Parse(json, CultureInfo.InvariantCulture);
 }
 
 public partial struct InternetMediaType : IXmlSerializable
@@ -142,7 +142,7 @@ public partial struct InternetMediaType : IXmlSerializable
     {
         Guard.NotNull(reader, nameof(reader));
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml);
+        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the Internet media type to an <see href="XmlWriter" />.</summary>
@@ -234,7 +234,17 @@ public partial struct InternetMediaType
     /// The <see cref="string"/> to validate.
     /// </param>
     [Pure]
-    public static bool IsValid(string val)
+    public static bool IsValid(string? val) => IsValid(val, (IFormatProvider?)null);
+
+    /// <summary>Returns true if the value represents a valid Internet media type.</summary>
+    /// <param name="val">
+    /// The <see cref="string"/> to validate.
+    /// </param>
+    /// <param name="formatProvider">
+    /// The <see cref="IFormatProvider"/> to interpret the <see cref="string"/> value with.
+    /// </param>
+    [Pure]
+    public static bool IsValid(string? val, IFormatProvider? formatProvider)
         => !string.IsNullOrWhiteSpace(val)
-        && TryParse(val, out _);
+        && TryParse(val, formatProvider, out _);
 }

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -181,6 +181,9 @@ public readonly partial struct Uuid : ISerializable, IXmlSerializable, IFormatta
     /// <param name="s">
     /// A string containing a UUID to convert.
     /// </param>
+    /// <param name="provider">
+    /// The specified format provider.
+    /// </param>
     /// <param name="result">
     /// The result of the parsing.
     /// </param>
@@ -188,7 +191,7 @@ public readonly partial struct Uuid : ISerializable, IXmlSerializable, IFormatta
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
     [Pure]
-    public static bool TryParse(string? s, out Uuid result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Uuid result)
     {
         result = default;
         if (behavior.TryParse(s, out var id))


### PR DESCRIPTION
With enabling `System.IParsable`, a big bug has been introduced. `UUID`'s TryParse made a circular reference.