### PR TITLE
Decorate string arguments representing regexes with [StringSyntax(StringSyntaxAttribute.Regex)]

### DIFF
--- a/src/Qowaiv/OpenApi/OpenApiDataType.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataType.cs
@@ -57,6 +57,9 @@ public sealed record OpenApiDataType
     public bool Nullable { get; }
 
     /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>
+#if NET7_0_OR_GREATER
+    [StringSyntax(StringSyntaxAttribute.Regex)]
+#endif
     public string? Pattern { get; }
 
     /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>

--- a/src/Qowaiv/OpenApi/OpenApiDataType.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataType.cs
@@ -17,7 +17,11 @@ public sealed record OpenApiDataType
        object? example,
        string? format = null,
        bool nullable = false,
-       string? pattern = null,
+#if NET7_0_OR_GREATER
+        [StringSyntax(StringSyntaxAttribute.Regex)] string? pattern = null,
+#else
+        string? pattern = null,
+#endif
        IReadOnlyCollection<string>? @enum = null)
 #pragma warning restore S107 // Methods should not have too many parameters
     {

--- a/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
@@ -47,6 +47,9 @@ public sealed class OpenApiDataTypeAttribute : Attribute
     public bool Nullable { get; }
 
     /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>
+#if NET7_0_OR_GREATER
+    [StringSyntax(StringSyntaxAttribute.Regex)]
+#endif
     public string? Pattern { get; }
 
     /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>

--- a/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
@@ -15,7 +15,11 @@ public sealed class OpenApiDataTypeAttribute : Attribute
         object example,
         string? format = null,
         bool nullable = false,
+#if NET7_0_OR_GREATER
+        [StringSyntax(StringSyntaxAttribute.Regex)] string? pattern = null,
+#else
         string? pattern = null,
+#endif
         string? @enum = null)
     {
         Description = Guard.NotNullOrEmpty(description, nameof(description));


### PR DESCRIPTION
By decorating arguments with `[StringSyntax(StringSyntaxAttribute.Regex)]`, the IDE will give visual hints on the regular expressions. This is available since .NET 7.0.