### PR TITLE
Add support for SVO's as property names

### DIFF
--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -362,9 +362,13 @@ public class Supports_JSON_serialization
     [Test]
     public void System_Text_JSON_serialization_of_dictionary_keys()
     {
-        var dictionary = new Dictionary<EmailAddress, int>() { [Svo.EmailAddress] = 42 };
+        var dictionary = new Dictionary<EmailAddress, int>()
+        {
+            [default] = 17,
+            [Svo.EmailAddress] = 42,
+        };
         System.Text.Json.JsonSerializer.Serialize(dictionary)
-            .Should().Be(@"{""info@qowaiv.org"":42}");
+            .Should().Be(@"{"""":17,""info@qowaiv.org"":42}");
     }
 #endif
 

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -348,6 +348,24 @@ public class Supports_JSON_serialization
     [TestCase("info@qowaiv.org", "info@qowaiv.org")]
     public void System_Text_JSON_serialization(object json, EmailAddress svo)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [Test]
+    public void System_Text_JSON_deserialization_of_dictionary_keys()
+    {
+        System.Text.Json.JsonSerializer.Deserialize<Dictionary<EmailAddress, int>>(@"{""info@qowaiv.org"":42}")
+            .Should().BeEquivalentTo(new Dictionary<EmailAddress, int>()
+            {
+                [Svo.EmailAddress] = 42,
+            });
+    }
+
+    [Test]
+    public void System_Text_JSON_serialization_of_dictionary_keys()
+    {
+        var dictionary = new Dictionary<EmailAddress, int>() { [Svo.EmailAddress] = 42 };
+        System.Text.Json.JsonSerializer.Serialize(dictionary)
+            .Should().Be(@"{""info@qowaiv.org"":42}");
+    }
 #endif
 
     [TestCase("?", "?")]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -118,9 +118,13 @@ public class Supports_JSON_serialization
     [Test]
     public void System_Text_JSON_serialization_of_dictionary_keys()
     {
-        var dictionary = new Dictionary<CustomGuid, int>() { [Svo.CustomGuid] = 42 };
+        var dictionary = new Dictionary<CustomGuid, int>() 
+        {
+            [default] = 17,
+            [Svo.CustomGuid] = 42,
+        };
         System.Text.Json.JsonSerializer.Serialize(dictionary)
-            .Should().Be(@"{""8a1a8c42-d2ff-e254-e26e-b6abcbf19420"":42}");
+            .Should().Be(@"{"""":17,""8a1a8c42-d2ff-e254-e26e-b6abcbf19420"":42}");
     }
 #endif
 }

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -102,6 +102,29 @@ public class Supports_type_conversion
         => Converting.To<Uuid>().From(Svo.CustomGuid).Should().Be(Svo.Uuid);
 }
 
+public class Supports_JSON_serialization
+{
+#if NET6_0_OR_GREATER
+    [Test]
+    public void System_Text_JSON_deserialization_of_dictionary_keys()
+    {
+        System.Text.Json.JsonSerializer.Deserialize<Dictionary<CustomGuid, int>>(@"{""8a1a8c42-d2ff-e254-e26e-b6abcbf19420"":42}")
+            .Should().BeEquivalentTo(new Dictionary<CustomGuid, int>() 
+            {
+                [Svo.CustomGuid] = 42,
+            });
+    }
+
+    [Test]
+    public void System_Text_JSON_serialization_of_dictionary_keys()
+    {
+        var dictionary = new Dictionary<CustomGuid, int>() { [Svo.CustomGuid] = 42 };
+        System.Text.Json.JsonSerializer.Serialize(dictionary)
+            .Should().Be(@"{""8a1a8c42-d2ff-e254-e26e-b6abcbf19420"":42}");
+    }
+#endif
+}
+
 public class Supports_binary_serialization
 {
     [Test]

--- a/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
+++ b/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
@@ -76,6 +76,18 @@ public sealed class IdJsonConverter : JsonConverterFactory
                 writer.WriteStringValue(obj.ToString());
             }
         }
+
+#if NET6_0_OR_GREATER
+
+        /// <inheritdoc />
+        public override Id<TBehavior> ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => Id<TBehavior>.FromJson(reader.GetString());
+
+        /// <inheritdoc />
+        public override void WriteAsPropertyName(Utf8JsonWriter writer, Id<TBehavior> value, JsonSerializerOptions options)
+            => writer.WritePropertyName(value.ToJson()?.ToString() ?? string.Empty);
+
+#endif
     }
 
     [Pure]

--- a/src/Qowaiv/Json/SvoJsonConverter.cs
+++ b/src/Qowaiv/Json/SvoJsonConverter.cs
@@ -82,6 +82,17 @@ public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo : 
         }
     }
 
+#if NET6_0_OR_GREATER
+
+    /// <inheritdoc />
+    public override TSvo ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => FromJson(reader.GetString());
+
+    /// <inheritdoc />
+    public override void WriteAsPropertyName(Utf8JsonWriter writer, TSvo value, JsonSerializerOptions options)
+        => writer.WritePropertyName(ToJson(value)?.ToString() ?? string.Empty);
+#endif
+
     /// <summary>Represent the SVO as a JSON node.</summary>
     [Pure]
     protected abstract object? ToJson(TSvo svo);

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,9 +5,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.5.3</Version>
+    <Version>6.5.4</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
+v6.5.4
+- SVO's can be used as keys when applying JSON serialization.
 v6.5.3
 - ToCShaprString() supports nested types with generic type definitions. #333
 v6.5.2

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,7 +9,7 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 v6.5.4
-- SVO's can be used as keys when applying JSON serialization.
+- SVO's can be used as keys when applying JSON serialization. #334
 v6.5.3
 - ToCShaprString() supports nested types with generic type definitions. #333
 v6.5.2


### PR DESCRIPTION
SVO's have meaning when using them as dictionary keys. Therefor, JSON serializing them as such should work.

See: #335.