### PR TITLE
Reduce null dereference related issues in unit tests

### DIFF
--- a/specs/Qowaiv.Specs/Data/SvoParameter_specs.cs
+++ b/specs/Qowaiv.Specs/Data/SvoParameter_specs.cs
@@ -63,7 +63,7 @@ namespace Data.SvoParameter_specs
     {
         private readonly string val;
         public StructWithoutRequiredCast(string str) => val = str;
-        public override bool Equals(object obj) => obj is StructWithoutRequiredCast svo && Equals(svo);
+        public override bool Equals(object? obj) => obj is StructWithoutRequiredCast svo && Equals(svo);
         public bool Equals(StructWithoutRequiredCast other) => other.val == val;
         public override int GetHashCode() => (val ?? "").GetHashCode();
         public override string ToString() => val;

--- a/specs/Qowaiv.Specs/Extensions/Type_specs.cs
+++ b/specs/Qowaiv.Specs/Extensions/Type_specs.cs
@@ -44,7 +44,7 @@ public class CSharpString
     [Test]
     public void Supports_generic_arguments()
     {
-        var generic = typeof(GenericOf).GetMethod(nameof(GenericOf.Default)).ReturnType;
+        var generic = typeof(GenericOf).GetMethod(nameof(GenericOf.Default))!.ReturnType;
         generic.ToCSharpString().Should().Be("CSharpString.GenericOf.TModel");
     }
 

--- a/specs/Qowaiv.Specs/Globalization/Countries_specs.cs
+++ b/specs/Qowaiv.Specs/Globalization/Countries_specs.cs
@@ -9,4 +9,9 @@ public class All
     [Test]
     public void _250_at_Januari_2016()
         => Country.GetExisting(new Date(2016, 01, 01)).Should().HaveCount(250);
+
+    [Test]
+    public void zero_at_1973()
+        => Country.GetExisting(new Date(1973, 12, 31)).Should().BeEmpty(because: "before the ISO standard was introduced.");
+
 }

--- a/specs/Qowaiv.Specs/Globalization/Country_specs.cs
+++ b/specs/Qowaiv.Specs/Globalization/Country_specs.cs
@@ -1,5 +1,44 @@
 ﻿namespace Globalization.Country_specs;
 
+public class Dipslay_name
+{
+    [Test]
+    public void string_empty_for_empty_country()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Country.Empty.DisplayName.Should().Be(string.Empty);
+        }
+    }
+
+    [Test]
+    public void Unknown_for_unknown_country()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Country.Unknown.DisplayName.Should().Be("Unknown");
+        }
+    }
+
+    [Test]
+    public void Culture_dependent()
+    {
+        using (TestCultures.En_GB.Scoped())
+        {
+            Svo.Country.DisplayName.Should().Be("Holy See");
+        }
+    }
+
+    [Test]
+    public void with_fallback_to_current_culture()
+    {
+        using (TestCultures.Es_EC.Scoped())
+        {
+            Svo.Country.GetDisplayName(null).Should().Be("Ciudad Del Vaticano");
+        }
+    }
+}
+
 public class Supports_type_conversion
 {
     [Test]
@@ -79,5 +118,23 @@ public class Supports_JSON_serialization
     {
         var exception = Assert.Catch(() => JsonTester.Read<Country>(json));
         Assert.IsInstanceOf(exceptionType, exception);
+    }
+}
+
+public class Supports_binary_serialization
+{
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void using_BinaryFormatter()
+    {
+        var round_tripped = SerializeDeserialize.Binary(Svo.Country);
+        Svo.Country.Should().Be(round_tripped);
+    }
+
+    [Test]
+    public void storing_value_in_SerializationInfo()
+    {
+        var info = Serialize.GetInfo(Svo.Country);
+        info.GetString("Value").Should().Be("VA");
     }
 }

--- a/specs/Qowaiv.Specs/Globalization/Country_specs.cs
+++ b/specs/Qowaiv.Specs/Globalization/Country_specs.cs
@@ -1,6 +1,6 @@
 ﻿namespace Globalization.Country_specs;
 
-public class Dipslay_name
+public class Dispslay_name
 {
     [Test]
     public void string_empty_for_empty_country()
@@ -37,6 +37,36 @@ public class Dipslay_name
             Svo.Country.GetDisplayName(null).Should().Be("Ciudad Del Vaticano");
         }
     }
