### PR TITLE
Fix issue with not closed comment in parsing email adresses

### DIFF
--- a/specs/Qowaiv.Specs/Email_address_format_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_format_specs.cs
@@ -251,7 +251,7 @@ public class Comments
     public void not_nested()
         => Email.ShouldBeInvalid("in( nested(extra) )fo@qowaiv.org");
 
-    [TestCase("inf(o@qowaiv.org", Ignore = "Crashes. Fix in separate ")]
+    [TestCase("inf(o@qowaiv.org")]
     [TestCase("info)@qowaiv.org")]
     [TestCase("in)wrong order(fo@qowaiv.org")]
     public void not_matching(string notMatching)

--- a/src/Qowaiv/EmailParser.State.cs
+++ b/src/Qowaiv/EmailParser.State.cs
@@ -46,7 +46,9 @@ internal static partial class EmailParser
                 ch = Next();
                 if (ch.IsCommentStart()) { return default; }
             }
-            return NextNoComment();
+            return Input.Length == 0
+                ? default 
+                : NextNoComment();
         }
 
         [Impure]


### PR DESCRIPTION
The test case "info(@qowaiv.org" was previously not executed as the test case attribute value was ignored. Enabling it uncovered a bug, that now has been fixed.