### PR TITLE
Introduction of `HasValue` and `IsKnown` properties

### DIFF
--- a/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
+++ b/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
@@ -4,12 +4,21 @@ namespace Chemistry.CAS_Registry_Number_specs;
 
 public class With_domain_logic
 {
+    [TestCase(true, "73–24–5")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, CasRegistryNumber svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "73–24–5")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, CasRegistryNumber svo) => svo.IsKnown.Should().Be(result);
+
     [TestCase("")]
     [TestCase("?")]
     public void has_length_zero_for_empty_and_unknown(CasRegistryNumber svo)
         => svo.Length.Should().Be(0);
 
-    
     [TestCase(5, "73–24–5")]
     [TestCase(7, "7732-18-5")]
     [TestCase(8, "10028-14-5")]

--- a/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
@@ -21,6 +21,16 @@ public class Default_behavior
 
 public class With_domain_logic
 {
+    [TestCase(true, "QOWAIV")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, CustomSvo svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "QOWAIV")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, CustomSvo svo) => svo.IsKnown.Should().Be(result);
+
     [TestCase("")]
     [TestCase("?")]
     public void has_length_zero_for_empty_and_unknown(CustomSvo svo)

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -2,17 +2,23 @@
 
 public class With_domain_logic
 {
+    [TestCase(true, "info@qowaiv.org")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, EmailAddress svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "info@qowaiv.org")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, EmailAddress svo) => svo.IsKnown.Should().Be(result);
+
     [TestCase("")]
     [TestCase("?")]
-    public void has_length_zero_for_empty_and_unknown(EmailAddress svo)
-        => svo.Length.Should().Be(0);
+    public void has_length_zero_for_empty_and_unknown(EmailAddress svo) => svo.Length.Should().Be(0);
 
     [TestCase(15, "info@qowaiv.org")]
-    public void has_length(int length, EmailAddress svo)
-    {
-        Assert.AreEqual(length, svo.Length);
-    }
-
+    public void has_length(int length, EmailAddress svo) => svo.Length.Should().Be(length);
+    
     [TestCase(false, "info@qowaiv.org")]
     [TestCase(false, "?")]
     [TestCase(true, "")]

--- a/specs/Qowaiv.Specs/Financial/BIC_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/BIC_specs.cs
@@ -1,5 +1,18 @@
 ﻿namespace Financial.BIC_specs;
 
+public class With_domain_logic
+{
+    [TestCase(true, "AEGONL2UXXX")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, BusinessIdentifierCode svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "AEGONL2UXXX")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, BusinessIdentifierCode svo) => svo.IsKnown.Should().Be(result);
+}
+
 public class Supports_type_conversion
 {
     [Test]

--- a/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
@@ -117,6 +117,19 @@ public class Supported
     }
 }
 
