### PR TITLE
Use BackwardsCompatibleFeatures package to simplify build

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -36,6 +36,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BackwardsCompatibleFeatures" Version="2.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="SonarAnalyzer.CSharp" Version="*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Qowaiv/Conversion/DateTypeConverter.cs
+++ b/src/Qowaiv/Conversion/DateTypeConverter.cs
@@ -11,9 +11,7 @@ public class DateTypeConverter : DateTypeConverter<Date>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     [WillBeSealed]
     protected override Date FromDate(Date date) => throw new NotSupportedException();
 
@@ -36,9 +34,7 @@ public class DateTypeConverter : DateTypeConverter<Date>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     [WillBeSealed]
     protected override Date ToDate(Date date) => throw new NotSupportedException();
 

--- a/src/Qowaiv/Conversion/LocalDateTimeTypeConverter.cs
+++ b/src/Qowaiv/Conversion/LocalDateTimeTypeConverter.cs
@@ -23,9 +23,7 @@ public class LocalDateTimeTypeConverter : DateTypeConverter<LocalDateTime>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     [WillBeSealed]
     protected override LocalDateTime FromLocalDateTime(LocalDateTime local) => throw new NotSupportedException();
 
@@ -45,9 +43,7 @@ public class LocalDateTimeTypeConverter : DateTypeConverter<LocalDateTime>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     [WillBeSealed]
     protected override LocalDateTime ToLocalDateTime(LocalDateTime date) => throw new NotSupportedException();
 

--- a/src/Qowaiv/Conversion/WeekDateTypeConverter.cs
+++ b/src/Qowaiv/Conversion/WeekDateTypeConverter.cs
@@ -27,9 +27,7 @@ public class WeekDateTypeConverter : DateTypeConverter<WeekDate>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     [WillBeSealed]
     protected override WeekDate FromWeekDate(WeekDate weekDate) => throw new NotSupportedException();
 
@@ -52,9 +50,7 @@ public class WeekDateTypeConverter : DateTypeConverter<WeekDate>
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     [Pure]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     [WillBeSealed]
     protected override WeekDate ToWeekDate(WeekDate date) => throw new NotSupportedException();
 }

--- a/src/Qowaiv/Customization/Svo.cs
+++ b/src/Qowaiv/Customization/Svo.cs
@@ -84,7 +84,7 @@ public readonly partial struct Svo<TSvoBehavior> : ISerializable, IXmlSerializab
 #else
     public int CompareTo(Svo<TSvoBehavior> other)
     {
-        // Comparing with char.max value does not work as accpected in older versions of .NET
+        // Comparing with char.max value does not work as expected in older versions of .NET
         if (IsUnknown() || other.IsUnknown())
         {
             if (IsUnknown())

--- a/src/Qowaiv/Hashing/Hash.cs
+++ b/src/Qowaiv/Hashing/Hash.cs
@@ -30,9 +30,7 @@ public readonly struct Hash : IEquatable<Hash>
     /// <summary>Throws a <see cref="HashingNotSupported" />.</summary>
     [Pure]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     [WillBeSealed]
     public override int GetHashCode() => NotSupportedBy<Hash>();
 
@@ -62,9 +60,7 @@ public readonly struct Hash : IEquatable<Hash>
 
     /// <summary>Indicates that hashing is not supported by the type.</summary>
     [Pure]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     public static int NotSupportedBy<T>()
         => throw new HashingNotSupported(string.Format(QowaivMessages.HashingNotSupported, typeof(T)));
 

--- a/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataTypeAttribute.cs
@@ -14,11 +14,7 @@ public sealed class OpenApiDataTypeAttribute : Attribute
         object example,
         string? format = null,
         bool nullable = false,
-#if NET7_0_OR_GREATER
         [StringSyntax(StringSyntaxAttribute.Regex)] string? pattern = null,
-#else
-        string? pattern = null,
-#endif
         string? @enum = null)
     {
         Description = Guard.NotNullOrEmpty(description, nameof(description));
@@ -46,9 +42,7 @@ public sealed class OpenApiDataTypeAttribute : Attribute
     public bool Nullable { get; }
 
     /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>
-#if NET7_0_OR_GREATER
     [StringSyntax(StringSyntaxAttribute.Regex)]
-#endif
     public string? Pattern { get; }
 
     /// <summary>Gets the Pattern of the OpenAPI Data Type.</summary>

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -52,9 +52,7 @@ public readonly struct CryptographicSeed : IEquatable<CryptographicSeed>
 
     /// <inheritdoc />
     [Pure]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     public override int GetHashCode() => Hash.NotSupportedBy<CryptographicSeed>();
 
     /// <summary>Represents the cryptographic seed as "*****".</summary>

--- a/src/Qowaiv/Security/Secret.cs
+++ b/src/Qowaiv/Security/Secret.cs
@@ -49,9 +49,7 @@ public readonly struct Secret : IEquatable<Secret>
 
     /// <inheritdoc />
     [Pure]
-#if NET5_0_OR_GREATER
     [DoesNotReturn]
-#endif
     public override int GetHashCode() => Hash.NotSupportedBy<Secret>();
 
     /// <summary>Represents the secret as "*****".</summary>


### PR DESCRIPTION
As BackwardsCompatibleFeatures reduces the need to some `#if` code blocks. More details can be found [here](https://github.com/CptWesley/BackwardsCompatibleFeatures).