### PR TITLE
Introduction of EmptyTestClass attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 |![v](https://img.shields.io/badge/version-6.4.0-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
 |![v](https://img.shields.io/badge/version-6.4.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Data.SqlCient](https://www.nuget.org/packages/Qowaiv.Data.SqlClient/)|
-|![v](https://img.shields.io/badge/version-6.4.1-darkblue.svg?cacheSeconds=3600)|[Qowaiv.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)         |
+|![v](https://img.shields.io/badge/version-6.4.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)         |
 
 # Qowaiv
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 |![v](https://img.shields.io/badge/version-6.4.0-blue.svg?cacheSeconds=3600)    |[Qowaiv](https://www.nuget.org/packages/Qowaiv/)                             |
 |![v](https://img.shields.io/badge/version-6.4.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Data.SqlCient](https://www.nuget.org/packages/Qowaiv.Data.SqlClient/)|
-|![v](https://img.shields.io/badge/version-6.4.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)         |
+|![v](https://img.shields.io/badge/version-6.4.1-darkblue.svg?cacheSeconds=3600)|[Qowaiv.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)         |
 
 # Qowaiv
 

--- a/specs/Qowaiv.Specs/Extensions/Type_specs.cs
+++ b/specs/Qowaiv.Specs/Extensions/Type_specs.cs
@@ -60,6 +60,7 @@ public class CSharpString
     public void With_namespaces_if_specified(Type type, string csharpString)
         => type.ToCSharpString(withNamespace: true).Should().Be(csharpString);
 
+    [EmptyTestClass]
     internal class NestedType { }
 
     internal static class GenericOf

--- a/specs/Qowaiv.Specs/TestTools/Have_debugger_display_specs.cs
+++ b/specs/Qowaiv.Specs/TestTools/Have_debugger_display_specs.cs
@@ -43,4 +43,5 @@ internal class SimpleClass
     private string DebuggerDisplay => $"{GetType().Name} display";
 }
 
+[EmptyTestClass]
 internal sealed class ChildClass : SimpleClass { }

--- a/specs/Qowaiv.Specs/TestTools/Svo.cs
+++ b/specs/Qowaiv.Specs/TestTools/Svo.cs
@@ -139,6 +139,11 @@ public sealed class ForInt64 : Int64IdBehavior
     private static bool IsValid(long number) => (number & 1) == 1;
 }
 
+[EmptyTestClass]
 public class ForString : StringIdBehavior { }
+
+[EmptyTestClass]
 public class ForGuid : GuidBehavior { }
+
+[EmptyTestClass]
 public class ForUuid : UuidBehavior { }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
@@ -1,487 +1,475 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Identifiers;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests.Identifiers;
 
-namespace Qowaiv.UnitTests.Identifiers
+[EmptyTestClass]
+public sealed class ForGuid : GuidBehavior { }
+
+/// <summary>Tests the identifier SVO.</summary>
+public class IdForGuidTest
 {
-    public sealed class ForGuid : GuidBehavior { }
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly Id<ForGuid> TestStruct = Id<ForGuid>.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504");
 
-    /// <summary>Tests the identifier SVO.</summary>
-    public class IdForGuidTest
+    /// <summary>Id<ForGuid>.Empty should be equal to the default of identifier.</summary>
+    [Test]
+    public void Empty_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly Id<ForGuid> TestStruct = Id<ForGuid>.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504");
+        Assert.AreEqual(default(Id<ForGuid>), Id<ForGuid>.Empty);
+    }
 
-        /// <summary>Id<ForGuid>.Empty should be equal to the default of identifier.</summary>
-        [Test]
-        public void Empty_None_EqualsDefault()
-        {
-            Assert.AreEqual(default(Id<ForGuid>), Id<ForGuid>.Empty);
-        }
+    /// <summary>Id<ForGuid>.IsEmpty() should be true for the default of identifier.</summary>
+    [Test]
+    public void IsEmpty_Default_IsTrue()
+    {
+        Assert.IsTrue(default(Id<ForGuid>).IsEmpty());
+    }
 
-        /// <summary>Id<ForGuid>.IsEmpty() should be true for the default of identifier.</summary>
-        [Test]
-        public void IsEmpty_Default_IsTrue()
-        {
-            Assert.IsTrue(default(Id<ForGuid>).IsEmpty());
-        }
+    /// <summary>Id<ForGuid>.IsEmpty() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsEmpty_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmpty());
+    }
 
-        /// <summary>Id<ForGuid>.IsEmpty() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsEmpty_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmpty());
-        }
+    [Test]
+    public void FromBytes_Null_IsEmpty()
+    {
+        var fromBytes = Id<ForGuid>.FromBytes(null);
+        Assert.AreEqual(Id<ForGuid>.Empty, fromBytes);
+    }
 
-        [Test]
-        public void FromBytes_Null_IsEmpty()
-        {
-            var fromBytes = Id<ForGuid>.FromBytes(null);
-            Assert.AreEqual(Id<ForGuid>.Empty, fromBytes);
-        }
+    [Test]
+    public void FromBytes_Bytes_IsTestStruct()
+    {
+        var fromBytes = Id<ForGuid>.FromBytes(new byte[] { 171, 181, 90, 15, 203, 18, 41, 70, 135, 141, 177, 139, 136, 185, 165, 4 });
+        Assert.AreEqual(TestStruct, fromBytes);
+    }
 
-        [Test]
-        public void FromBytes_Bytes_IsTestStruct()
-        {
-            var fromBytes = Id<ForGuid>.FromBytes(new byte[] { 171, 181, 90, 15, 203, 18, 41, 70, 135, 141, 177, 139, 136, 185, 165, 4 });
-            Assert.AreEqual(TestStruct, fromBytes);
-        }
+    [Test]
+    public void ToByteArray_Empty_EmptyArray()
+    {
+        var bytes = Id<ForGuid>.Empty.ToByteArray();
+        Assert.AreEqual(Array.Empty<byte>(), bytes);
+    }
 
-        [Test]
-        public void ToByteArray_Empty_EmptyArray()
-        {
-            var bytes = Id<ForGuid>.Empty.ToByteArray();
-            Assert.AreEqual(Array.Empty<byte>(), bytes);
-        }
+    [Test]
+    public void ToByteArray_TestStruct_FilledArray()
+    {
+        var bytes = TestStruct.ToByteArray();
+        var exepected = new byte[] { 171, 181, 90, 15, 203, 18, 41, 70, 135, 141, 177, 139, 136, 185, 165, 4 };
+        Assert.AreEqual(exepected, bytes);
+    }
 
-        [Test]
-        public void ToByteArray_TestStruct_FilledArray()
-        {
-            var bytes = TestStruct.ToByteArray();
-            var exepected = new byte[] { 171, 181, 90, 15, 203, 18, 41, 70, 135, 141, 177, 139, 136, 185, 165, 4 };
-            Assert.AreEqual(exepected, bytes);
-        }
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
+    {
+        Assert.IsTrue(Id<ForGuid>.TryParse(null, out var val));
+        Assert.AreEqual(default(Id<ForGuid>), val);
+    }
 
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            Assert.IsTrue(Id<ForGuid>.TryParse(null, out var val));
-            Assert.AreEqual(default(Id<ForGuid>), val);
-        }
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
+    {
+        Assert.IsTrue(Id<ForGuid>.TryParse(string.Empty, out var val));
+        Assert.AreEqual(default(Id<ForGuid>), val);
+    }
 
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            Assert.IsTrue(Id<ForGuid>.TryParse(string.Empty, out var val));
-            Assert.AreEqual(default(Id<ForGuid>), val);
-        }
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "0f5ab5ab-12cb-4629-878d-b18b88b9a504";
+        Assert.IsTrue(Id<ForGuid>.TryParse(str, out var val));
+        Assert.AreEqual(str, val.ToString());
+    }
 
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            string str = "0f5ab5ab-12cb-4629-878d-b18b88b9a504";
-            Assert.IsTrue(Id<ForGuid>.TryParse(str, out var val));
-            Assert.AreEqual(str, val.ToString());
-        }
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "0F5AB5AB-12CB-4629-878D";
+        Assert.IsFalse(Id<ForGuid>.TryParse(str, out var val));
+        Assert.AreEqual(default(Id<ForGuid>), val);
+    }
 
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
         {
-            string str = "0F5AB5AB-12CB-4629-878D";
-            Assert.IsFalse(Id<ForGuid>.TryParse(str, out var val));
-            Assert.AreEqual(default(Id<ForGuid>), val);
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
+            Assert.Catch<FormatException>(() =>
             {
-                Assert.Catch<FormatException>(() =>
-                {
-                    Id<ForGuid>.Parse("InvalidInput");
-                }
-
-                , "Not a valid identifier");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = Id<ForGuid>.TryParse(exp.ToString());
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Id<ForGuid>);
-                var act = Id<ForGuid>.TryParse("InvalidInput");
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void TryCreate_Int_NotSuccessful()
-        {
-            Assert.IsFalse(Id<ForGuid>.TryCreate(17L, out _));
-        }
-
-        [Test]
-        public void TryCreate_Guid_Successful()
-        {
-            Assert.IsTrue(Id<ForGuid>.TryCreate(Guid.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), out var id));
-            Assert.AreEqual(Id<ForGuid>.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), id);
-        }
-
-        [Test]
-        public void GetObjectData_NulSerializationInfo_Throws()
-        {
-            ISerializable obj = TestStruct;
-            Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
-        }
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(Id<ForGuid>), new FormatterConverter());
-            obj.GetObjectData(info, default);
-            Assert.AreEqual(Guid.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), info.GetValue("Value", typeof(Guid)));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "0f5ab5ab-12cb-4629-878d-b18b88b9a504";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<Id<ForGuid>>("0F5AB5AB-12CB-4629-878D-B18B88B9A504");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_IdForGuidSerializeObject_AreEqual()
-        {
-            var input = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
+                Id<ForGuid>.Parse("InvalidInput");
             }
 
