### PR TITLE
Analyzers should not be included in NuGet packages

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -47,8 +47,8 @@
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="AsyncFixer" Version="*" />
-    <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="AsyncFixer" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 

--- a/specs/Qowaiv.Specs/NuGet_packages_specs.cs
+++ b/specs/Qowaiv.Specs/NuGet_packages_specs.cs
@@ -7,20 +7,6 @@ public class All_NuGet_Packages
         => package.Should().HavePublicKey(
             "0024000004800000940000000602000000240000525341310004000001000100EF35DF58AA7FEC73A11E70572E6B3791601006EF3FB1C6C1F1A402BA83BB2EDC975C61E8A32D792EDB864127F0D2C67EB7A64A9D3A0CDB0B1BB37FF2D0FCFD7990304623C044439D04DAC49624CC6D7937581419D995C2689F9898EC09C941B3EB3CAB8E4FC8F90B4AE5D45AB03D691D4D1F4B68450DAD41FED46671376934B0");
 
-    [TestCaseSource(nameof(Packages))]
-    public void x(Assembly package)
-    {
-        var references = package.GetReferencedAssemblies();
-
-        foreach(var reference in references) 
-        {
-            Console.WriteLine(reference);
-        }
-
-        references.Should().BeEmpty();
-    }
-
-
     private static IEnumerable<Assembly> Packages
     {
         get

--- a/specs/Qowaiv.Specs/NuGet_packages_specs.cs
+++ b/specs/Qowaiv.Specs/NuGet_packages_specs.cs
@@ -1,20 +1,33 @@
-﻿namespace NuGet_packages_specs
-{
-    public class All_NuGet_Packages
-    {
-        [TestCaseSource(nameof(Packages))]
-        public void Are_signed(Assembly package)
-            => package.Should().HavePublicKey(
-                "0024000004800000940000000602000000240000525341310004000001000100EF35DF58AA7FEC73A11E70572E6B3791601006EF3FB1C6C1F1A402BA83BB2EDC975C61E8A32D792EDB864127F0D2C67EB7A64A9D3A0CDB0B1BB37FF2D0FCFD7990304623C044439D04DAC49624CC6D7937581419D995C2689F9898EC09C941B3EB3CAB8E4FC8F90B4AE5D45AB03D691D4D1F4B68450DAD41FED46671376934B0");
+﻿namespace NuGet_packages_specs;
 
-        private static IEnumerable<Assembly> Packages
+public class All_NuGet_Packages
+{
+    [TestCaseSource(nameof(Packages))]
+    public void Are_signed(Assembly package)
+        => package.Should().HavePublicKey(
+            "0024000004800000940000000602000000240000525341310004000001000100EF35DF58AA7FEC73A11E70572E6B3791601006EF3FB1C6C1F1A402BA83BB2EDC975C61E8A32D792EDB864127F0D2C67EB7A64A9D3A0CDB0B1BB37FF2D0FCFD7990304623C044439D04DAC49624CC6D7937581419D995C2689F9898EC09C941B3EB3CAB8E4FC8F90B4AE5D45AB03D691D4D1F4B68450DAD41FED46671376934B0");
+
+    [TestCaseSource(nameof(Packages))]
+    public void x(Assembly package)
+    {
+        var references = package.GetReferencedAssemblies();
+
+        foreach(var reference in references) 
         {
-            get
-            {
-                yield return typeof(Qowaiv.SingleValueObjectAttribute).Assembly;
-                yield return typeof(Qowaiv.Data.SvoParameter).Assembly;
-                yield return typeof(Qowaiv.TestTools.JsonTester).Assembly;
-            }
+            Console.WriteLine(reference);
+        }
+
+        references.Should().BeEmpty();
+    }
+
+
+    private static IEnumerable<Assembly> Packages
+    {
+        get
+        {
+            yield return typeof(Qowaiv.SingleValueObjectAttribute).Assembly;
+            yield return typeof(Qowaiv.Data.SvoParameter).Assembly;
+            yield return typeof(Qowaiv.TestTools.JsonTester).Assembly;
         }
     }
 }

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -25,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="FluentAssertions.Analyzers" Version="*" />
-    <PackageReference Include="NUnit.Analyzers" Version="*" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"  />
   </ItemGroup>
 
   <ItemGroup>

--- a/specs/Qowaiv.Specs/TestTools/XML_structure_specs.cs
+++ b/specs/Qowaiv.Specs/TestTools/XML_structure_specs.cs
@@ -23,5 +23,5 @@ public class With_debugger_experience
 {
     [Test]
     public void via_ToString()
-        => XmlStructure.New(true).ToString().Should().Be("ID: 17, SVO: True, Date: 2017-06-11T00:00:00.0000000");
+        => XmlStructure.New(true).ToString().Should().Be("ID: 17, SVO: True, Date: 2017-06-11T00:00:00.0000000Z");
 }

--- a/src/Qowaiv.TestTools/XmlStructure.cs
+++ b/src/Qowaiv.TestTools/XmlStructure.cs
@@ -22,7 +22,7 @@ public sealed class XmlStructure<TSvo>
     public TSvo Svo { get; set; }
 
     /// <summary>Gets and sets a date (time) property.</summary>
-    public DateTime Date { get; set; } = new DateTime(2017, 06, 11, 00, 00, 000, DateTimeKind.Local);
+    public DateTime Date { get; set; } = new DateTime(2017, 06, 11, 00, 00, 000, DateTimeKind.Utc);
 
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,9 +5,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.4.2</Version>
+    <Version>6.4.3</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
+v6.4.3
+- Analyzers should not be included in NuGet packages. #321 (fix)
 V6.4.2
 - Svo&lt;SvoBehavior&gt; and Id&lt;IdBehavior&gt; decorated with IEqualityOperators. #315
 v6.4.1


### PR DESCRIPTION
By cleaning-up the props, two analyzers where not longer marked as `PrivateAssets`.

See: #321 