### PR TITLE
Use Spans to concatenate strings

### DIFF
--- a/src/Qowaiv/Extensions/System.String.cs
+++ b/src/Qowaiv/Extensions/System.String.cs
@@ -84,14 +84,4 @@ public static class QowaivSystemExtensions
 
     [Pure]
     internal static CharSpan CharSpan(this string? str) => str is null ? new(string.Empty) : new(str);
-
-#if NETSTANDARD
-    /// <summary>Alias to provide an implantation that works for .NET standard.</summary>
-    [Pure]
-    internal static string AsSpan(this string str, int startIndex) => str.Substring(startIndex);
-
-    /// <summary>Alias to provide an implantation that works for .NET standard.</summary>
-    [Pure]
-    internal static string AsSpan(this string str, int startIndex, int length) => str.Substring(startIndex, length);
-#endif
 }

--- a/src/Qowaiv/Extensions/System.String.cs
+++ b/src/Qowaiv/Extensions/System.String.cs
@@ -84,4 +84,14 @@ public static class QowaivSystemExtensions
 
     [Pure]
     internal static CharSpan CharSpan(this string? str) => str is null ? new(string.Empty) : new(str);
+
+#if NETSTANDARD
+    /// <summary>Alias to provide an implantation that works for .NET standard.</summary>
+    [Pure]
+    internal static string AsSpan(this string str, int startIndex) => str.Substring(startIndex);
+
+    /// <summary>Alias to provide an implantation that works for .NET standard.</summary>
+    [Pure]
+    internal static string AsSpan(this string str, int startIndex, int length) => str.Substring(startIndex, length);
+#endif
 }

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -207,7 +207,7 @@ public readonly partial struct InternationalBankAccountNumber : ISerializable, I
     [Pure]
     private static bool Mod97(string iban)
     {
-        var digits = iban.Substring(4) + iban.Substring(0, 4);
+        var digits = string.Concat(iban.AsSpan(4), iban.AsSpan(0, 4));
         var mod = 0;
         foreach (var digit in digits)
         {

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -207,10 +207,10 @@ public readonly partial struct InternationalBankAccountNumber : ISerializable, I
     [Pure]
     private static bool Mod97(string iban)
     {
-        var digits = string.Concat(iban.AsSpan(4), iban.AsSpan(0, 4));
         var mod = 0;
-        foreach (var digit in digits)
+        for (var i = 0; i < iban.Length; i++)
         {
+            var digit = iban[(i + 4) % iban.Length]; // Calculate the first 4 characters (country and checksum) last
             var index = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".IndexOf(digit);
             mod *= index > 9 ? 100 : 10;
             mod += index;

--- a/src/Qowaiv/Identifiers/GuidBehavior.cs
+++ b/src/Qowaiv/Identifiers/GuidBehavior.cs
@@ -112,7 +112,8 @@ public class GuidBehavior : IdentifierBehavior
         }
         else if (Uuid.Pattern.IsMatch(str))
         {
-            var bytes = Convert.FromBase64String(str.Replace('-', '+').Replace('_', '/').Substring(0, 22) + "==");
+            var base64 = string.Concat(str.Replace('-', '+').Replace('_', '/').AsSpan(0, 22), "==");
+            var bytes = Convert.FromBase64String(base64);
             id = new Guid(bytes);
 
             if (Guid.Empty.Equals(id))

--- a/src/Qowaiv/Identifiers/GuidBehavior.cs
+++ b/src/Qowaiv/Identifiers/GuidBehavior.cs
@@ -107,29 +107,17 @@ public class GuidBehavior : IdentifierBehavior
         }
         else if (Guid.TryParse(str, out Guid guid))
         {
-            id = guid == Guid.Empty ? null : guid;
+            id = NullIfEmpty(guid);
             return true;
         }
         else if (Uuid.Pattern.IsMatch(str))
         {
-            var base64 = string.Concat(str.Replace('-', '+').Replace('_', '/').AsSpan(0, 22), "==");
-            var bytes = Convert.FromBase64String(base64);
-            id = new Guid(bytes);
-
-            if (Guid.Empty.Equals(id))
-            {
-                id = null;
-            }
+            id = NullIfEmpty(GuidFromBase64(str));
             return true;
         }
         else if (str.Length == 26 && Base32.TryGetBytes(str, out var b32))
         {
-            id = new Guid(b32);
-
-            if (Guid.Empty.Equals(id))
-            {
-                id = null;
-            }
+            id = NullIfEmpty(new Guid(b32));
             return true;
         }
         else
@@ -137,6 +125,20 @@ public class GuidBehavior : IdentifierBehavior
             id = default;
             return false;
         }
+        
+        static Guid GuidFromBase64(string str)
+        {
+            var base64 = new char[24];
+            for (int i = 0; i < 22; i++)
+            {
+                base64[i] = str[i] switch { '-' => '+', '_' => '/', _ => str[i] };
+            }
+            base64[22] = '=';
+            base64[23] = '=';
+            return new Guid(Convert.FromBase64String(new string(base64)));
+        }
+
+        static object? NullIfEmpty(Guid guid) => guid == Guid.Empty ? null : guid;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
As suggested by CA1845, use `.AsSpan()` for string manipulations.