-            ;
-            var exp = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_IdForGuidSerializeObject_AreEqual()
-        {
-            var input = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_IdForGuidSerializeObject_AreEqual()
-        {
-            var input = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Default_AreEqual()
-        {
-            var input = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_Default_AreEqual()
-        {
-            var input = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForGuidSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<Id<ForGuid>>(json));
-        }
-
-        [TestCase("0F5AB5AB-12CB-4629-878D-B18B88B9A504", "0F5AB5AB-12CB-4629-878D-B18B88B9A504")]
-        [TestCase("", "")]
-        public void FromJson(Id<ForGuid> expected, object json)
-        {
-            var actual = JsonTester.Read<Id<ForGuid>>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ToJson_TestStruct_StringValue()
-        {
-            var json = TestStruct.ToJson();
-            Assert.AreEqual("0f5ab5ab-12cb-4629-878d-b18b88b9a504", json);
-        }
-
-        [Test]
-        public void ToString_Empty_StringEmpty()
-        {
-            var act = Id<ForGuid>.Empty.ToString();
-            var exp = "";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("S", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: 'q7VaD8sSKUaHjbGLiLmlBA', format: 'S'";
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>GetHash should not fail for Id<ForGuid>.Empty.</summary>
-        [Test]
-        public void GetHash_Empty_Hash()
-        {
-            Assert.AreEqual(0, Id<ForGuid>.Empty.GetHashCode());
-        }
-
-        /// <summary>GetHash should not fail for the test struct.</summary>
-        [Test]
-        public void GetHash_TestStruct_Hash()
-        {
-            Assert.AreNotEqual(0, TestStruct.GetHashCode());
-        }
-
-        [Test]
-        public void Equals_EmptyEmpty_IsTrue()
-        {
-            Assert.IsTrue(Id<ForGuid>.Empty.Equals(Id<ForGuid>.Empty));
-        }
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            var l = Id<ForGuid>.Parse("Qowaiv_SVOLibrary_GUIA");
-            var r = Id<ForGuid>.Parse("8a1a8c42-d2ff-e254-e26e-b6abcbf19420");
-            Assert.IsTrue(l.Equals(r));
-        }
-
-        [Test]
-        public void Equals_TestStructTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructEmpty_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(Id<ForGuid>.Empty));
-        }
-
-        [Test]
-        public void Equals_EmptyTestStruct_IsFalse()
-        {
-            Assert.IsFalse(Id<ForGuid>.Empty.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructObjectTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals((object)TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructNull_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(null));
-        }
-
-        [Test]
-        public void Equals_TestStructObject_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(new object()));
-        }
-
-        [Test]
-        public void OperatorIs_TestStructTestStruct_IsTrue()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsTrue(l == r);
-        }
-
-        [Test]
-        public void OperatorIsNot_TestStructTestStruct_IsFalse()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsFalse(l != r);
-        }
-
-        [Test]
-        public void Next_100Items_AllUnique()
-        {
-            var nexts = Enumerable.Range(0, 100).Select(i => Id<ForGuid>.Next()).ToArray();
-            CollectionAssert.AllItemsAreUnique(nexts);
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase("Complex")]
-        public void IsInvalid_String(string str)
-        {
-            Assert.IsFalse(Id<ForGuid>.IsValid(str));
-        }
-
-        [TestCase("0F5AB5AB-12CB-4629-878D-B18B88B9A504")]
-        [TestCase("Qowaiv_SVOLibrary_GUIA")]
-        public void IsValid_String(string str)
-        {
-            Assert.IsTrue(Id<ForGuid>.IsValid(str));
+            , "Not a valid identifier");
         }
     }
 
-    [Serializable]
-    public class IdForGuidSerializeObject
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
     {
-        public int Id { get; set; }
-        public Id<ForGuid> Obj { get; set; }
-        public DateTime Date { get; set; }
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = Id<ForGuid>.TryParse(exp.ToString());
+            Assert.AreEqual(exp, act);
+        }
     }
