### PR TITLE
Decorate methods that always throw with [DoesNotReturn] attribute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -85,6 +85,12 @@ dotnet_diagnostic.CA2249.severity = warning
 # CA2254: Template should be a static expression
 dotnet_diagnostic.CA2254.severity = warning
 
+# CS8763 A method marked [DoesNotReturn] should not return.
+dotnet_diagnostic.CS8763.severity = warning
+
+# CS8770 Method lacks [DoesNotReturn] annotation to match implemented or overridden member.
+dotnet_diagnostic.CS8770.severity = warning
+
 # QW0003: Decorate Pure functions
 dotnet_diagnostic.QW0003.severity = warning
 

--- a/src/Qowaiv/Conversion/DateTypeConverter.cs
+++ b/src/Qowaiv/Conversion/DateTypeConverter.cs
@@ -11,6 +11,9 @@ public class DateTypeConverter : DateTypeConverter<Date>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
+#if NET5_0_OR_GREATER
+    [DoesNotReturn]
+#endif
     protected override Date FromDate(Date date) => throw new NotSupportedException();
 
     /// <inheritdoc />
@@ -32,6 +35,9 @@ public class DateTypeConverter : DateTypeConverter<Date>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
+#if NET5_0_OR_GREATER
+    [DoesNotReturn]
+#endif
     protected override Date ToDate(Date date) => throw new NotSupportedException();
 
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/DateTypeConverter.cs
+++ b/src/Qowaiv/Conversion/DateTypeConverter.cs
@@ -14,6 +14,7 @@ public class DateTypeConverter : DateTypeConverter<Date>
 #if NET5_0_OR_GREATER
     [DoesNotReturn]
 #endif
+    [WillBeSealed]
     protected override Date FromDate(Date date) => throw new NotSupportedException();
 
     /// <inheritdoc />
@@ -38,6 +39,7 @@ public class DateTypeConverter : DateTypeConverter<Date>
 #if NET5_0_OR_GREATER
     [DoesNotReturn]
 #endif
+    [WillBeSealed]
     protected override Date ToDate(Date date) => throw new NotSupportedException();
 
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/LocalDateTimeTypeConverter.cs
+++ b/src/Qowaiv/Conversion/LocalDateTimeTypeConverter.cs
@@ -23,6 +23,9 @@ public class LocalDateTimeTypeConverter : DateTypeConverter<LocalDateTime>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
+#if NET5_0_OR_GREATER
+    [DoesNotReturn]
+#endif
     protected override LocalDateTime FromLocalDateTime(LocalDateTime local) => throw new NotSupportedException();
 
     /// <inheritdoc />
@@ -41,6 +44,9 @@ public class LocalDateTimeTypeConverter : DateTypeConverter<LocalDateTime>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
+#if NET5_0_OR_GREATER
+    [DoesNotReturn]
+#endif
     protected override LocalDateTime ToLocalDateTime(LocalDateTime date) => throw new NotSupportedException();
 
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/LocalDateTimeTypeConverter.cs
+++ b/src/Qowaiv/Conversion/LocalDateTimeTypeConverter.cs
@@ -26,6 +26,7 @@ public class LocalDateTimeTypeConverter : DateTypeConverter<LocalDateTime>
 #if NET5_0_OR_GREATER
     [DoesNotReturn]
 #endif
+    [WillBeSealed]
     protected override LocalDateTime FromLocalDateTime(LocalDateTime local) => throw new NotSupportedException();
 
     /// <inheritdoc />
@@ -47,6 +48,7 @@ public class LocalDateTimeTypeConverter : DateTypeConverter<LocalDateTime>
 #if NET5_0_OR_GREATER
     [DoesNotReturn]
 #endif
+    [WillBeSealed]
     protected override LocalDateTime ToLocalDateTime(LocalDateTime date) => throw new NotSupportedException();
 
     /// <inheritdoc />

--- a/src/Qowaiv/Conversion/WeekDateTypeConverter.cs
+++ b/src/Qowaiv/Conversion/WeekDateTypeConverter.cs
@@ -30,6 +30,7 @@ public class WeekDateTypeConverter : DateTypeConverter<WeekDate>
 #if NET5_0_OR_GREATER
     [DoesNotReturn]
 #endif
