### PR TITLE
Regexes should be CultureInvariant for Qowaiv

### DIFF
--- a/src/Qowaiv/Text/RegOptions.cs
+++ b/src/Qowaiv/Text/RegOptions.cs
@@ -17,9 +17,9 @@ internal static class RegOptions
 #if NET7_0_OR_GREATER
     public const RegexOptions Default = RegexOptions.Compiled | RegexOptions.NonBacktracking;
 #else
-    public const RegexOptions Default = RegexOptions.Compiled;
+    public const RegexOptions Default = RegexOptions.Compiled | RegexOptions.CultureInvariant;
 #endif
     public const RegexOptions IgnoreCase = Default | RegexOptions.IgnoreCase;
     public const RegexOptions RightToLeft = RegexOptions.Compiled | RegexOptions.RightToLeft;
-    public const RegexOptions WithBackTracking = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+    public const RegexOptions WithBackTracking = RegexOptions.CultureInvariant | RegexOptions.IgnoreCase;
 }

--- a/src/Qowaiv/Text/RegOptions.cs
+++ b/src/Qowaiv/Text/RegOptions.cs
@@ -20,6 +20,6 @@ internal static class RegOptions
     public const RegexOptions Default = RegexOptions.Compiled | RegexOptions.CultureInvariant;
 #endif
     public const RegexOptions IgnoreCase = Default | RegexOptions.IgnoreCase;
-    public const RegexOptions RightToLeft = RegexOptions.Compiled | RegexOptions.RightToLeft;
+    public const RegexOptions RightToLeft = RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.RightToLeft;
     public const RegexOptions WithBackTracking = RegexOptions.CultureInvariant | RegexOptions.IgnoreCase;
 }


### PR DESCRIPTION
All regular expressions in Qowaiv check for alphanumeric input. All this input is within the ASCII range. It should not take different alphabets or numeric systems into account.