+
+    [Test]
+    public void TryParse_InvalidInput_DefaultValue()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = default(Id<ForGuid>);
+            var act = Id<ForGuid>.TryParse("InvalidInput");
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void TryCreate_Int_NotSuccessful()
+    {
+        Assert.IsFalse(Id<ForGuid>.TryCreate(17L, out _));
+    }
+
+    [Test]
+    public void TryCreate_Guid_Successful()
+    {
+        Assert.IsTrue(Id<ForGuid>.TryCreate(Guid.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), out var id));
+        Assert.AreEqual(Id<ForGuid>.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), id);
+    }
+
+    [Test]
+    public void GetObjectData_NulSerializationInfo_Throws()
+    {
+        ISerializable obj = TestStruct;
+        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
+    }
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(Id<ForGuid>), new FormatterConverter());
+        obj.GetObjectData(info, default);
+        Assert.AreEqual(Guid.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), info.GetValue("Value", typeof(Guid)));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "0f5ab5ab-12cb-4629-878d-b18b88b9a504";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<Id<ForGuid>>("0F5AB5AB-12CB-4629-878D-B18B88B9A504");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_IdForGuidSerializeObject_AreEqual()
+    {
+        var input = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_IdForGuidSerializeObject_AreEqual()
+    {
+        var input = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_IdForGuidSerializeObject_AreEqual()
+    {
+        var input = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Default_AreEqual()
+    {
+        var input = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_Default_AreEqual()
+    {
+        var input = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForGuidSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    [TestCase("2017-06-11")]
+    public void FromJson_Invalid_Throws(object json)
+    {
+        Assert.Catch<FormatException>(() => JsonTester.Read<Id<ForGuid>>(json));
+    }
+
+    [TestCase("0F5AB5AB-12CB-4629-878D-B18B88B9A504", "0F5AB5AB-12CB-4629-878D-B18B88B9A504")]
+    [TestCase("", "")]
+    public void FromJson(Id<ForGuid> expected, object json)
+    {
+        var actual = JsonTester.Read<Id<ForGuid>>(json);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void ToJson_TestStruct_StringValue()
+    {
+        var json = TestStruct.ToJson();
+        Assert.AreEqual("0f5ab5ab-12cb-4629-878d-b18b88b9a504", json);
+    }
+
+    [Test]
+    public void ToString_Empty_StringEmpty()
+    {
+        var act = Id<ForGuid>.Empty.ToString();
+        var exp = "";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("S", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: 'q7VaD8sSKUaHjbGLiLmlBA', format: 'S'";
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>GetHash should not fail for Id<ForGuid>.Empty.</summary>
+    [Test]
+    public void GetHash_Empty_Hash()
+    {
+        Assert.AreEqual(0, Id<ForGuid>.Empty.GetHashCode());
+    }
+
+    /// <summary>GetHash should not fail for the test struct.</summary>
+    [Test]
+    public void GetHash_TestStruct_Hash()
+    {
+        Assert.AreNotEqual(0, TestStruct.GetHashCode());
+    }
+
+    [Test]
+    public void Equals_EmptyEmpty_IsTrue()
+    {
+        Assert.IsTrue(Id<ForGuid>.Empty.Equals(Id<ForGuid>.Empty));
+    }
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        var l = Id<ForGuid>.Parse("Qowaiv_SVOLibrary_GUIA");
+        var r = Id<ForGuid>.Parse("8a1a8c42-d2ff-e254-e26e-b6abcbf19420");
+        Assert.IsTrue(l.Equals(r));
+    }
+
+    [Test]
+    public void Equals_TestStructTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructEmpty_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(Id<ForGuid>.Empty));
+    }
+
+    [Test]
+    public void Equals_EmptyTestStruct_IsFalse()
+    {
+        Assert.IsFalse(Id<ForGuid>.Empty.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructObjectTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals((object)TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructNull_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(null));
+    }
+
+    [Test]
+    public void Equals_TestStructObject_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(new object()));
+    }
+
+    [Test]
+    public void OperatorIs_TestStructTestStruct_IsTrue()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsTrue(l == r);
+    }
+
+    [Test]
+    public void OperatorIsNot_TestStructTestStruct_IsFalse()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsFalse(l != r);
+    }
+
+    [Test]
+    public void Next_100Items_AllUnique()
+    {
+        var nexts = Enumerable.Range(0, 100).Select(i => Id<ForGuid>.Next()).ToArray();
+        CollectionAssert.AllItemsAreUnique(nexts);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("Complex")]
+    public void IsInvalid_String(string str)
+    {
+        Assert.IsFalse(Id<ForGuid>.IsValid(str));
+    }
+
+    [TestCase("0F5AB5AB-12CB-4629-878D-B18B88B9A504")]
+    [TestCase("Qowaiv_SVOLibrary_GUIA")]
+    public void IsValid_String(string str)
+    {
+        Assert.IsTrue(Id<ForGuid>.IsValid(str));
+    }
+}
+
+[Serializable]
+public class IdForGuidSerializeObject
+{
+    public int Id { get; set; }
+    public Id<ForGuid> Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
@@ -1,485 +1,472 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Globalization;
-using Qowaiv.Identifiers;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests.Identifiers;
 
-namespace Qowaiv.UnitTests.Identifiers
+[EmptyTestClass]
+public sealed class ForInt32 : Int32IdBehavior { }
+
+/// <summary>Tests the identifier SVO.</summary>
+public class IdForInt32Test
 {
-    public sealed class ForInt32 : Int32IdBehavior { }
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly Id<ForInt32> TestStruct = Id<ForInt32>.Parse("123456789");
 
-    /// <summary>Tests the identifier SVO.</summary>
-    public class IdForInt32Test
+    /// <summary>Id<ForInt32>.Empty should be equal to the default of identifier.</summary>
+    [Test]
+    public void Empty_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly Id<ForInt32> TestStruct = Id<ForInt32>.Parse("123456789");
+        Assert.AreEqual(default(Id<ForInt32>), Id<ForInt32>.Empty);
+    }
 
-        /// <summary>Id<ForInt32>.Empty should be equal to the default of identifier.</summary>
-        [Test]
-        public void Empty_None_EqualsDefault()
-        {
-            Assert.AreEqual(default(Id<ForInt32>), Id<ForInt32>.Empty);
-        }
+    /// <summary>Id<ForInt32>.IsEmpty() should be true for the default of identifier.</summary>
+    [Test]
+    public void IsEmpty_Default_IsTrue()
+    {
+        Assert.IsTrue(default(Id<ForInt32>).IsEmpty());
+    }
 
-        /// <summary>Id<ForInt32>.IsEmpty() should be true for the default of identifier.</summary>
-        [Test]
-        public void IsEmpty_Default_IsTrue()
-        {
-            Assert.IsTrue(default(Id<ForInt32>).IsEmpty());
-        }
+    /// <summary>Id<ForInt32>.IsEmpty() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsEmpty_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmpty());
+    }
 
-        /// <summary>Id<ForInt32>.IsEmpty() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsEmpty_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmpty());
-        }
+    [Test]
+    public void FromBytes_Null_IsEmpty()
+    {
+        var fromBytes = Id<ForInt32>.FromBytes(null);
+        Assert.AreEqual(Id<ForInt32>.Empty, fromBytes);
+    }
 
-        [Test]
-        public void FromBytes_Null_IsEmpty()
-        {
-            var fromBytes = Id<ForInt32>.FromBytes(null);
-            Assert.AreEqual(Id<ForInt32>.Empty, fromBytes);
-        }
+    [Test]
+    public void FromBytes_Bytes_IsTestStruct()
+    {
+        var fromBytes = Id<ForInt32>.FromBytes(new byte[] { 21, 205, 91, 7 });
+        Assert.AreEqual(TestStruct, fromBytes);
+    }
 
-        [Test]
-        public void FromBytes_Bytes_IsTestStruct()
-        {
-            var fromBytes = Id<ForInt32>.FromBytes(new byte[] { 21, 205, 91, 7 });
-            Assert.AreEqual(TestStruct, fromBytes);
-        }
+    [Test]
+    public void ToByteArray_Empty_EmptyArray()
+    {
+        var bytes = Id<ForInt32>.Empty.ToByteArray();
+        Assert.AreEqual(Array.Empty<byte>(), bytes);
+    }
 
-        [Test]
-        public void ToByteArray_Empty_EmptyArray()
-        {
-            var bytes = Id<ForInt32>.Empty.ToByteArray();
-            Assert.AreEqual(Array.Empty<byte>(), bytes);
-        }
+    [Test]
+    public void ToByteArray_TestStruct_FilledArray()
+    {
+        var bytes = TestStruct.ToByteArray();
+        var exepected = new byte[] { 21, 205, 91, 7 };
+        Assert.AreEqual(exepected, bytes);
+    }
 