+    [WillBeSealed]
     protected override WeekDate FromWeekDate(WeekDate weekDate) => throw new NotSupportedException();
 
     /// <inheritdoc />
@@ -54,5 +55,6 @@ public class WeekDateTypeConverter : DateTypeConverter<WeekDate>
 #if NET5_0_OR_GREATER
     [DoesNotReturn]
 #endif
+    [WillBeSealed]
     protected override WeekDate ToWeekDate(WeekDate date) => throw new NotSupportedException();
 }

--- a/src/Qowaiv/Conversion/WeekDateTypeConverter.cs
+++ b/src/Qowaiv/Conversion/WeekDateTypeConverter.cs
@@ -27,6 +27,9 @@ public class WeekDateTypeConverter : DateTypeConverter<WeekDate>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
+#if NET5_0_OR_GREATER
+    [DoesNotReturn]
+#endif
     protected override WeekDate FromWeekDate(WeekDate weekDate) => throw new NotSupportedException();
 
     /// <inheritdoc />
@@ -48,5 +51,8 @@ public class WeekDateTypeConverter : DateTypeConverter<WeekDate>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
+#if NET5_0_OR_GREATER
+    [DoesNotReturn]
+#endif
     protected override WeekDate ToWeekDate(WeekDate date) => throw new NotSupportedException();
 }

--- a/src/Qowaiv/Diagnostics/Contracts/WillBeSealedAttribute.cs
+++ b/src/Qowaiv/Diagnostics/Contracts/WillBeSealedAttribute.cs
@@ -1,6 +1,6 @@
 ﻿namespace Qowaiv.Diagnostics.Contracts;
 
 /// <summary>Indicates the class will be sealed with the next major change.</summary>
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 [Conditional("CONTRACTS_FULL")]
 public sealed class WillBeSealedAttribute : InheritableAttribute { }

--- a/src/Qowaiv/Hashing/Hash.cs
+++ b/src/Qowaiv/Hashing/Hash.cs
@@ -33,6 +33,7 @@ public readonly struct Hash : IEquatable<Hash>
 #if NET5_0_OR_GREATER
     [DoesNotReturn]
 #endif
+    [WillBeSealed]
     public override int GetHashCode() => NotSupportedBy<Hash>();
 
     /// <summary>extends the hash with the added item.</summary>

--- a/src/Qowaiv/Identifiers/IdentifierBehavior.cs
+++ b/src/Qowaiv/Identifiers/IdentifierBehavior.cs
@@ -29,9 +29,6 @@ public abstract class IdentifierBehavior : TypeConverter, IIdentifierBehavior
 
     /// <inheritdoc/>
     [Pure]
-#if NET5_0_OR_GREATER
-    [DoesNotReturn]
-#endif
     public virtual object? FromJson(long obj) => throw new NotSupportedException();
 
     /// <inheritdoc/>
@@ -40,9 +37,6 @@ public abstract class IdentifierBehavior : TypeConverter, IIdentifierBehavior
 
     /// <inheritdoc/>
     [Pure]
-#if NET5_0_OR_GREATER
-    [DoesNotReturn]
-#endif
     public virtual object Next() => throw new NotSupportedException();
 
     /// <inheritdoc/>

--- a/src/Qowaiv/Identifiers/IdentifierBehavior.cs
+++ b/src/Qowaiv/Identifiers/IdentifierBehavior.cs
@@ -29,6 +29,9 @@ public abstract class IdentifierBehavior : TypeConverter, IIdentifierBehavior
 
     /// <inheritdoc/>
     [Pure]
+#if NET5_0_OR_GREATER
+    [DoesNotReturn]
+#endif
     public virtual object? FromJson(long obj) => throw new NotSupportedException();
 
     /// <inheritdoc/>
@@ -37,6 +40,9 @@ public abstract class IdentifierBehavior : TypeConverter, IIdentifierBehavior
 
     /// <inheritdoc/>
     [Pure]
+#if NET5_0_OR_GREATER
+    [DoesNotReturn]
+#endif
     public virtual object Next() => throw new NotSupportedException();
 
     /// <inheritdoc/>


### PR DESCRIPTION
The `[DoesNotReturn]` attribute  should be used to decorate methods that never return (but always throw). 

## See
* https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.doesnotreturnattribute.
* https://endjin.com/blog/2020/08/dotnet-csharp-8-nullable-references-when-methods-dont-return