+}
+
+public class Start_date
+{
+    [Test]
+    public void min_value_for_empty() => Country.Empty.StartDate.Should().Be(Date.MinValue);
+
+    [Test]
+    public void min_value_for_unknown() => Country.Unknown.StartDate.Should().Be(Date.MinValue);
+
+    [Test]
+    public void set_for_active_from_start() => Svo.Country.StartDate.Should().Be(new Date(1974, 01, 01));
+
+    [Test]
+    public void set_for_counties_established_after_ISO() => Country.CZ.StartDate.Should().Be(new Date(1993, 01, 01));
+}
+
+public class End_date
+{
+    [Test]
+    public void null_for_empty() => Country.Empty.EndDate.Should().BeNull();
+
+    [Test]
+    public void null_for_unkown() => Country.Unknown.EndDate.Should().BeNull();
+
+    [Test]
+    public void null_for_active() => Svo.Country.EndDate.Should().BeNull();
+
+    [Test]
+    public void set_for_inactive() => Country.CSHH.EndDate.Should().Be(new Date(1992, 12, 31));
 }
 
 public class Supports_type_conversion

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -95,6 +95,24 @@ public class Supports_type_conversion
         => Converting.To<Uuid>().From(Svo.CustomGuid).Should().Be(Svo.Uuid);
 }
 
+public class Supports_binary_serialization
+{
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void using_BinaryFormatter()
+    {
+        var round_tripped = SerializeDeserialize.Binary(Svo.CustomGuid);
+        Svo.CustomGuid.Should().Be(round_tripped);
+    }
+
+    [Test]
+    public void storing_value_in_SerializationInfo()
+    {
+        var info = Serialize.GetInfo(Svo.CustomGuid);
+        info.GetValue("Value", typeof(Guid)).Should().Be(Guid.Parse("8A1A8C42-D2FF-E254-E26E-B6ABCBF19420"));
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
@@ -85,6 +85,24 @@ public class Supports_type_conversion
         => Converting.To<int>().From(Svo.Int32Id).Should().Be(17);
 }
 
+public class Supports_binary_serialization
+{
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void using_BinaryFormatter()
+    {
+        var round_tripped = SerializeDeserialize.Binary(Svo.Int32Id);
+        Svo.Int32Id.Should().Be(round_tripped);
+    }
+
+    [Test]
+    public void storing_value_in_SerializationInfo()
+    {
+        var info = Serialize.GetInfo(Svo.Int32Id);
+        info.GetInt32("Value").Should().Be(17);
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -126,6 +126,24 @@ public class Supports_type_conversion
     }
 }
 
+public class Supports_binary_serialization
+{
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void using_BinaryFormatter()
+    {
+        var round_tripped = SerializeDeserialize.Binary(Svo.Int64Id);
+        Svo.Int64Id.Should().Be(round_tripped);
+    }
+
+    [Test]
+    public void storing_value_in_SerializationInfo()
+    {
+        var info = Serialize.GetInfo(Svo.Int64Id);
+        info.GetInt64("Value").Should().Be(987654321L);
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_String_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_String_specs.cs
@@ -1,4 +1,4 @@
-﻿namespace Identifiers.Id_for_String_specs;
+﻿    namespace Identifiers.Id_for_String_specs;
 
 public class Is_comparable
 {
@@ -75,6 +75,24 @@ public class Supports_type_conversion
         {
             Converting.ToString().From(Svo.StringId).Should().Be("Qowaiv-ID");
         }
+    }
+}
+
+public class Supports_binary_serialization
+{
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void using_BinaryFormatter()
+    {
+        var round_tripped = SerializeDeserialize.Binary(Svo.StringId);
+        Svo.StringId.Should().Be(round_tripped);
+    }
+
+    [Test]
+    public void storing_value_in_SerializationInfo()
+    {
+        var info = Serialize.GetInfo(Svo.StringId);
+        info.GetString("Value").Should().Be("Qowaiv-ID");
     }
 }
 

--- a/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
+++ b/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
@@ -280,6 +280,25 @@ public class Supports_JSON_serialization
     }
 }
 
+public class Supports_binary_serialization
+{
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void using_BinaryFormatter()
+    {
+        var round_tripped = SerializeDeserialize.Binary(Svo.Fraction);
+        Svo.Fraction.Should().Be(round_tripped);
+    }
+
+    [Test]
+    public void storing_values_in_SerializationInfo()
+    {
+        var info = Serialize.GetInfo(Svo.Fraction);
+        info.GetInt64("numerator").Should().Be(-69);
+        info.GetInt64("denominator").Should().Be(17);
+    }
+}
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/TestTools/Nil.cs
+++ b/specs/Qowaiv.Specs/TestTools/Nil.cs
@@ -3,4 +3,6 @@
 internal static class Nil
 {
     public static readonly string? String;
+
+    public static readonly object? Object;
 }