-        [Test]
-        public void ToByteArray_TestStruct_FilledArray()
-        {
-            var bytes = TestStruct.ToByteArray();
-            var exepected = new byte[] { 21, 205, 91, 7 };
-            Assert.AreEqual(exepected, bytes);
-        }
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
+    {
+        Assert.IsTrue(Id<ForInt32>.TryParse(null, out var val));
+        Assert.AreEqual(default(Id<ForInt32>), val);
+    }
 
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            Assert.IsTrue(Id<ForInt32>.TryParse(null, out var val));
-            Assert.AreEqual(default(Id<ForInt32>), val);
-        }
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
+    {
+        Assert.IsTrue(Id<ForInt32>.TryParse(string.Empty, out var val));
+        Assert.AreEqual(default(Id<ForInt32>), val);
+    }
 
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            Assert.IsTrue(Id<ForInt32>.TryParse(string.Empty, out var val));
-            Assert.AreEqual(default(Id<ForInt32>), val);
-        }
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "123456789";
+        Assert.IsTrue(Id<ForInt32>.TryParse(str, out var val));
+        Assert.AreEqual(str, val.ToString());
+    }
 
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            string str = "123456789";
-            Assert.IsTrue(Id<ForInt32>.TryParse(str, out var val));
-            Assert.AreEqual(str, val.ToString());
-        }
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "ABC";
+        Assert.IsFalse(Id<ForInt32>.TryParse(str, out var val));
+        Assert.AreEqual(default(Id<ForInt32>), val);
+    }
 
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
         {
-            string str = "ABC";
-            Assert.IsFalse(Id<ForInt32>.TryParse(str, out var val));
-            Assert.AreEqual(default(Id<ForInt32>), val);
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
+            Assert.Catch<FormatException>(() =>
             {
-                Assert.Catch<FormatException>(() =>
-                {
-                    Id<ForInt32>.Parse("InvalidInput");
-                }
-
-                , "Not a valid identifier");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = Id<ForInt32>.TryParse(exp.ToString());
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Id<ForInt32>);
-                var act = Id<ForInt32>.TryParse("InvalidInput");
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void TryCreate_Int_Successful()
-        {
-            Assert.IsTrue(Id<ForInt32>.TryCreate(13, out var id));
-            Assert.AreEqual(Id<ForInt32>.Parse("13"), id);
-        }
-
-        [Test]
-        public void GetObjectData_NulSerializationInfo_Throws()
-        {
-            ISerializable obj = TestStruct;
-            Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
-        }
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(Id<ForInt32>), new FormatterConverter());
-            obj.GetObjectData(info, default);
-            Assert.AreEqual(123456789L, info.GetValue("Value", typeof(long)));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "123456789";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<Id<ForInt32>>("123456789");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_IdForInt32SerializeObject_AreEqual()
-        {
-            var input = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
+                Id<ForInt32>.Parse("InvalidInput");
             }
 
-            ;
-            var exp = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_IdForInt32SerializeObject_AreEqual()
-        {
-            var input = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_IdForInt32SerializeObject_AreEqual()
-        {
-            var input = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Default_AreEqual()
-        {
-            var input = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_Default_AreEqual()
-        {
-            var input = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForInt32SerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<Id<ForInt32>>(json));
-        }
-
-        [TestCase("123456789", "123456789")]
-        [TestCase("12345678", 12345678L)]
-        [TestCase("", "")]
-        [TestCase("", 0L)]
-        public void FromJson(Id<ForInt32> expected, object json)
-        {
-            var actual = JsonTester.Read<Id<ForInt32>>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ToJson_TestStruct_LongValue()
-        {
-            var json = TestStruct.ToJson();
-            Assert.AreEqual(123456789L, json);
-        }
-
-        [Test]
-        public void ToString_Empty_StringEmpty()
-        {
-            var act = Id<ForInt32>.Empty.ToString(CultureInfo.InvariantCulture);
-            var exp = "";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("#,##0.0", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: '123,456,789.0', format: '#,##0.0'";
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>GetHash should not fail for Id<ForInt32>.Empty.</summary>
-        [Test]
-        public void GetHash_Empty_Hash()
-        {
-            Assert.AreEqual(0, Id<ForInt32>.Empty.GetHashCode());
-        }
-
-        /// <summary>GetHash should not fail for the test struct.</summary>
-        [Test]
-        public void GetHash_TestStruct_Hash()
-        {
-            Assert.AreNotEqual(0, TestStruct.GetHashCode());
-        }
-
-        [Test]
-        public void Equals_EmptyEmpty_IsTrue()
-        {
-            Assert.IsTrue(Id<ForInt32>.Empty.Equals(Id<ForInt32>.Empty));
-        }
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            var l = Id<ForInt32>.Parse("123456");
-            var r = Id<ForInt32>.Parse("+0000123456");
-            Assert.IsTrue(l.Equals(r));
-        }
-
-        [Test]
-        public void Equals_TestStructTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructEmpty_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(Id<ForInt32>.Empty));
-        }
-
-        [Test]
-        public void Equals_EmptyTestStruct_IsFalse()
-        {
-            Assert.IsFalse(Id<ForInt32>.Empty.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructObjectTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals((object)TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructNull_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(null));
-        }
-
-        [Test]
-        public void Equals_TestStructObject_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(new object()));
-        }
-
-        [Test]
-        public void OperatorIs_TestStructTestStruct_IsTrue()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsTrue(l == r);
-        }
-
-        [Test]
-        public void OperatorIsNot_TestStructTestStruct_IsFalse()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsFalse(l != r);
-        }
-
-        [Test]
-        public void Next_NotSupported()
-        {
-            Assert.Throws<NotSupportedException>(() => Id<ForInt32>.Next());
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase("ABC")]
-        [TestCase("-1")]
-        public void IsInvalid_String(string str)
-        {
-            Assert.IsFalse(Id<ForInt32>.IsValid(str));
-        }
-
-        [TestCase("0")]
-        [TestCase("1234")]
-        [TestCase("+123456")]
-        public void IsValid_String(string str)
-        {
-            Assert.IsTrue(Id<ForInt32>.IsValid(str));
+            , "Not a valid identifier");
         }
     }
 
-    [Serializable]
-    public class IdForInt32SerializeObject
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
     {
-        public int Id { get; set; }
-        public Id<ForInt32> Obj { get; set; }
-        public DateTime Date { get; set; }
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = Id<ForInt32>.TryParse(exp.ToString());
+            Assert.AreEqual(exp, act);
+        }
     }
+
+    [Test]
+    public void TryParse_InvalidInput_DefaultValue()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = default(Id<ForInt32>);
+            var act = Id<ForInt32>.TryParse("InvalidInput");
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void TryCreate_Int_Successful()
+    {
+        Assert.IsTrue(Id<ForInt32>.TryCreate(13, out var id));
+        Assert.AreEqual(Id<ForInt32>.Parse("13"), id);
+    }
+
+    [Test]
+    public void GetObjectData_NulSerializationInfo_Throws()
+    {
+        ISerializable obj = TestStruct;
+        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
+    }
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(Id<ForInt32>), new FormatterConverter());
+        obj.GetObjectData(info, default);
+        Assert.AreEqual(123456789L, info.GetValue("Value", typeof(long)));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "123456789";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<Id<ForInt32>>("123456789");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_IdForInt32SerializeObject_AreEqual()
+    {
+        var input = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_IdForInt32SerializeObject_AreEqual()
+    {
+        var input = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_IdForInt32SerializeObject_AreEqual()
+    {
+        var input = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Default_AreEqual()
+    {
+        var input = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_Default_AreEqual()
+    {
+        var input = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt32SerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    [TestCase("2017-06-11")]
+    public void FromJson_Invalid_Throws(object json)
+    {
+        Assert.Catch<FormatException>(() => JsonTester.Read<Id<ForInt32>>(json));
+    }
+
+    [TestCase("123456789", "123456789")]
+    [TestCase("12345678", 12345678L)]
+    [TestCase("", "")]
+    [TestCase("", 0L)]
+    public void FromJson(Id<ForInt32> expected, object json)
+    {
+        var actual = JsonTester.Read<Id<ForInt32>>(json);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void ToJson_TestStruct_LongValue()
+    {
+        var json = TestStruct.ToJson();
+        Assert.AreEqual(123456789L, json);
+    }
+
+    [Test]
+    public void ToString_Empty_StringEmpty()
+    {
+        var act = Id<ForInt32>.Empty.ToString(CultureInfo.InvariantCulture);
+        var exp = "";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("#,##0.0", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: '123,456,789.0', format: '#,##0.0'";
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>GetHash should not fail for Id<ForInt32>.Empty.</summary>
+    [Test]
+    public void GetHash_Empty_Hash()
+    {
+        Assert.AreEqual(0, Id<ForInt32>.Empty.GetHashCode());
+    }
+
+    /// <summary>GetHash should not fail for the test struct.</summary>
+    [Test]
+    public void GetHash_TestStruct_Hash()
+    {
+        Assert.AreNotEqual(0, TestStruct.GetHashCode());
+    }
+
+    [Test]
+    public void Equals_EmptyEmpty_IsTrue()
+    {
+        Assert.IsTrue(Id<ForInt32>.Empty.Equals(Id<ForInt32>.Empty));
+    }
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        var l = Id<ForInt32>.Parse("123456");
+        var r = Id<ForInt32>.Parse("+0000123456");
+        Assert.IsTrue(l.Equals(r));
+    }
+
+    [Test]
+    public void Equals_TestStructTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructEmpty_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(Id<ForInt32>.Empty));
+    }
+
+    [Test]
+    public void Equals_EmptyTestStruct_IsFalse()
+    {
+        Assert.IsFalse(Id<ForInt32>.Empty.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructObjectTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals((object)TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructNull_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(null));
+    }
+
+    [Test]
+    public void Equals_TestStructObject_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(new object()));
+    }
+
+    [Test]
+    public void OperatorIs_TestStructTestStruct_IsTrue()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsTrue(l == r);
+    }
+
+    [Test]
+    public void OperatorIsNot_TestStructTestStruct_IsFalse()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsFalse(l != r);
+    }
+
+    [Test]
+    public void Next_NotSupported()
+    {
+        Assert.Throws<NotSupportedException>(() => Id<ForInt32>.Next());
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("ABC")]
+    [TestCase("-1")]
+    public void IsInvalid_String(string str)
+    {
+        Assert.IsFalse(Id<ForInt32>.IsValid(str));
+    }
+
+    [TestCase("0")]
+    [TestCase("1234")]
+    [TestCase("+123456")]
+    public void IsValid_String(string str)
+    {
+        Assert.IsTrue(Id<ForInt32>.IsValid(str));
+    }
+}
+
+[Serializable]
+public class IdForInt32SerializeObject
+{
+    public int Id { get; set; }
+    public Id<ForInt32> Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
@@ -1,468 +1,455 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Globalization;
-using Qowaiv.Identifiers;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests.Identifiers;
 
-namespace Qowaiv.UnitTests.Identifiers
+[EmptyTestClass]
+public sealed class ForInt64 : Int64IdBehavior { }
+
+/// <summary>Tests the identifier SVO.</summary>
+public class IdForInt64Test
 {
-    public sealed class ForInt64 : Int64IdBehavior { }
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly Id<ForInt64> TestStruct = Id<ForInt64>.Parse("123456789");
 
-    /// <summary>Tests the identifier SVO.</summary>
-    public class IdForInt64Test
+    /// <summary>Id<ForInt64>.Empty should be equal to the default of identifier.</summary>
+    [Test]
+    public void Empty_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly Id<ForInt64> TestStruct = Id<ForInt64>.Parse("123456789");
+        Assert.AreEqual(default(Id<ForInt64>), Id<ForInt64>.Empty);
+    }
 
-        /// <summary>Id<ForInt64>.Empty should be equal to the default of identifier.</summary>
-        [Test]
-        public void Empty_None_EqualsDefault()
-        {
-            Assert.AreEqual(default(Id<ForInt64>), Id<ForInt64>.Empty);
-        }
+    /// <summary>Id<ForInt64>.IsEmpty() should be true for the default of identifier.</summary>
+    [Test]
+    public void IsEmpty_Default_IsTrue()
+    {
+        Assert.IsTrue(default(Id<ForInt64>).IsEmpty());
+    }
 
-        /// <summary>Id<ForInt64>.IsEmpty() should be true for the default of identifier.</summary>
-        [Test]
-        public void IsEmpty_Default_IsTrue()
-        {
-            Assert.IsTrue(default(Id<ForInt64>).IsEmpty());
-        }
+    /// <summary>Id<ForInt64>.IsEmpty() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsEmpty_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmpty());
+    }
 
-        /// <summary>Id<ForInt64>.IsEmpty() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsEmpty_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmpty());
-        }
+    [Test]
+    public void FromBytes_Null_IsEmpty()
+    {
+        var fromBytes = Id<ForInt64>.FromBytes(null);
+        Assert.AreEqual(Id<ForInt64>.Empty, fromBytes);
+    }
 