+public class With_domain_logic
+{
+    [TestCase(true, "NL20INGB0001234567")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, InternationalBankAccountNumber svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "NL20INGB0001234567")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, InternationalBankAccountNumber svo) => svo.IsKnown.Should().Be(result);
+}
+
 public class Supports_type_conversion
 {
     [Test]

--- a/specs/Qowaiv.Specs/Gender_specs.cs
+++ b/specs/Qowaiv.Specs/Gender_specs.cs
@@ -3,6 +3,18 @@
 [Obsolete("Will be dropped in version 7. Use Qowaiv.Sex instead.")]
 public class With_domain_logic
 {
+    [TestCase(true, "Male")]
+    [TestCase(true, "Female")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, Gender svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "Male")]
+    [TestCase(true, "Female")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, Gender svo) => svo.IsKnown.Should().Be(result);
+
     [TestCase(false, "Male")]
     [TestCase(false, "Female")]
     [TestCase(false, "?")]

--- a/specs/Qowaiv.Specs/Globalization/Country_specs.cs
+++ b/specs/Qowaiv.Specs/Globalization/Country_specs.cs
@@ -1,5 +1,18 @@
 ﻿namespace Globalization.Country_specs;
 
+public class With_domain_logic
+{
+    [TestCase(true, "VA")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, Country svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "VA")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, Country svo) => svo.IsKnown.Should().Be(result);
+}
+
 public class Display_name
 {
     [Test]

--- a/specs/Qowaiv.Specs/HouseNumber_specs.cs
+++ b/specs/Qowaiv.Specs/HouseNumber_specs.cs
@@ -1,5 +1,19 @@
 ﻿namespace HouseNumber_specs;
 
+
+public class With_domain_logic
+{
+    [TestCase(true, 123456789)]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, HouseNumber svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, 123456789)]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, HouseNumber svo) => svo.IsKnown.Should().Be(result);
+}
+
 public class Is_equal_by_value
 {
     [Test]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -1,5 +1,12 @@
 ﻿namespace Identifiers.Id_for_Guid_specs;
 
+public class With_domain_logic
+{
+    [TestCase(true, "33ef5805-c472-4b1f-88bb-2f0723c43889")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, CustomGuid svo) => svo.HasValue.Should().Be(result);
+}
+
 public class Is_comparable
 {
     [Test]

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -2,6 +2,16 @@
 
 public class With_domain_logic
 {
+    [TestCase(true, "February")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, Month svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "February")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, Month svo) => svo.IsKnown.Should().Be(result);
+
     [TestCase(false, "February")]
     [TestCase(false, "?")]
     [TestCase(true, "")]

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -2,6 +2,16 @@
 
 public class With_domain_logic
 {
+    [TestCase(true, "H0H0H0")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, PostalCode svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "H0H0H0")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, PostalCode svo) => svo.IsKnown.Should().Be(result);
+
     [TestCase("")]
     [TestCase("?")]
     public void has_length_zero_for_empty_and_unknown(PostalCode svo)

--- a/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
+++ b/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
@@ -24,6 +24,11 @@ public class Not_computed
 
 public class With_domain_logic
 {
+    [TestCase(true, "Qowaiv==")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, CryptographicSeed svo)
+      => svo.HasValue.Should().Be(result);
+
     [TestCase(false, "Qowaiv==")]
     [TestCase(true, "")]
     public void IsEmpty_returns(bool result, CryptographicSeed svo)

--- a/specs/Qowaiv.Specs/Security/Secret_specs.cs
+++ b/specs/Qowaiv.Specs/Security/Secret_specs.cs
@@ -21,6 +21,10 @@ public class Cryptographic_seed_can_be_created
 
 public class With_domain_logic
 {
+    [TestCase(true, "Ken sent me!")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, Secret svo) => svo.HasValue.Should().Be(result);
+
     [TestCase(false, "Ken sent me!")]
     [TestCase(true, "")]
     public void IsEmpty_returns(bool result, Secret svo)

--- a/specs/Qowaiv.Specs/Sex_specs.cs
+++ b/specs/Qowaiv.Specs/Sex_specs.cs
@@ -2,6 +2,18 @@
 
 public class With_domain_logic
 {
+    [TestCase(true, "Male")]
+    [TestCase(true, "Female")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, Sex svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "Male")]
+    [TestCase(true, "Female")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, Sex svo) => svo.IsKnown.Should().Be(result);
+
     [TestCase(false, "Male")]
     [TestCase(false, "Female")]
     [TestCase(false, "?")]

--- a/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
+++ b/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
@@ -274,7 +274,7 @@ public class Has_custom_formatting
     public void custom_format_provider_is_applied()
     {
         var formatted = Svo.EnergyLabel.ToString("SomeFormat", FormatProvider.CustomFormatter);
-        Assert.AreEqual("Unit Test Formatter, value: 'A++', format: 'SomeFormat'", formatted);
+        formatted.Should().Be("Unit Test Formatter, value: 'A++', format: 'SomeFormat'");
     }
 
     [TestCase(null, "A++", "A++")]
@@ -507,7 +507,7 @@ public class Supports_XML_serialization
     public void has_no_custom_XML_schema()
     {
         IXmlSerializable obj = Svo.EnergyLabel;
-        Assert.IsNull(obj.GetSchema());
+        obj.GetSchema().Should().BeNull();
     }
 }
 

--- a/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
+++ b/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
@@ -1,9 +1,19 @@
 ﻿using Qowaiv.Sustainability;
 
-namespace EnergyLabel_specs;
+namespace Energy_label_specs;
 
 public class With_domain_logic
 {
+    [TestCase(true, "A++")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, EnergyLabel svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "A++")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, EnergyLabel svo) => svo.IsKnown.Should().Be(result);
+
     [TestCase(false, "A++")]
     [TestCase(false, "?")]
     [TestCase(true, "")]

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -2,6 +2,10 @@
 
 public class With_domain_logic
 {
+    [TestCase(true, "Qowaiv_SVOLibrary_GUIA")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, Uuid svo) => svo.HasValue.Should().Be(result);
+
     [TestCase(false, "Qowaiv_SVOLibrary_GUIA")]
     [TestCase(true, "")]
     public void IsEmpty_returns(bool result, Uuid svo)

--- a/specs/Qowaiv.Specs/Web/InternetMediaType_specs.cs
+++ b/specs/Qowaiv.Specs/Web/InternetMediaType_specs.cs
@@ -1,5 +1,18 @@
 ﻿namespace Web.InternetMediaType_specs;
 
+public class With_domain_logic
+{
+    [TestCase(true, "application/x-chess-pgn")]
+    [TestCase(true, "application/octet-stream")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, InternetMediaType svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "application/x-chess-pgn")]
+    [TestCase(false, "application/octet-stream")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, InternetMediaType svo) => svo.IsKnown.Should().Be(result);
+}
+
 public class Supports_type_conversion
 {
     [Test]

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -2,6 +2,16 @@
 
 public class With_domain_logic
 {
+    [TestCase(true, 1979)]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, Year svo) => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, 1979)]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsKnown_is(bool result, Year svo) => svo.IsKnown.Should().Be(result);
+
     [TestCase(false, 1979)]
     [TestCase(false, "?")]
     [TestCase(true, "")]

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -2,61 +2,56 @@ namespace YesNo_specs;
 
 public class With_domain_logic
 {
-    [TestCase(false, "yes")]
-    [TestCase(false, "no")]
-    [TestCase(false, "?")]
-    [TestCase(true, "")]
-    public void IsEmpty_returns(bool result, YesNo svo)
-    {
-        Assert.AreEqual(result, svo.IsEmpty());
-    }
-
-    [TestCase(false, "yes")]
-    [TestCase(false, "no")]
-    [TestCase(true, "?")]
-    [TestCase(true, "")]
-    public void IsEmptyOrUnknown_returns(bool result, YesNo svo)
-    {
-        Assert.AreEqual(result, svo.IsEmptyOrUnknown());
-    }
-
-    [TestCase(false, "yes")]
-    [TestCase(false, "no")]
+    [TestCase(true, "yes")]
+    [TestCase(true, "no")]
     [TestCase(true, "?")]
     [TestCase(false, "")]
-    public void IsUnknown_returns(bool result, YesNo svo)
-    {
-        Assert.AreEqual(result, svo.IsUnknown());
-    }
+    public void HasValue_is(bool result, YesNo svo) => svo.HasValue.Should().Be(result);
 
     [TestCase(true, "yes")]
     [TestCase(true, "no")]
     [TestCase(false, "?")]
     [TestCase(false, "")]
-    public void IsYesOrNo_returns(bool result, YesNo svo)
-    {
-        Assert.AreEqual(result, svo.IsYesOrNo());
-    }
+    public void IsKnown_is(bool result, YesNo svo) => svo.IsKnown.Should().Be(result);
+
+    [TestCase(false, "yes")]
+    [TestCase(false, "no")]
+    [TestCase(false, "?")]
+    [TestCase(true, "")]
+    public void IsEmpty_returns(bool result, YesNo svo) => svo.IsEmpty().Should().Be(result);
+
+    [TestCase(false, "yes")]
+    [TestCase(false, "no")]
+    [TestCase(true, "?")]
+    [TestCase(true, "")]
+    public void IsEmptyOrUnknown_returns(bool result, YesNo svo) => svo.IsEmptyOrUnknown().Should().Be(result);
+
+    [TestCase(false, "yes")]
+    [TestCase(false, "no")]
+    [TestCase(true, "?")]
+    [TestCase(false, "")]
+    public void IsUnknown_returns(bool result, YesNo svo) => svo.IsUnknown().Should().Be(result);
+
+    [TestCase(true, "yes")]
+    [TestCase(true, "no")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsYesOrNo_returns(bool result, YesNo svo) => svo.IsYesOrNo().Should().Be(result);
+
 
     [TestCase(false, "")]
     [TestCase(false, "N")]
     [TestCase(true, "Y")]
     [TestCase(false, "?")]
 
-    public void IsYes_returns(bool result, YesNo svo)
-    {
-        Assert.AreEqual(result, svo.IsYes());
-    }
+    public void IsYes_returns(bool result, YesNo svo) => svo.IsYes().Should().Be(result);
 
     [TestCase(false, "")]
     [TestCase(true, "N")]
     [TestCase(false, "Y")]
     [TestCase(false, "?")]
 
-    public void IsNo_returns(bool result, YesNo svo)
-    {
-        Assert.AreEqual(result, svo.IsNo());
-    }
+    public void IsNo_returns(bool result, YesNo svo) => svo.IsNo().Should().Be(result);
 }
 
 public class Is_valid_for

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -16,8 +16,8 @@ public partial struct Timestamp
     private Timestamp(ulong value) => m_Value = value;
 
     /// <summary>The inner value of the timestamp.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly ulong m_Value;
-
 }
 
 public partial struct Timestamp : IEquatable<Timestamp>

--- a/src/Qowaiv/Customization/Svo.cs
+++ b/src/Qowaiv/Customization/Svo.cs
@@ -56,6 +56,14 @@ public readonly struct Svo<TSvoBehavior> : ISerializable, IXmlSerializable, IFor
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string? m_Value;
 
+    /// <summary>Returns true if the Single Value Object is set.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value is { };
+
+    /// <summary>False if theSingle Value Object is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value is { } && m_Value != SvoBehavior.unknown;
+
     /// <summary>Returns true if the Single Value Object is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -16,14 +16,25 @@ public partial struct CasRegistryNumber
     private CasRegistryNumber(long value) => m_Value = value;
 
     /// <summary>The inner value of the CAS Registry Number.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly long m_Value;
+
+    /// <summary>False if the CAS Registry Number is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the CAS Registry Number is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the CAS Registry Number is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the CAS Registry Number is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the CAS Registry Number is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -16,8 +16,8 @@ public partial struct DateSpan
     private DateSpan(ulong value) => m_Value = value;
 
     /// <summary>The inner value of the date span.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly ulong m_Value;
-
 }
 
 public partial struct DateSpan : IEquatable<DateSpan>

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -16,14 +16,25 @@ public partial struct EmailAddress
     private EmailAddress(string? value) => m_Value = value;
 
     /// <summary>The inner value of the email address.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string? m_Value;
+
+    /// <summary>False if the email address is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the email address is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the email address is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the email address is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the email address is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -16,8 +16,8 @@ public partial struct Amount
     private Amount(decimal value) => m_Value = value;
 
     /// <summary>The inner value of the amount.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly decimal m_Value;
-
 }
 
 public partial struct Amount : IEquatable<Amount>

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -16,14 +16,25 @@ public partial struct BusinessIdentifierCode
     private BusinessIdentifierCode(string? value) => m_Value = value;
 
     /// <summary>The inner value of the BIC.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string? m_Value;