--- a/specs/Qowaiv.Specs/TestTools/Serialize_deserialize_helper_specs.cs
+++ b/specs/Qowaiv.Specs/TestTools/Serialize_deserialize_helper_specs.cs
@@ -6,7 +6,7 @@ public class Fails_on
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void binary_roundtrip_null()
     {
-        Func<object> roundtrip = () => SerializeDeserialize.Binary<object>(null);
+        Func<object> roundtrip = () => SerializeDeserialize.Binary<object>(null!);
         roundtrip.Should().Throw<ArgumentNullException>();
     }
 }

--- a/specs/Qowaiv.Specs/TestTools/SingleValueObjectSpecs.cs
+++ b/specs/Qowaiv.Specs/TestTools/SingleValueObjectSpecs.cs
@@ -6,7 +6,7 @@
 
         public static IEnumerable<Type> AllSvos
             => AppDomain.CurrentDomain.GetAssemblies()
-            .Where(assembly => assembly.FullName.Contains("Qowaiv"))
+            .Where(assembly => assembly.FullName!.Contains("Qowaiv"))
             .SelectMany(assembly => assembly.GetExportedTypes())
             .Where(type 
                 => type.GetCustomAttributes<SingleValueObjectAttribute>().Any() 

--- a/specs/Qowaiv.Specs/TestTools/Temporary_directory_specs.cs
+++ b/specs/Qowaiv.Specs/TestTools/Temporary_directory_specs.cs
@@ -13,8 +13,8 @@ public  class Implicitly_converts
     [Test]
     public void To_directory_info_from_null()
     {
-        TemporaryDirectory dir = null;
-        DirectoryInfo casted = dir;
+        TemporaryDirectory? dir = null;
+        DirectoryInfo? casted = dir;
         casted.Should().BeNull();
     }
 }

--- a/specs/Qowaiv.Specs/Text/Base32_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base32_specs.cs
@@ -4,16 +4,12 @@ public class ToString
 {
     [Test]
     public void Null_StringEmpty()
-    {
-        Assert.AreEqual(string.Empty, Base32.ToString(null));
-    }
+        => Base32.ToString(null).Should().Be(string.Empty);
 
     [Test]
     public void EmptyArray_StringEmpty()
-    {
-        Assert.AreEqual(string.Empty, Array.Empty<byte>());
-    }
-
+        => Base32.ToString(Array.Empty<byte>()).Should().Be(string.Empty);
+    
     [TestCase("BQ", 12)]
     [TestCase("BQRA", 12, 34)]
     [TestCase("QOWAI", 131, 172, 4)]
@@ -27,20 +23,17 @@ public class ToString
     [TestCase("BQRDQTS2N55YNEM4U4", 12, 34, 56, 78, 90, 111, 123, 134, 145, 156, 167)]
     [TestCase("BQRDQTS2N55YNEM4U6ZA", 12, 34, 56, 78, 90, 111, 123, 134, 145, 156, 167, 178)]
     [TestCase("THEQUICKBROWNFOXJUMBSOVERTHELAZYDOG2345674", 153, 201, 010, 032, 074, 012, 093, 102, 149, 215, 077, 024, 025, 058, 164, 140, 206, 069, 131, 056, 027, 141, 173, 243, 190, 255)]
-    public void bytes(string expected, params int[] data)
+    public void bytes(string base32, params int[] data)
     {
         var bytes = data.Select(v => (byte)v).ToArray();
-
-        var actualString = Base32.ToString(bytes);
-        Assert.AreEqual(expected, actualString);
+        Base32.ToString(bytes).Should().Be(base32);
     }
 
     [Test]
     public void LowerCase()
     {
         var bytes = new byte[] { 153, 201, 010, 032, 074, 012, 093, 102, 149, 215, 077, 024, 025, 058, 164, 140, 206, 069, 131, 056, 027, 141, 173, 243, 190, 255 };
-        var str = Base32.ToString(bytes, true);
-        Assert.AreEqual("thequickbrownfoxjumbsoverthelazydog2345674", str);
+        Base32.ToString(bytes, true).Should().Be("thequickbrownfoxjumbsoverthelazydog2345674");
     }
 }
 

--- a/specs/Qowaiv.Specs/Text/Base64_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base64_specs.cs
@@ -4,25 +4,19 @@ public class ToString
 {
     [Test]
     public void Null_StringEmpty()
-    {
-        Assert.AreEqual(string.Empty, Base64.ToString(null));
-    }
+        => Base64.ToString(null).Should().Be(string.Empty);
 
     [Test]
     public void EmptyArray_StringEmpty()
-    {
-        Assert.AreEqual(string.Empty, Array.Empty<byte>());
-    }
+        => Base64.ToString(Array.Empty<byte>()).Should().Be(string.Empty);
 
     [TestCase("Aao=", 1, 170)]
     [TestCase("Cxct", 11, 23, 45)]
     [TestCase("Qowaig==", 66, 140, 26, 138)]
-    public void bytes(string expected, params int[] data)
+    public void bytes(string base64, params int[] data)
     {
         var bytes = data.Select(v => (byte)v).ToArray();
-
-        var actualString = Base64.ToString(bytes);
-        Assert.AreEqual(expected, actualString);
+        Base64.ToString(bytes).Should().Be(base64);
     }
 }
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
@@ -31,19 +31,11 @@ public class AmountTest
 
     /// <summary>TryParse null should be valid.</summary>
     [Test]