-        [Test]
-        public void FromBytes_Null_IsEmpty()
-        {
-            var fromBytes = Id<ForInt64>.FromBytes(null);
-            Assert.AreEqual(Id<ForInt64>.Empty, fromBytes);
-        }
+    [Test]
+    public void FromBytes_Bytes_IsTestStruct()
+    {
+        var fromBytes = Id<ForInt64>.FromBytes(new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 });
+        Assert.AreEqual(TestStruct, fromBytes);
+    }
 
-        [Test]
-        public void FromBytes_Bytes_IsTestStruct()
-        {
-            var fromBytes = Id<ForInt64>.FromBytes(new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 });
-            Assert.AreEqual(TestStruct, fromBytes);
-        }
+    [Test]
+    public void ToByteArray_Empty_EmptyArray()
+    {
+        var bytes = Id<ForInt64>.Empty.ToByteArray();
+        Assert.AreEqual(Array.Empty<byte>(), bytes);
+    }
 
-        [Test]
-        public void ToByteArray_Empty_EmptyArray()
-        {
-            var bytes = Id<ForInt64>.Empty.ToByteArray();
-            Assert.AreEqual(Array.Empty<byte>(), bytes);
-        }
+    [Test]
+    public void ToByteArray_TestStruct_FilledArray()
+    {
+        var bytes = TestStruct.ToByteArray();
+        var exepected = new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
+        Assert.AreEqual(exepected, bytes);
+    }
 
-        [Test]
-        public void ToByteArray_TestStruct_FilledArray()
-        {
-            var bytes = TestStruct.ToByteArray();
-            var exepected = new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
-            Assert.AreEqual(exepected, bytes);
-        }
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
+    {
+        Assert.IsTrue(Id<ForInt64>.TryParse(null, out var val));
+        Assert.AreEqual(default(Id<ForInt64>), val);
+    }
 
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            Assert.IsTrue(Id<ForInt64>.TryParse(null, out var val));
-            Assert.AreEqual(default(Id<ForInt64>), val);
-        }
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
+    {
+        Assert.IsTrue(Id<ForInt64>.TryParse(string.Empty, out var val));
+        Assert.AreEqual(default(Id<ForInt64>), val);
+    }
 
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            Assert.IsTrue(Id<ForInt64>.TryParse(string.Empty, out var val));
-            Assert.AreEqual(default(Id<ForInt64>), val);
-        }
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "123456789";
+        Assert.IsTrue(Id<ForInt64>.TryParse(str, out var val));
+        Assert.AreEqual(str, val.ToString());
+    }
 
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
-        {
-            string str = "123456789";
-            Assert.IsTrue(Id<ForInt64>.TryParse(str, out var val));
-            Assert.AreEqual(str, val.ToString());
-        }
+    /// <summary>TryParse with specified string value should be invalid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsNotValid()
+    {
+        string str = "ABC";
+        Assert.IsFalse(Id<ForInt64>.TryParse(str, out var val));
+        Assert.AreEqual(default(Id<ForInt64>), val);
+    }
 
-        /// <summary>TryParse with specified string value should be invalid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsNotValid()
-        {
-            string str = "ABC";
-            Assert.IsFalse(Id<ForInt64>.TryParse(str, out var val));
-            Assert.AreEqual(default(Id<ForInt64>), val);
-        }
+    [Test]
+    public void TryCreate_Int_Successful()
+    {
+        Assert.IsTrue(Id<ForInt64>.TryCreate(13L, out var id));
+        Assert.AreEqual(Id<ForInt64>.Parse("13"), id);
+    }
 
-        [Test]
-        public void TryCreate_Int_Successful()
+    [Test]
+    public void Parse_InvalidInput_ThrowsFormatException()
+    {
+        using (TestCultures.En_GB.Scoped())
         {
-            Assert.IsTrue(Id<ForInt64>.TryCreate(13L, out var id));
-            Assert.AreEqual(Id<ForInt64>.Parse("13"), id);
-        }
-
-        [Test]
-        public void Parse_InvalidInput_ThrowsFormatException()
-        {
-            using (TestCultures.En_GB.Scoped())
+            Assert.Catch<FormatException>(() =>
             {
-                Assert.Catch<FormatException>(() =>
-                {
-                    Id<ForInt64>.Parse("InvalidInput");
-                }
-
-                , "Not a valid identifier");
-            }
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = Id<ForInt64>.TryParse(exp.ToString());
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void TryParse_InvalidInput_DefaultValue()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = default(Id<ForInt64>);
-                var act = Id<ForInt64>.TryParse("InvalidInput");
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void GetObjectData_NulSerializationInfo_Throws()
-        {
-            ISerializable obj = TestStruct;
-            Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
-        }
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(Id<ForInt64>), new FormatterConverter());
-            obj.GetObjectData(info, default);
-            Assert.AreEqual(123456789L, info.GetValue("Value", typeof(long)));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "123456789";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<Id<ForInt64>>("123456789");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_IdForInt64SerializeObject_AreEqual()
-        {
-            var input = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
+                Id<ForInt64>.Parse("InvalidInput");
             }
 
-            ;
-            var exp = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_IdForInt64SerializeObject_AreEqual()
-        {
-            var input = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_IdForInt64SerializeObject_AreEqual()
-        {
-            var input = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Default_AreEqual()
-        {
-            var input = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_Default_AreEqual()
-        {
-            var input = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForInt64SerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        [TestCase("2017-06-11")]
-        public void FromJson_Invalid_Throws(object json)
-        {
-            Assert.Catch<FormatException>(() => JsonTester.Read<Id<ForInt64>>(json));
-        }
-
-        [Test]
-        public void ToString_Empty_StringEmpty()
-        {
-            var act = Id<ForInt64>.Empty.ToString(CultureInfo.InvariantCulture);
-            var exp = "";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("#,##0.0", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: '123,456,789.0', format: '#,##0.0'";
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>GetHash should not fail for Id<ForInt64>.Empty.</summary>
-        [Test]
-        public void GetHash_Empty_Hash()
-        {
-            Assert.AreEqual(0, Id<ForInt64>.Empty.GetHashCode());
-        }
-
-        /// <summary>GetHash should not fail for the test struct.</summary>
-        [Test]
-        public void GetHash_TestStruct_Hash()
-        {
-            Assert.AreNotEqual(0, TestStruct.GetHashCode());
-        }
-
-        [Test]
-        public void Equals_EmptyEmpty_IsTrue()
-        {
-            Assert.IsTrue(Id<ForInt64>.Empty.Equals(Id<ForInt64>.Empty));
-        }
-
-        [Test]
-        public void Equals_FormattedAndUnformatted_IsTrue()
-        {
-            var l = Id<ForInt64>.Parse("123456");
-            var r = Id<ForInt64>.Parse("+0000123456");
-            Assert.IsTrue(l.Equals(r));
-        }
-
-        [Test]
-        public void Equals_TestStructTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructEmpty_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(Id<ForInt64>.Empty));
-        }
-
-        [Test]
-        public void Equals_EmptyTestStruct_IsFalse()
-        {
-            Assert.IsFalse(Id<ForInt64>.Empty.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructObjectTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals((object)TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructNull_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(null));
-        }
-
-        [Test]
-        public void Equals_TestStructObject_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(new object()));
-        }
-
-        [Test]
-        public void OperatorIs_TestStructTestStruct_IsTrue()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsTrue(l == r);
-        }
-
-        [Test]
-        public void OperatorIsNot_TestStructTestStruct_IsFalse()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsFalse(l != r);
-        }
-
-        [Test]
-        public void Next_NotSupported()
-        {
-            Assert.Throws<NotSupportedException>(() => Id<ForInt64>.Next());
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase("ABC")]
-        [TestCase("-1")]
-        public void IsInvalid_String(string str)
-        {
-            Assert.IsFalse(Id<ForInt64>.IsValid(str));
-        }
-
-        [TestCase("0")]
-        [TestCase("1234")]
-        [TestCase("+123456")]
-        public void IsValid_String(string str)
-        {
-            Assert.IsTrue(Id<ForInt64>.IsValid(str));
+            , "Not a valid identifier");
         }
     }
 
-    [Serializable]
-    public class IdForInt64SerializeObject
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
     {
-        public int Id { get; set; }
-        public Id<ForInt64> Obj { get; set; }
-        public DateTime Date { get; set; }
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = TestStruct;
+            var act = Id<ForInt64>.TryParse(exp.ToString());
+            Assert.AreEqual(exp, act);
+        }
     }
