### PR TITLE
Supports nested types with generic type definitions.

### DIFF
--- a/specs/Qowaiv.Specs/Extensions/Type_specs.cs
+++ b/specs/Qowaiv.Specs/Extensions/Type_specs.cs
@@ -28,6 +28,8 @@ public class CSharpString
 
     [TestCase(typeof(Nullable<>), "Nullable<>")]
     [TestCase(typeof(Dictionary<,>), "Dictionary<,>")]
+    [TestCase(typeof(GenericBase<>.NestedType), "GenericBase<>.NestedType")]
+    [TestCase(typeof(Nested0<>.Nested1<>.Nested2<>), "Nested0<>.Nested1<>.Nested2<>")]
     public void Supports_generic_type_definitions(Type definition, string csharpString)
         => definition.ToCSharpString().Should().Be(csharpString);
 
@@ -41,6 +43,7 @@ public class CSharpString
     [TestCase(typeof(GenericBase<int>.NestedType), "GenericBase<int>.NestedType")]
     [TestCase(typeof(GenericBase<int>.GenericNested<long>), "GenericBase<int>.GenericNested<long>")]
     [TestCase(typeof(Nested0<int>.Nested1<long>.Nested2<bool>), "Nested0<int>.Nested1<long>.Nested2<bool>")]
+    [TestCase(typeof(Nested0<int>.Nested1<long>.Nested2<bool>.Nested3<string, char>), "Nested0<int>.Nested1<long>.Nested2<bool>.Nested3<string, char>")]
     [TestCase(typeof(NonGenericBase.GenericNested<int>), "NonGenericBase.GenericNested<int>")]
     public void Supports_nested_types(Type nestedType, string csharpString)
         => nestedType.ToCSharpString().Should().Be(csharpString);
@@ -97,6 +100,12 @@ internal class Nested0<T0>
         internal class Nested2<T2>
         {
             public T2? Model { get; set; }
+
+            internal class Nested3<T3, T4>
+            {
+                public T3? First { get; set; }
+                public T4? Second { get; set; }
+            }
         }
     }
 }

--- a/specs/Qowaiv.Specs/Extensions/Type_specs.cs
+++ b/specs/Qowaiv.Specs/Extensions/Type_specs.cs
@@ -45,6 +45,7 @@ public class CSharpString
     [TestCase(typeof(Nested0<int>.Nested1<long>.Nested2<bool>), "Nested0<int>.Nested1<long>.Nested2<bool>")]
     [TestCase(typeof(Nested0<int>.Nested1<long>.Nested2<bool>.Nested3<string, char>), "Nested0<int>.Nested1<long>.Nested2<bool>.Nested3<string, char>")]
     [TestCase(typeof(NonGenericBase.GenericNested<int>), "NonGenericBase.GenericNested<int>")]
+    [TestCase(typeof(GenericBase<NonGenericBase.GenericNested<int>>.NestedType), "GenericBase<NonGenericBase.GenericNested<int>>.NestedType")]
     public void Supports_nested_types(Type nestedType, string csharpString)
         => nestedType.ToCSharpString().Should().Be(csharpString);
 

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,7 +9,7 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 v6.5.3
-- ToCShaprString() supported nested types with generic type definitions. #333
+- ToCShaprString() supports nested types with generic type definitions. #333
 v6.5.2
 - ToCSharpString() supports nested types with generics. #332
 v6.5.1

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,11 +5,13 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.5.2</Version>
+    <Version>6.5.3</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
+v6.5.3
+- ToCShaprString() supported nested types with generic type definitions. #333
 v6.5.2
-- ToCSharpString() should supported Nested types with generics. #332
+- ToCSharpString() supports nested types with generics. #332
 v6.5.1
 - Make JSON ID converters thread-safe. #330
 v6.5.0


### PR DESCRIPTION
In addtion to #332, `typeof(Microsoft.Extensions.Http.DefaultTypedHttpClientFactory<>.Cache).ToCSharpString()` should also not crash.