-    public void TryParse_Null_IsInvalid()
-    {
-        string str = null;
-        Assert.IsFalse(Amount.TryParse(str, out _));
-    }
+    public void TryParse_Null_IsInvalid() => Amount.TryParse(Nil.String, out _).Should().BeFalse();
 
     /// <summary>TryParse string.Empty should be valid.</summary>
     [Test]
-    public void TryParse_StringEmpty_IsInvalid()
-    {
-        string str = string.Empty;
-        Assert.IsFalse(Amount.TryParse(str, out _));
-    }
+    public void TryParse_StringEmpty_IsInvalid() => Amount.TryParse(string.Empty, out _).Should().BeFalse();
 
     /// <summary>TryParse with specified string value should be valid.</summary>
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsCollectionTest.cs
@@ -116,7 +116,7 @@ public class FormattingArgumentsCollectionTest
     public void Format_ArrayWithNullItem_String()
     {
         var collection = new FormattingArgumentsCollection();
-        var args = new object[] { null };
+        var args = new object?[] { null };
         var act = collection.Format("Value: '{0}'", args);
         var exp = "Value: ''";
 
@@ -200,21 +200,17 @@ public class FormattingArgumentsCollectionTest
     [Test]
     public void ToString_IFormattableNull_IsNull()
     {
+        IFormattable? obj = null;
         var collection = new FormattingArgumentsCollection();
-        string act = collection.ToString((IFormattable)null);
-        string exp = null;
-
-        Assert.AreEqual(exp, act);
+        collection.ToString(obj)
+            .Should().BeNull();
     }
     [Test]
     public void ToString_ObjectNull_IsNull()
     {
         var collection = new FormattingArgumentsCollection();
-        string act = collection.ToString((object)null);
-        string exp = null;
-
-        Assert.AreEqual(exp, act);
-    }
+        collection.ToString((object?)null)
+            .Should().BeNull();    }
     [Test]
     public void ToString_TypeInt32_SystemInt32()
     {
@@ -231,10 +227,7 @@ public class FormattingArgumentsCollectionTest
         {
             { typeof(int), "000" }
         };
-        string act = collection.ToString((object)7);
-        string exp = "007";
-
-        Assert.AreEqual(exp, act);
+        collection.ToString((object)7).Should().Be("007");
     }
 
     #region Collection manipulation

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -164,7 +164,7 @@ public class CountryTest
     public void Create_RegionInfoNull_Empty()
     {
         var exp = Country.Empty;
-        var act = Country.Create((RegionInfo)null);
+        var act = Country.Create((RegionInfo?)null);
         Assert.AreEqual(exp, act);
     }
 
@@ -172,7 +172,7 @@ public class CountryTest
     public void Create_CultureInfoNull_Empty()
     {
         var exp = Country.Empty;
-        var act = Country.Create((CultureInfo)null);
+        var act = Country.Create((CultureInfo?)null);
         Assert.AreEqual(exp, act);
     }
 
@@ -521,7 +521,7 @@ public class CountryTest
     [Test]
     public void Equals_TestStructNull_IsFalse()
     {
-        Assert.IsFalse(CountryTest.TestStruct.Equals(null));
+        Assert.IsFalse(CountryTest.TestStruct.Equals(Nil.Object));
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -690,68 +690,6 @@ public class CountryTest
         Assert.AreEqual(exp, act);
     }
 
