### PR TITLE
Run MVC model binding tests in .NET 7.0

### DIFF
--- a/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
+++ b/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
@@ -3,11 +3,11 @@
   <Import Project="..\..\props\nopackage.props" />
   
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.*" />
     <PackageReference Include="nunit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.*">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Update to .NET 7.0 for MVC model binding tests. Resolves #278 