+
+    /// <summary>False if the BIC is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the BIC is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the BIC is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the BIC is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the BIC is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -16,14 +16,25 @@ public partial struct Currency
     private Currency(string? value) => m_Value = value;
 
     /// <summary>The inner value of the currency.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string? m_Value;
+
+    /// <summary>False if the currency is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the currency is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the currency is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the currency is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the currency is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -16,14 +16,25 @@ public partial struct InternationalBankAccountNumber
     private InternationalBankAccountNumber(string? value) => m_Value = value;
 
     /// <summary>The inner value of the IBAN.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string? m_Value;
+
+    /// <summary>False if the IBAN is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the IBAN is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the IBAN is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the IBAN is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the IBAN is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -16,14 +16,25 @@ public partial struct Gender
     private Gender(byte value) => m_Value = value;
 
     /// <summary>The inner value of the gender.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly byte m_Value;
+
+    /// <summary>False if the gender is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the gender is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the gender is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the gender is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the gender is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -16,14 +16,25 @@ public partial struct Country
     private Country(string? value) => m_Value = value;
 
     /// <summary>The inner value of the country.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string? m_Value;
+
+    /// <summary>False if the country is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the country is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the country is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the country is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the country is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -16,14 +16,25 @@ public partial struct HouseNumber
     private HouseNumber(int value) => m_Value = value;
 
     /// <summary>The inner value of the house number.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly int m_Value;