+
+    [Test]
+    public void TryParse_InvalidInput_DefaultValue()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            var exp = default(Id<ForInt64>);
+            var act = Id<ForInt64>.TryParse("InvalidInput");
+            Assert.AreEqual(exp, act);
+        }
+    }
+
+    [Test]
+    public void GetObjectData_NulSerializationInfo_Throws()
+    {
+        ISerializable obj = TestStruct;
+        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
+    }
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(Id<ForInt64>), new FormatterConverter());
+        obj.GetObjectData(info, default);
+        Assert.AreEqual(123456789L, info.GetValue("Value", typeof(long)));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "123456789";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<Id<ForInt64>>("123456789");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_IdForInt64SerializeObject_AreEqual()
+    {
+        var input = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_IdForInt64SerializeObject_AreEqual()
+    {
+        var input = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_IdForInt64SerializeObject_AreEqual()
+    {
+        var input = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Default_AreEqual()
+    {
+        var input = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_Default_AreEqual()
+    {
+        var input = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForInt64SerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    [TestCase("2017-06-11")]
+    public void FromJson_Invalid_Throws(object json)
+    {
+        Assert.Catch<FormatException>(() => JsonTester.Read<Id<ForInt64>>(json));
+    }
+
+    [Test]
+    public void ToString_Empty_StringEmpty()
+    {
+        var act = Id<ForInt64>.Empty.ToString(CultureInfo.InvariantCulture);
+        var exp = "";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("#,##0.0", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: '123,456,789.0', format: '#,##0.0'";
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>GetHash should not fail for Id<ForInt64>.Empty.</summary>
+    [Test]
+    public void GetHash_Empty_Hash()
+    {
+        Assert.AreEqual(0, Id<ForInt64>.Empty.GetHashCode());
+    }
+
+    /// <summary>GetHash should not fail for the test struct.</summary>
+    [Test]
+    public void GetHash_TestStruct_Hash()
+    {
+        Assert.AreNotEqual(0, TestStruct.GetHashCode());
+    }
+
+    [Test]
+    public void Equals_EmptyEmpty_IsTrue()
+    {
+        Assert.IsTrue(Id<ForInt64>.Empty.Equals(Id<ForInt64>.Empty));
+    }
+
+    [Test]
+    public void Equals_FormattedAndUnformatted_IsTrue()
+    {
+        var l = Id<ForInt64>.Parse("123456");
+        var r = Id<ForInt64>.Parse("+0000123456");
+        Assert.IsTrue(l.Equals(r));
+    }
+
+    [Test]
+    public void Equals_TestStructTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructEmpty_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(Id<ForInt64>.Empty));
+    }
+
+    [Test]
+    public void Equals_EmptyTestStruct_IsFalse()
+    {
+        Assert.IsFalse(Id<ForInt64>.Empty.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructObjectTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals((object)TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructNull_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(null));
+    }
+
+    [Test]
+    public void Equals_TestStructObject_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(new object()));
+    }
+
+    [Test]
+    public void OperatorIs_TestStructTestStruct_IsTrue()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsTrue(l == r);
+    }
+
+    [Test]
+    public void OperatorIsNot_TestStructTestStruct_IsFalse()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsFalse(l != r);
+    }
+
+    [Test]
+    public void Next_NotSupported()
+    {
+        Assert.Throws<NotSupportedException>(() => Id<ForInt64>.Next());
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("ABC")]
+    [TestCase("-1")]
+    public void IsInvalid_String(string str)
+    {
+        Assert.IsFalse(Id<ForInt64>.IsValid(str));
+    }
+
+    [TestCase("0")]
+    [TestCase("1234")]
+    [TestCase("+123456")]
+    public void IsValid_String(string str)
+    {
+        Assert.IsTrue(Id<ForInt64>.IsValid(str));
+    }
+}
+
+[Serializable]
+public class IdForInt64SerializeObject
+{
+    public int Id { get; set; }
+    public Id<ForInt64> Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
@@ -1,418 +1,406 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
-using Qowaiv.Identifiers;
-using Qowaiv.TestTools;
-using Qowaiv.TestTools.Globalization;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+﻿namespace Qowaiv.UnitTests.Identifiers;
 
-namespace Qowaiv.UnitTests.Identifiers
+[EmptyTestClass]
+public class ForString : StringIdBehavior { }
+
+/// <summary>Tests the identifier SVO.</summary>
+public class IdForStringTest
 {
-    public class ForString : StringIdBehavior { }
+    /// <summary>The test instance for most tests.</summary>
+    public static readonly Id<ForString> TestStruct = Id<ForString>.Parse("Qowaiv-ID");
 
-    /// <summary>Tests the identifier SVO.</summary>
-    public class IdForStringTest
+    /// <summary>Id<ForString>.Empty should be equal to the default of identifier.</summary>
+    [Test]
+    public void Empty_None_EqualsDefault()
     {
-        /// <summary>The test instance for most tests.</summary>
-        public static readonly Id<ForString> TestStruct = Id<ForString>.Parse("Qowaiv-ID");
+        Assert.AreEqual(default(Id<ForString>), Id<ForString>.Empty);
+    }
 
-        /// <summary>Id<ForString>.Empty should be equal to the default of identifier.</summary>
-        [Test]
-        public void Empty_None_EqualsDefault()
-        {
-            Assert.AreEqual(default(Id<ForString>), Id<ForString>.Empty);
-        }
+    /// <summary>Id<ForString>.IsEmpty() should be true for the default of identifier.</summary>
+    [Test]
+    public void IsEmpty_Default_IsTrue()
+    {
+        Assert.IsTrue(default(Id<ForString>).IsEmpty());
+    }
 
-        /// <summary>Id<ForString>.IsEmpty() should be true for the default of identifier.</summary>
-        [Test]
-        public void IsEmpty_Default_IsTrue()
-        {
-            Assert.IsTrue(default(Id<ForString>).IsEmpty());
-        }
+    /// <summary>Id<ForString>.IsEmpty() should be false for the TestStruct.</summary>
+    [Test]
+    public void IsEmpty_TestStruct_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.IsEmpty());
+    }
 
-        /// <summary>Id<ForString>.IsEmpty() should be false for the TestStruct.</summary>
-        [Test]
-        public void IsEmpty_TestStruct_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.IsEmpty());
-        }
+    [Test]
+    public void FromBytes_Null_IsEmpty()
+    {
+        var fromBytes = Id<ForString>.FromBytes(null);
+        Assert.AreEqual(Id<ForString>.Empty, fromBytes);
+    }
 