-    [Test]
-    public void StartDate_Empty_AreEqual()
-    {
-        var exp = Date.MinValue;
-        var act = Country.Empty.StartDate;
-        Assert.AreEqual(exp, act);
-    }
-    [Test]
-    public void StartDate_Unknown_AreEqual()
-    {
-        var exp = Date.MinValue;
-        var act = Country.Unknown.StartDate;
-        Assert.AreEqual(exp, act);
-    }
-    [Test]
-    public void StartDate_TestStruct_AreEqual()
-    {
-        var exp = new Date(1974, 01, 01);
-        var act = TestStruct.StartDate;
-        Assert.AreEqual(exp, act);
-    }
-    [Test]
-    public void StartDate_CZ_AreEqual()
-    {
-        var exp = new Date(1993, 01, 01);
-        var act = Country.CZ.StartDate;
-        Assert.AreEqual(exp, act);
-    }
-
-    [Test]
-    public void EndDate_Empty_AreEqual()
-    {
-        Country.Empty.EndDate.Should().BeNull();
-    }
-
-    [Test]
-    public void EndDate_Unknown_AreEqual()
-    {
-        Country.Unknown.EndDate.Should().BeNull();
-    }
-
-    [Test]
-    public void EndDate_TestStruct_AreEqual()
-    {
-        TestStruct.EndDate.Should().BeNull();
-    }
-
-    [Test]
-    public void EndDate_CZ_AreEqual()
-    {
-        DateTime? exp = null;
-        var act = Country.CZ.EndDate;
-        Assert.AreEqual(exp, act);
-    }
-    [Test]
-    public void EndDate_CSHH_AreEqual()
-    {
-        var exp = new Date(1992, 12, 31);
-        var act = Country.CSHH.EndDate;
-        Assert.AreEqual(exp, act);
-    }
-
     #endregion
 
     #region Methods

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -229,25 +229,6 @@ public class CountryTest
     #region (XML) (De)serialization tests
 
     [Test]
-    public void GetObjectData_SerializationInfo_AreEqual()
-    {
-        ISerializable obj = TestStruct;
-        var info = new SerializationInfo(typeof(Country), new System.Runtime.Serialization.FormatterConverter());
-        obj.GetObjectData(info, default);
-
-        Assert.AreEqual("VA", info.GetString("Value"));
-    }
-
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void SerializeDeserialize_TestStruct_AreEqual()
-    {
-        var input = CountryTest.TestStruct;
-        var exp = CountryTest.TestStruct;
-        var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
-    }
-    [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
         var input = CountryTest.TestStruct;
@@ -688,47 +669,6 @@ public class CountryTest
     }
 
     [Test]
-    public void DisplayName_Empty_AreEqual()
-    {
-        using (TestCultures.En_GB.Scoped())
-        {
-            var exp = "";
-            var act = Country.Empty.DisplayName;
-            Assert.AreEqual(exp, act);
-        }
-    }
-    [Test]
-    public void DisplayName_Unknown_AreEqual()
-    {
-        using (TestCultures.En_GB.Scoped())
-        {
-            var exp = "Unknown";
-            var act = Country.Unknown.DisplayName;
-            Assert.AreEqual(exp, act);
-        }
-    }
-    [Test]
-    public void DisplayName_TestStruct_AreEqual()
-    {
-        using (TestCultures.En_GB.Scoped())
-        {
-            var exp = "Holy See";
-            var act = TestStruct.DisplayName;
-            Assert.AreEqual(exp, act);
-        }
-    }
-    [Test]
-    public void GetDisplayName_TestStruct_AreEqual()
-    {
-        using (TestCultures.En_GB.Scoped())
-        {
-            var exp = "Holy See";
-            var act = TestStruct.GetDisplayName(null);
-            Assert.AreEqual(exp, act);
-        }
-    }
-
-    [Test]
     public void IsoNumericCode_Empty_AreEqual()
     {
         var exp = 0;
@@ -876,30 +816,6 @@ public class CountryTest
         var exp = Currency.EUR;
 
         Assert.AreEqual(act, exp);
-    }
-
-    #endregion
-
-    #region Collection tests
-
-    [Test]
-    public void GetCurrent_1973_0()
-    {
-        var exp = 0;
-
-        // before the ISO standard was introduced.
-        var act = Country.GetExisting(new Date(1973, 12, 31)).ToList();
-
-        Assert.AreEqual(exp, act.Count);
-    }
-
-    [Test]
-    public void GetCurrent_None_250()
-    {
-        var exp = 250;
-        var act = Country.GetExisting().ToList();
-
-        Assert.AreEqual(exp, act.Count);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
@@ -143,32 +143,6 @@ public class IdForGuidTest
     }
 
     [Test]
-    public void GetObjectData_NulSerializationInfo_Throws()
-    {
-        ISerializable obj = TestStruct;
-        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
-    }
-
-    [Test]
-    public void GetObjectData_SerializationInfo_AreEqual()
-    {
-        ISerializable obj = TestStruct;
-        var info = new SerializationInfo(typeof(Id<ForGuid>), new FormatterConverter());
-        obj.GetObjectData(info, default);
-        Assert.AreEqual(Guid.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), info.GetValue("Value", typeof(Guid)));
-    }
-
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void SerializeDeserialize_TestStruct_AreEqual()
-    {
-        var input = TestStruct;
-        var exp = TestStruct;
-        var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
-    }
-
-    [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
         var input = TestStruct;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
@@ -137,32 +137,6 @@ public class IdForInt32Test
     }
 
     [Test]