+
+    /// <summary>False if the house number is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the house number is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the house number is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the house number is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the house number is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -16,14 +16,25 @@ public partial struct Month
     private Month(byte value) => m_Value = value;
 
     /// <summary>The inner value of the month.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly byte m_Value;
+
+    /// <summary>False if the month is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the month is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the month is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the month is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the month is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -16,8 +16,8 @@ public partial struct MonthSpan
     private MonthSpan(int value) => m_Value = value;
 
     /// <summary>The inner value of the month span.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly int m_Value;
-
 }
 
 public partial struct MonthSpan : IEquatable<MonthSpan>

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -16,8 +16,8 @@ public partial struct Percentage
     private Percentage(decimal value) => m_Value = value;
 
     /// <summary>The inner value of the percentage.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly decimal m_Value;
-
 }
 
 public partial struct Percentage : IEquatable<Percentage>

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -16,14 +16,25 @@ public partial struct PostalCode
     private PostalCode(string? value) => m_Value = value;
 
     /// <summary>The inner value of the postal code.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string? m_Value;
+
+    /// <summary>False if the postal code is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the postal code is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the postal code is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the postal code is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the postal code is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -16,14 +16,25 @@ public partial struct Sex
     private Sex(byte value) => m_Value = value;
 
     /// <summary>The inner value of the sex.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly byte m_Value;