-        [Test]
-        public void FromBytes_Null_IsEmpty()
-        {
-            var fromBytes = Id<ForString>.FromBytes(null);
-            Assert.AreEqual(Id<ForString>.Empty, fromBytes);
-        }
+    [Test]
+    public void FromBytes_Bytes_IsTestStruct()
+    {
+        var fromBytes = Id<ForString>.FromBytes(new byte[] { 81, 111, 119, 97, 105, 118, 45, 73, 68 });
+        Assert.AreEqual(TestStruct, fromBytes);
+    }
 
-        [Test]
-        public void FromBytes_Bytes_IsTestStruct()
-        {
-            var fromBytes = Id<ForString>.FromBytes(new byte[] { 81, 111, 119, 97, 105, 118, 45, 73, 68 });
-            Assert.AreEqual(TestStruct, fromBytes);
-        }
+    [Test]
+    public void ToByteArray_Empty_EmptyArray()
+    {
+        var bytes = Id<ForString>.Empty.ToByteArray();
+        Assert.AreEqual(Array.Empty<byte>(), bytes);
+    }
 
-        [Test]
-        public void ToByteArray_Empty_EmptyArray()
-        {
-            var bytes = Id<ForString>.Empty.ToByteArray();
-            Assert.AreEqual(Array.Empty<byte>(), bytes);
-        }
+    [Test]
+    public void ToByteArray_TestStruct_FilledArray()
+    {
+        var bytes = TestStruct.ToByteArray();
+        var exepected = new byte[] { 81, 111, 119, 97, 105, 118, 45, 73, 68 };
+        Assert.AreEqual(exepected, bytes);
+    }
 
-        [Test]
-        public void ToByteArray_TestStruct_FilledArray()
-        {
-            var bytes = TestStruct.ToByteArray();
-            var exepected = new byte[] { 81, 111, 119, 97, 105, 118, 45, 73, 68 };
-            Assert.AreEqual(exepected, bytes);
-        }
+    /// <summary>TryParse null should be valid.</summary>
+    [Test]
+    public void TryParse_Null_IsValid()
+    {
+        Assert.IsTrue(Id<ForString>.TryParse(null, out var val));
+        Assert.AreEqual(default(Id<ForString>), val);
+    }
 
-        /// <summary>TryParse null should be valid.</summary>
-        [Test]
-        public void TryParse_Null_IsValid()
-        {
-            Assert.IsTrue(Id<ForString>.TryParse(null, out var val));
-            Assert.AreEqual(default(Id<ForString>), val);
-        }
+    /// <summary>TryParse string.Empty should be valid.</summary>
+    [Test]
+    public void TryParse_StringEmpty_IsValid()
+    {
+        Assert.IsTrue(Id<ForString>.TryParse(string.Empty, out var val));
+        Assert.AreEqual(default(Id<ForString>), val);
+    }
 
-        /// <summary>TryParse string.Empty should be valid.</summary>
-        [Test]
-        public void TryParse_StringEmpty_IsValid()
-        {
-            Assert.IsTrue(Id<ForString>.TryParse(string.Empty, out var val));
-            Assert.AreEqual(default(Id<ForString>), val);
-        }
+    /// <summary>TryParse with specified string value should be valid.</summary>
+    [Test]
+    public void TryParse_StringValue_IsValid()
+    {
+        string str = "0f5ab5ab-12cb-4629-878d-b18b88b9a504";
+        Assert.IsTrue(Id<ForString>.TryParse(str, out var val));
+        Assert.AreEqual(str, val.ToString());
+    }
 