-    public void GetObjectData_NulSerializationInfo_Throws()
-    {
-        ISerializable obj = TestStruct;
-        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
-    }
-
-    [Test]
-    public void GetObjectData_SerializationInfo_AreEqual()
-    {
-        ISerializable obj = TestStruct;
-        var info = new SerializationInfo(typeof(Id<ForInt32>), new FormatterConverter());
-        obj.GetObjectData(info, default);
-        Assert.AreEqual(123456789L, info.GetValue("Value", typeof(long)));
-    }
-
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void SerializeDeserialize_TestStruct_AreEqual()
-    {
-        var input = TestStruct;
-        var exp = TestStruct;
-        var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
-    }
-
-    [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
         var input = TestStruct;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
@@ -137,32 +137,6 @@ public class IdForInt64Test
     }
 
     [Test]
-    public void GetObjectData_NulSerializationInfo_Throws()
-    {
-        ISerializable obj = TestStruct;
-        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null!, default));
-    }
-
-    [Test]
-    public void GetObjectData_SerializationInfo_AreEqual()
-    {
-        ISerializable obj = TestStruct;
-        var info = new SerializationInfo(typeof(Id<ForInt64>), new FormatterConverter());
-        obj.GetObjectData(info, default);
-        Assert.AreEqual(123456789L, info.GetValue("Value", typeof(long)));
-    }
-
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void SerializeDeserialize_TestStruct_AreEqual()
-    {
-        var input = TestStruct;
-        var exp = TestStruct;
-        var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
-    }
-
-    [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
         var input = TestStruct;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
@@ -140,7 +140,7 @@ public class IdForInt64Test
     public void GetObjectData_NulSerializationInfo_Throws()
     {
         ISerializable obj = TestStruct;
-        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
+        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null!, default));
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
@@ -96,32 +96,6 @@ public class IdForStringTest
     }
 
     [Test]
-    public void GetObjectData_NulSerializationInfo_Throws()
-    {
-        ISerializable obj = TestStruct;
-        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
-    }
-
-    [Test]
-    public void GetObjectData_SerializationInfo_AreEqual()
-    {
-        ISerializable obj = TestStruct;
-        var info = new SerializationInfo(typeof(Id<ForString>), new FormatterConverter());
-        obj.GetObjectData(info, default);
-        Assert.AreEqual("Qowaiv-ID", info.GetValue("Value", typeof(string)));
-    }
-
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void SerializeDeserialize_TestStruct_AreEqual()
-    {
-        var input = TestStruct;
-        var exp = TestStruct;
-        var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
-    }
-
-    [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
         var input = TestStruct;

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
@@ -70,23 +70,6 @@ public class FractionTest
     }
 
     [Test]
-    public void GetObjectData_NulSerializationInfo_Throws()
-    {
-        ISerializable obj = TestStruct;
-        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
-    }
-
-    [Test]
-    public void GetObjectData_SerializationInfo_AreEqual()
-    {
-        ISerializable obj = TestStruct;
-        var info = new SerializationInfo(typeof(Fraction), new FormatterConverter());
-        obj.GetObjectData(info, default);
-        Assert.AreEqual(-69, info.GetInt64("numerator"));
-        Assert.AreEqual(17, info.GetInt64("denominator"));
-    }
-
-    [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -104,7 +104,7 @@ public class MonthSpanTest
     public void GetObjectData_NulSerializationInfo_Throws()
     {
         ISerializable obj = TestStruct;
-        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null, default));
+        Assert.Catch<ArgumentNullException>(() => obj.GetObjectData(null!, default));
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
@@ -69,7 +69,7 @@ public class WildcardPatternTest
     [TestCase("ig*ks", "IGeeks", false, WildcardPatternOptions.None, StringComparison.OrdinalIgnoreCase, "tr-TR")]
     [TestCase("Ig*ks", "ıGeeks", true, WildcardPatternOptions.None, StringComparison.OrdinalIgnoreCase, "tr-TR")]
     [TestCase("ıg*ks", "IGeeks", true, WildcardPatternOptions.None, StringComparison.OrdinalIgnoreCase, "tr-TR")]