+
+    /// <summary>False if the sex is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the sex is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the sex is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the sex is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the sex is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -16,8 +16,8 @@ public partial struct Elo
     private Elo(double value) => m_Value = value;
 
     /// <summary>The inner value of the elo.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly double m_Value;
-
 }
 
 public partial struct Elo : IEquatable<Elo>

--- a/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
+++ b/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
@@ -16,14 +16,25 @@ public partial struct EnergyLabel
     private EnergyLabel(int value) => m_Value = value;
 
     /// <summary>The inner value of the EU energy label.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly int m_Value;
+
+    /// <summary>False if the EU energy label is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the EU energy label is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the EU energy label is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the EU energy label is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the EU energy label is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();
@@ -227,3 +238,28 @@ public partial struct EnergyLabel
     public static bool TryParse(string? s, out EnergyLabel result) => TryParse(s, null, out result);
 }
 
+public partial struct EnergyLabel
+{
+    /// <summary>Returns true if the value represents a valid EU energy label.</summary>
+    /// <param name="val">
+    /// The <see cref="string"/> to validate.
+    /// </param>
+    [Pure]
+    [ExcludeFromCodeCoverage]
+    [Obsolete("Use EnergyLabel.TryParse(str) is { } instead. Will be dropped when the next major version is released.")]
+    public static bool IsValid(string? val) => IsValid(val, (IFormatProvider?)null);
+
+    /// <summary>Returns true if the value represents a valid EU energy label.</summary>
+    /// <param name="val">
+    /// The <see cref="string"/> to validate.
+    /// </param>
+    /// <param name="formatProvider">
+    /// The <see cref="IFormatProvider"/> to interpret the <see cref="string"/> value with.
+    /// </param>
+    [Pure]
+    [ExcludeFromCodeCoverage]
+    [Obsolete("Use EnergyLabel.TryParse(str, formatProvider) is { } instead. Will be dropped when the next major version is released.")]
+    public static bool IsValid(string? val, IFormatProvider? formatProvider)
+        => !string.IsNullOrWhiteSpace(val)
+        && TryParse(val, formatProvider, out _);
+}

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -16,7 +16,12 @@ public partial struct Uuid
     private Uuid(Guid value) => m_Value = value;
 
     /// <summary>The inner value of the UUID.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly Guid m_Value;
