### PR TITLE
Make JSON ID converters thread-safe

### DIFF
--- a/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
+++ b/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
@@ -1,6 +1,7 @@
 ﻿#if NET5_0_OR_GREATER
 
 using Qowaiv.Identifiers;
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -103,8 +104,8 @@ public sealed class IdJsonConverter : JsonConverterFactory
         return parser.Invoke(null, new object?[] { number })!;
     }
 
-    private static readonly Dictionary<Type, MethodInfo> stringParsers = new();
-    private static readonly Dictionary<Type, MethodInfo> int64Parsers = new();
+    private static readonly ConcurrentDictionary<Type, MethodInfo> stringParsers = new();
+    private static readonly ConcurrentDictionary<Type, MethodInfo> int64Parsers = new();
 }
 
 #endif

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,9 +5,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
+v6.5.1
+- Make JSON ID converters thread-safe. #330
 v6.5.0
 - Introduction of HasValue and IsKnown for non-continuous SVO's. #327
 v6.4.4


### PR DESCRIPTION
Although rare, conversion can fail when (initially) called (and then added) for multiple threads. See: #329