### PR TITLE
Adjust tests to run correctly with .NET Core 3.1

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4,9 +4,6 @@ jobs:
   build:
     name: Build
     runs-on: windows-latest
-    strategy:
-      matrix:
-        dotnet: [ '3.1.x', '5.0.x', '6.0.x', '7.0.x' ]
     steps:
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -15,10 +12,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+      - name: Setup .NET Core 3.1
+        uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: '3.1.x'
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+      - name: Setup .NET 7.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '7.0.x'
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -8,15 +8,25 @@ jobs:
   build:
  
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: [ '3.1.x', '5.0.x', '6.0.x', '7.0.x' ]
+ 
     steps:
       - uses: actions/checkout@v1
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+      - name: Setup .NET Core 3.1
+        uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: '3.1.x'
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+      - name: Setup .NET 7.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '7.0.x'
       - name: Generate coverage report
         run: dotnet test /p:CollectCoverage=true /p:ThresholdType=branch /p:CoverletOutputFormat=lcov
       - name: Publish coverage report to coveralls.io

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -138,11 +138,7 @@ public class Is_equal_by_value
     }
 
     [TestCase("0%", 0)]
-#if NET5_0_OR_GREATER
     [TestCase("17.51%", 665367300)]
-#else
-    [TestCase("17.51%", 1521030558)]
-#endif
     public void hash_code_is_value_based(Percentage svo, int hash)
     {
         using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\nopackage.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net4.8;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -139,11 +139,7 @@ public class Is_equal_by_value
     }
 
     [TestCase("", 0)]
-#if NET5_0_OR_GREATER
     [TestCase("Qowaiv_SVOLibrary_GUIA", -994020281)]
-#else
-    [TestCase("Qowaiv_SVOLibrary_GUIA", -917906459)]
-#endif
     public void hash_code_is_value_based(Uuid svo, int hash)
     {
         using (Hash.WithoutRandomizer())

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -187,11 +187,7 @@ public class Is_equal_by_value
         }
 
     [TestCase("", 0)]
-#if NET5_0_OR_GREATER
     [TestCase("1979", 665629288)]
-#else
-    [TestCase("1979", 538423912)]
-#endif
     public void hash_code_is_value_based(Year svo, int hash)
     {
         using (Hash.WithoutRandomizer())

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>6.3.0</Version>
     <PackageReleaseNotes>

--- a/src/Qowaiv/Text/RegOptions.cs
+++ b/src/Qowaiv/Text/RegOptions.cs
@@ -8,12 +8,11 @@ internal static class RegOptions
     /// the match time-out is set 1 ms.
     /// </summary>
 #if DEBUG
-    public static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(10);
+    public static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(100);
 #else
-    public static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(1);
+    public static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(10);
 #endif
-
-    public static readonly TimeSpan Replacement = TimeSpan.FromMilliseconds(50);
+    public static readonly TimeSpan Replacement = TimeSpan.FromMilliseconds(100);
 
 #if NET7_0_OR_GREATER
     public const RegexOptions Default = RegexOptions.Compiled | RegexOptions.NonBacktracking;


### PR DESCRIPTION
To make both code coverage and Sonar happy again.