+
+    /// <summary>False if the UUID is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
 
     /// <summary>Returns true if the UUID is empty, otherwise false.</summary>
     [Pure]

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -16,14 +16,25 @@ public partial struct InternetMediaType
     private InternetMediaType(string? value) => m_Value = value;
 
     /// <summary>The inner value of the Internet media type.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string? m_Value;
+
+    /// <summary>False if the Internet media type is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the Internet media type is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the Internet media type is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the Internet media type is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the Internet media type is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -16,14 +16,25 @@ public partial struct Year
     private Year(short value) => m_Value = value;
 
     /// <summary>The inner value of the year.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly short m_Value;
+
+    /// <summary>False if the year is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the year is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the year is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the year is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the year is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -16,14 +16,25 @@ public partial struct YesNo
     private YesNo(byte value) => m_Value = value;
 
     /// <summary>The inner value of the yes-no.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly byte m_Value;
+
+    /// <summary>False if the yes-no is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+
+    /// <summary>False if the yes-no is empty or unknown, otherwise false.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
     /// <summary>Returns true if the yes-no is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
+
     /// <summary>Returns true if the yes-no is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
+
     /// <summary>Returns true if the yes-no is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -43,7 +43,12 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     }
 
     /// <summary>The inner value of the identifier.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly object? m_Value;
+
+    /// <summary>False if the identifier is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => !IsEmpty();
 
     /// <summary>Returns true if the identifier is empty, otherwise false.</summary>
     [Pure]

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,9 +5,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.4.4</Version>
+    <Version>6.5.0</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
+v6.5.0
+- Introduction of HasValue and IsKnown for non-continuous SVO's. #327
 v6.4.4
 - Introduction of EnergyLabel. #324
 v6.4.3

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -18,6 +18,10 @@ public readonly struct CryptographicSeed : IEquatable<CryptographicSeed>
 
     private CryptographicSeed(byte[] value) => m_Value = value;
 
+    /// <summary>Returns true if the cryptographic seed is set.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value is { };
+
     /// <summary>Returns true if the cryptographic seed is empty/not set.</summary>
     [Pure]
     public bool IsEmpty() => m_Value is null;

--- a/src/Qowaiv/Security/Secret.cs
+++ b/src/Qowaiv/Security/Secret.cs
@@ -20,6 +20,10 @@ public readonly struct Secret : IEquatable<Secret>
 
     private Secret(string value) => m_Value = value;
 
+    /// <summary>Returns true if the secret is set.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value is { };
+
     /// <summary>Returns true if the secret is empty/not set.</summary>
     [Pure]
     public bool IsEmpty() => m_Value is null;


### PR DESCRIPTION
When Qowaiv started, it was a considered decision to make `.IsEmpty()` ,`.IsUnknown()`, and `.IsEmptyOrUnknown()` methods, rather then properties of the SVO's. After all, they are only partly related to those SVO domains.

That being said, with the introduction of [#C pattern matching](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/pattern-matching) it would be nice to check for those states via properties, in one way, or another.

To allow pattern matching, and not to change those long lived methods, this is the proposal:

- `.HasValue` as the functional equivalent of `!IsEmpty()`
- `.IsKnown` as the functional equivalent of `!IsEmptyOrUnknown()` 

This can be used like this:

``` C#
if (EmailAddress.TryParse(str) is { IsKnown: true } email(
{
    ...
}
```
 
 and obviously other pattern matching scenario's. 