-    public void IsMatch(string pattern, string input, bool isMatch, WildcardPatternOptions options = default, StringComparison comparsionType = default, string culture = null)
+    public void IsMatch(string pattern, string input, bool isMatch, WildcardPatternOptions options = default, StringComparison comparsionType = default, string? culture = null)
     {
         using (culture is null ? CultureInfoScope.NewInvariant() : new CultureInfoScope(culture))
         {

--- a/src/Qowaiv.TestTools/IO/TemporaryDirectory.cs
+++ b/src/Qowaiv.TestTools/IO/TemporaryDirectory.cs
@@ -26,6 +26,7 @@ public sealed class TemporaryDirectory : IDisposable
     public string FullName => Root.FullName;
 
     /// <summary>Casts the temporary directory to a <see cref="DirectoryInfo"/>.</summary>
+    [return: NotNullIfNotNull(nameof(dir))]
     public static implicit operator DirectoryInfo?(TemporaryDirectory? dir) => dir?.Root;
 
     /// <summary>Represents the temporary directory as <see cref="string"/>.</summary>

--- a/src/Qowaiv/Formatting/FormattingArguments.cs
+++ b/src/Qowaiv/Formatting/FormattingArguments.cs
@@ -47,6 +47,7 @@ public readonly struct FormattingArguments : ISerializable, IEquatable<Formattin
     /// A formatted string representing the object.
     /// </returns>
     [Pure]
+    [return: NotNullIfNotNull(nameof(obj))]
     public string? ToString(IFormattable? obj)
         => obj?.ToString(Format, FormatProvider ?? CultureInfo.CurrentCulture);
 
@@ -61,6 +62,7 @@ public readonly struct FormattingArguments : ISerializable, IEquatable<Formattin
     /// If the object does not implement IFormattable, the ToString() will be used.
     /// </remarks>
     [Pure]
+    [return: NotNullIfNotNull(nameof(obj))]
     public string? ToString(object? obj)
         => obj is IFormattable formattable
         ? ToString(formattable)

--- a/src/Qowaiv/Formatting/FormattingArgumentsCollection.cs
+++ b/src/Qowaiv/Formatting/FormattingArgumentsCollection.cs
@@ -60,7 +60,8 @@ public class FormattingArgumentsCollection : IEnumerable<KeyValuePair<Type, Form
     /// If the object does not implement IFormattable, the ToString() will be used.
     /// </remarks>
     [Pure]
-    public string? ToString(object obj)
+    [return: NotNullIfNotNull(nameof(obj))]
+    public string? ToString(object? obj)
         => obj is IFormattable formattable
         ? ToString(formattable)
         : obj?.ToString();

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -108,7 +108,7 @@ public readonly partial struct Country : ISerializable, IXmlSerializable, IForma
     /// Returns a localized display name.
     /// </returns>
     [Pure]
-    public string GetDisplayName(CultureInfo culture) => GetResourceString("DisplayName", culture);
+    public string GetDisplayName(CultureInfo? culture) => GetResourceString("DisplayName", culture);
 
     /// <summary>Returns true if the country exists at the given date, otherwise false.</summary>
     /// <param name="measurement">
@@ -377,6 +377,6 @@ public readonly partial struct Country : ISerializable, IXmlSerializable, IForma
     /// The format provider.
     /// </param>
     [Pure]
-    private string GetResourceString(string postfix, IFormatProvider formatProvider)
+    private string GetResourceString(string postfix, IFormatProvider? formatProvider)
         => ResourceManager.Localized(formatProvider, $"{m_Value}_{postfix}");
 }

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -264,7 +264,7 @@ public readonly partial struct Country : ISerializable, IXmlSerializable, IForma
     /// Returns a country that represents the same region as region info.
     /// </returns>
     [Pure]
-    public static Country Create(RegionInfo region)
+    public static Country Create(RegionInfo? region)
     {
         if (region == null) { return default; }
         // In .NET, Serbia and Montenegro (CS) is still active.
@@ -285,7 +285,7 @@ public readonly partial struct Country : ISerializable, IXmlSerializable, IForma
     /// any, otherwise Empty.
     /// </returns>
     [Pure]
-    public static Country Create(CultureInfo culture)
+    public static Country Create(CultureInfo? culture)
     {
         if (culture == null || culture == CultureInfo.InvariantCulture || culture.IsNeutralCulture)
         {

--- a/src/Qowaiv/Hashing/Hash.cs
+++ b/src/Qowaiv/Hashing/Hash.cs
@@ -43,7 +43,7 @@ public readonly struct Hash : IEquatable<Hash>
     /// </param>
     /// <returns>The new hash.</returns>
     [Pure]
-    public Hash And<T>(T item)
+    public Hash And<T>(T? item)
         => Equals(default(T), item)
         ? this
         : new(Combine(Value, HashCode(item)));

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -310,9 +310,9 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     /// The <see cref="byte"/> array that represents the underlying value.
     /// </param>
     [Pure]
-    public static Id<TIdentifier> FromBytes(byte[] bytes)
+    public static Id<TIdentifier> FromBytes(byte[]? bytes)
     {
-        return bytes is null || bytes.Length == 0
+        return bytes is not { Length: > 0 }
             ? Empty
             : new Id<TIdentifier>(behavior.FromBytes(bytes));
     }
@@ -325,7 +325,7 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     /// if the identifier could not be created from the <see cref="object"/>.
     /// </exception>
     [Pure]
-    public static Id<TIdentifier> Create(object obj)
+    public static Id<TIdentifier> Create(object? obj)
         => TryCreate(obj, out var id)
         ? id
         : throw Exceptions.InvalidCast(obj?.GetType(), typeof(Id<TIdentifier>));
@@ -340,7 +340,7 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     /// <returns>
     /// True if the identifier could be created.
     /// </returns>
-    public static bool TryCreate(object obj, out Id<TIdentifier> id)
+    public static bool TryCreate(object? obj, out Id<TIdentifier> id)
     {
         id = default;
 

--- a/src/Qowaiv/Text/Base32.cs
+++ b/src/Qowaiv/Text/Base32.cs
@@ -113,7 +113,7 @@ public static class Base32
     [Pure]
     public static bool TryGetBytes(string? s, out byte[] bytes)
     {
-        if (string.IsNullOrEmpty(s))
+        if (s is not { Length: > 0 })
         {
             bytes = Array.Empty<byte>();
             return true;

--- a/src/Qowaiv/Text/Base32.cs
+++ b/src/Qowaiv/Text/Base32.cs
@@ -28,7 +28,7 @@ public static class Base32
     /// Uppercase by default.
     /// </remarks>
     [Pure]
-    public static string ToString(byte[] bytes) => ToString(bytes, false);
+    public static string ToString(byte[]? bytes) => ToString(bytes, false);
 
     /// <summary>Represents a byte array as a <see cref="string"/>.</summary>
     /// <param name="bytes">
@@ -38,7 +38,7 @@ public static class Base32
     /// An indicator to specify lower case or upper case.
     /// </param>
     [Pure]
-    public static string ToString(byte[] bytes, bool lowerCase)
+    public static string ToString(byte[]? bytes, bool lowerCase)
     {
         if (bytes == null || bytes.Length == 0) return string.Empty;
         else
@@ -91,7 +91,7 @@ public static class Base32
     /// If the string is not a valid Base32 string.
     /// </exception>
     [Pure]
-    public static byte[] GetBytes(string s)
+    public static byte[] GetBytes(string? s)
     {
         if (TryGetBytes(s, out byte[] bytes))
         {
@@ -111,7 +111,7 @@ public static class Base32
     /// True if the string is a Base32 string, otherwise false.
     /// </returns>
     [Pure]
-    public static bool TryGetBytes(string s, out byte[] bytes)
+    public static bool TryGetBytes(string? s, out byte[] bytes)
     {
         if (string.IsNullOrEmpty(s))
         {

--- a/src/Qowaiv/Text/Base64.cs
+++ b/src/Qowaiv/Text/Base64.cs
@@ -9,7 +9,7 @@ public static class Base64
 {
     /// <summary>Represents a byte array as a <see cref="string"/>.</summary>
     [Pure]
-    public static string ToString(byte[] bytes)
+    public static string ToString(byte[]? bytes)
         => bytes == null || bytes.Length == 0
         ? string.Empty
         : Convert.ToBase64String(bytes);
@@ -27,7 +27,7 @@ public static class Base64
     /// <remarks>
     /// If the conversion fails,  bytes is an empty byte array, not null.
     /// </remarks>
-    public static bool TryGetBytes(string s, out byte[] bytes)
+    public static bool TryGetBytes(string? s, out byte[] bytes)
     {
         if (string.IsNullOrEmpty(s))
         {

--- a/src/Qowaiv/Unknown.cs
+++ b/src/Qowaiv/Unknown.cs
@@ -18,7 +18,7 @@ public static class Unknown
     /// The string value to test.
     /// </param>
     [Pure]
-    public static bool IsUnknown(string val) => IsUnknown(val, null);
+    public static bool IsUnknown(string? val) => IsUnknown(val, null);
 
     /// <summary>Returns true if the string represents unknown, otherwise false.</summary>
     /// <param name="val">
@@ -70,7 +70,7 @@ public static class Unknown
     /// The unknown value is expected to be static field or property of the type with the name "Unknown".
     /// </remarks>
     [Pure]
-    public static object? Value(Type type)
+    public static object? Value(Type? type)
     {
         if (type is not null)
         {


### PR DESCRIPTION
Includes decorating some (shipped) code with `?` and `[return: NotNullIfNotNull(parameterName)]`.