-        /// <summary>TryParse with specified string value should be valid.</summary>
-        [Test]
-        public void TryParse_StringValue_IsValid()
+    [Test]
+    public void TryParse_TestStructInput_AreEqual()
+    {
+        using (TestCultures.En_GB.Scoped())
         {
-            string str = "0f5ab5ab-12cb-4629-878d-b18b88b9a504";
-            Assert.IsTrue(Id<ForString>.TryParse(str, out var val));
-            Assert.AreEqual(str, val.ToString());
-        }
-
-        [Test]
-        public void TryParse_TestStructInput_AreEqual()
-        {
-            using (TestCultures.En_GB.Scoped())
-            {
-                var exp = TestStruct;
-                var act = Id<ForString>.TryParse(exp.ToString());
-                Assert.AreEqual(exp, act);
-            }
-        }
-
-        [Test]
-        public void GetObjectData_NulSerializationInfo_Throws()
-        {
-            ISerializable obj = TestStruct;
-            Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
-        }
-
-        [Test]
-        public void GetObjectData_SerializationInfo_AreEqual()
-        {
-            ISerializable obj = TestStruct;
-            var info = new SerializationInfo(typeof(Id<ForString>), new FormatterConverter());
-            obj.GetObjectData(info, default);
-            Assert.AreEqual("Qowaiv-ID", info.GetValue("Value", typeof(string)));
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
             var exp = TestStruct;
-            var act = SerializeDeserialize.Binary(input);
+            var act = Id<ForString>.TryParse(exp.ToString());
             Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_TestStruct_AreEqual()
-        {
-            var input = TestStruct;
-            var exp = TestStruct;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlSerialize_TestStruct_AreEqual()
-        {
-            var act = Serialize.Xml(TestStruct);
-            var exp = "Qowaiv-ID";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void XmlDeserialize_XmlString_AreEqual()
-        {
-            var act =Deserialize.Xml<Id<ForString>>("Qowaiv-ID");
-            Assert.AreEqual(TestStruct, act);
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_IdForStringSerializeObject_AreEqual()
-        {
-            var input = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_IdForStringSerializeObject_AreEqual()
-        {
-            var input = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void DataContractSerializeDeserialize_IdForStringSerializeObject_AreEqual()
-        {
-            var input = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = TestStruct,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        [Obsolete("Usage of the binary formatter is considered harmful.")]
-        public void SerializeDeserialize_Default_AreEqual()
-        {
-            var input = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void XmlSerializeDeserialize_Default_AreEqual()
-        {
-            var input = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var exp = new IdForStringSerializeObject
-            {
-                Id = 17,
-                Obj = default,
-                Date = new DateTime(1970, 02, 14),
-            }
-
-            ;
-            var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
-        }
-
-        [Test]
-        public void GetSchema_None_IsNull()
-        {
-            IXmlSerializable obj = TestStruct;
-            Assert.IsNull(obj.GetSchema());
-        }
-
-        [TestCase("0F5AB5AB-12CB-4629-878D-B18B88B9A504", "0F5AB5AB-12CB-4629-878D-B18B88B9A504")]
-        [TestCase("", "")]
-        [TestCase("123456789", 123456789L)]
-        public void FromJson(Id<ForString> expected, object json)
-        {
-            var actual = JsonTester.Read<Id<ForString>>(json);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ToString_Empty_StringEmpty()
-        {
-            var act = Id<ForString>.Empty.ToString();
-            var exp = "";
-            Assert.AreEqual(exp, act);
-        }
-
-        [Test]
-        public void ToString_CustomFormatter_SupportsCustomFormatting()
-        {
-            var act = TestStruct.ToString("S", FormatProvider.CustomFormatter);
-            var exp = "Unit Test Formatter, value: 'Qowaiv-ID', format: 'S'";
-            Assert.AreEqual(exp, act);
-        }
-
-        /// <summary>GetHash should not fail for Id<ForString>.Empty.</summary>
-        [Test]
-        public void GetHash_Empty_Hash()
-        {
-            Assert.AreEqual(0, Id<ForString>.Empty.GetHashCode());
-        }
-
-        /// <summary>GetHash should not fail for the test struct.</summary>
-        [Test]
-        public void GetHash_TestStruct_Hash()
-        {
-            Assert.AreNotEqual(0, TestStruct.GetHashCode());
-        }
-
-        [Test]
-        public void Equals_EmptyEmpty_IsTrue()
-        {
-            Assert.IsTrue(Id<ForString>.Empty.Equals(Id<ForString>.Empty));
-        }
-
-        [Test]
-        public void Equals_TestStructTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructEmpty_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(Id<ForString>.Empty));
-        }
-
-        [Test]
-        public void Equals_EmptyTestStruct_IsFalse()
-        {
-            Assert.IsFalse(Id<ForString>.Empty.Equals(TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructObjectTestStruct_IsTrue()
-        {
-            Assert.IsTrue(TestStruct.Equals((object)TestStruct));
-        }
-
-        [Test]
-        public void Equals_TestStructNull_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(null));
-        }
-
-        [Test]
-        public void Equals_TestStructObject_IsFalse()
-        {
-            Assert.IsFalse(TestStruct.Equals(new object()));
-        }
-
-        [Test]
-        public void OperatorIs_TestStructTestStruct_IsTrue()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsTrue(l == r);
-        }
-
-        [Test]
-        public void OperatorIsNot_TestStructTestStruct_IsFalse()
-        {
-            var l = TestStruct;
-            var r = TestStruct;
-            Assert.IsFalse(l != r);
-        }
-
-        [Test]
-        public void Next_NotSupported()
-        {
-            Assert.Throws<NotSupportedException>(()=> Id<ForString>.Next());
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        public void IsInvalid_String(string str)
-        {
-            Assert.IsFalse(Id<ForString>.IsValid(str));
-        }
-
-        [TestCase("0F5AB5AB-12CB-4629-878D-B18B88B9A504")]
-        [TestCase("Qowaiv_SVOLibrary_GUIA")]
-        public void IsValid_String(string str)
-        {
-            Assert.IsTrue(Id<ForString>.IsValid(str));
         }
     }
 
-    [Serializable]
-    public class IdForStringSerializeObject
+    [Test]
+    public void GetObjectData_NulSerializationInfo_Throws()
     {
-        public int Id { get; set; }
-        public Id<ForString> Obj { get; set; }
-        public DateTime Date { get; set; }
+        ISerializable obj = TestStruct;
+        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
     }
+
+    [Test]
+    public void GetObjectData_SerializationInfo_AreEqual()
+    {
+        ISerializable obj = TestStruct;
+        var info = new SerializationInfo(typeof(Id<ForString>), new FormatterConverter());
+        obj.GetObjectData(info, default);
+        Assert.AreEqual("Qowaiv-ID", info.GetValue("Value", typeof(string)));
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_TestStruct_AreEqual()
+    {
+        var input = TestStruct;
+        var exp = TestStruct;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlSerialize_TestStruct_AreEqual()
+    {
+        var act = Serialize.Xml(TestStruct);
+        var exp = "Qowaiv-ID";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void XmlDeserialize_XmlString_AreEqual()
+    {
+        var act =Deserialize.Xml<Id<ForString>>("Qowaiv-ID");
+        Assert.AreEqual(TestStruct, act);
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_IdForStringSerializeObject_AreEqual()
+    {
+        var input = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_IdForStringSerializeObject_AreEqual()
+    {
+        var input = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void DataContractSerializeDeserialize_IdForStringSerializeObject_AreEqual()
+    {
+        var input = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = TestStruct,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.DataContract(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void SerializeDeserialize_Default_AreEqual()
+    {
+        var input = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Binary(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void XmlSerializeDeserialize_Default_AreEqual()
+    {
+        var input = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var exp = new IdForStringSerializeObject
+        {
+            Id = 17,
+            Obj = default,
+            Date = new DateTime(1970, 02, 14),
+        }
+
+        ;
+        var act = SerializeDeserialize.Xml(input);
+        Assert.AreEqual(exp.Id, act.Id, "Id");
+        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
+        Assert.AreEqual(exp.Date, act.Date, "Date");
+    }
+
+    [Test]
+    public void GetSchema_None_IsNull()
+    {
+        IXmlSerializable obj = TestStruct;
+        Assert.IsNull(obj.GetSchema());
+    }
+
+    [TestCase("0F5AB5AB-12CB-4629-878D-B18B88B9A504", "0F5AB5AB-12CB-4629-878D-B18B88B9A504")]
+    [TestCase("", "")]
+    [TestCase("123456789", 123456789L)]
+    public void FromJson(Id<ForString> expected, object json)
+    {
+        var actual = JsonTester.Read<Id<ForString>>(json);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void ToString_Empty_StringEmpty()
+    {
+        var act = Id<ForString>.Empty.ToString();
+        var exp = "";
+        Assert.AreEqual(exp, act);
+    }
+
+    [Test]
+    public void ToString_CustomFormatter_SupportsCustomFormatting()
+    {
+        var act = TestStruct.ToString("S", FormatProvider.CustomFormatter);
+        var exp = "Unit Test Formatter, value: 'Qowaiv-ID', format: 'S'";
+        Assert.AreEqual(exp, act);
+    }
+
+    /// <summary>GetHash should not fail for Id<ForString>.Empty.</summary>
+    [Test]
+    public void GetHash_Empty_Hash()
+    {
+        Assert.AreEqual(0, Id<ForString>.Empty.GetHashCode());
+    }
+
+    /// <summary>GetHash should not fail for the test struct.</summary>
+    [Test]
+    public void GetHash_TestStruct_Hash()
+    {
+        Assert.AreNotEqual(0, TestStruct.GetHashCode());
+    }
+
+    [Test]
+    public void Equals_EmptyEmpty_IsTrue()
+    {
+        Assert.IsTrue(Id<ForString>.Empty.Equals(Id<ForString>.Empty));
+    }
+
+    [Test]
+    public void Equals_TestStructTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructEmpty_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(Id<ForString>.Empty));
+    }
+
+    [Test]
+    public void Equals_EmptyTestStruct_IsFalse()
+    {
+        Assert.IsFalse(Id<ForString>.Empty.Equals(TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructObjectTestStruct_IsTrue()
+    {
+        Assert.IsTrue(TestStruct.Equals((object)TestStruct));
+    }
+
+    [Test]
+    public void Equals_TestStructNull_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(null));
+    }
+
+    [Test]
+    public void Equals_TestStructObject_IsFalse()
+    {
+        Assert.IsFalse(TestStruct.Equals(new object()));
+    }
+
+    [Test]
+    public void OperatorIs_TestStructTestStruct_IsTrue()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsTrue(l == r);
+    }
+
+    [Test]
+    public void OperatorIsNot_TestStructTestStruct_IsFalse()
+    {
+        var l = TestStruct;
+        var r = TestStruct;
+        Assert.IsFalse(l != r);
+    }
+
+    [Test]
+    public void Next_NotSupported()
+    {
+        Assert.Throws<NotSupportedException>(()=> Id<ForString>.Next());
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void IsInvalid_String(string str)
+    {
+        Assert.IsFalse(Id<ForString>.IsValid(str));
+    }
+
+    [TestCase("0F5AB5AB-12CB-4629-878D-B18B88B9A504")]
+    [TestCase("Qowaiv_SVOLibrary_GUIA")]
+    public void IsValid_String(string str)
+    {
+        Assert.IsTrue(Id<ForString>.IsValid(str));
+    }
+}
+
+[Serializable]
+public class IdForStringSerializeObject
+{
+    public int Id { get; set; }
+    public Id<ForString> Obj { get; set; }
+    public DateTime Date { get; set; }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Threading/ThreadDomainTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Threading/ThreadDomainTest.cs
@@ -75,7 +75,6 @@ public class ThreadDomainTest
         var exp0 = (Percentage)0.031418m;
 
         Assert.AreEqual(exp0, act0, "Old");
-
     }
 
     [Test]
@@ -91,4 +90,6 @@ public class ThreadDomainTest
         }
     }
 }
+
+[EmptyTestClass]
 public class NoConverterClass { }

--- a/src/Qowaiv.TestTools/EmptyTestClassAttribute.cs
+++ b/src/Qowaiv.TestTools/EmptyTestClassAttribute.cs
@@ -1,0 +1,16 @@
+﻿namespace Qowaiv.TestTools;
+
+/// <summary>
+/// Indicates that this class exists for test purposes only, in most cases to
+/// create a specific type, without the need of properties of methods.
+/// </summary>
+/// <remarks>
+/// Using this attribute prevents S2094 (Classes should not be empty) from
+/// showing up.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class EmptyTestClassAttribute : Attribute
+{
+    /// <summary>(Optional) justification for having this empty test class.</summary>
+    public string? Justification { get; set; }
+}

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -5,8 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.4.0</Version>
+    <Version>6.4.1</Version>
     <PackageReleaseNotes>
+v6.4.1
+- Introduction of the EmptyTestClass attribute.
 v6.4.0
 - Support .NET 7.0. #261
 v6.3.0

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -5,9 +5,9 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.4.1</Version>
+    <Version>6.4.0</Version>
     <PackageReleaseNotes>
-v6.4.1
+Next release
 - Introduction of the EmptyTestClass attribute.
 v6.4.0
 - Support .NET 7.0. #261


### PR DESCRIPTION
For testing purposes, sometimes just having an empty class is enough for your test case. However, having static code analysis enabled such a Sonar (more precisely: S2094) this will result in a warning.

By decorating such a class with a descriptive attribute, the intend will be clear, and the warning resolved.