### PR TITLE
Extend FormatException with detailed information for failed parsings

### DIFF
--- a/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
+++ b/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.*"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">

--- a/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
+++ b/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
@@ -158,15 +158,20 @@ public class Can_be_parsed
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Func<CasRegistryNumber> parse = () => CasRegistryNumber.Parse("invalid input");
-            parse.Should().Throw<FormatException>()
-                .WithMessage("Not a valid CAS Registry Number");
+            "not a CAS registry".Invoking(CasRegistryNumber.Parse)
+                .Should().Throw<FormatException>()
+                .WithMessage("Not a valid CAS Registry Number")
+                .And.InnerException.Should().BeEquivalentTo(new
+                {
+                    Type = "Qowaiv.Chemistry.CasRegistryNumber",
+                    Value = "not a CAS registry"
+                });
         }
     }
 
     [Test]
     public void from_valid_input_only_otherwise_return_false_on_TryParse()
-        => (CasRegistryNumber.TryParse("invalid input", out _)).Should().BeFalse();
+        => CasRegistryNumber.TryParse("invalid input", out _).Should().BeFalse();
 
     [Test]
     public void from_invalid_as_null_with_TryParse()

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -102,14 +102,15 @@ public class Supports_type_conversion
         => Converting.To<Uuid>().From(Svo.CustomGuid).Should().Be(Svo.Uuid);
 }
 
+#if NET6_0_OR_GREATER
+
 public class Supports_JSON_serialization
 {
-#if NET6_0_OR_GREATER
     [Test]
     public void System_Text_JSON_deserialization_of_dictionary_keys()
     {
         System.Text.Json.JsonSerializer.Deserialize<Dictionary<CustomGuid, int>>(@"{""8a1a8c42-d2ff-e254-e26e-b6abcbf19420"":42}")
-            .Should().BeEquivalentTo(new Dictionary<CustomGuid, int>() 
+            .Should().BeEquivalentTo(new Dictionary<CustomGuid, int>()
             {
                 [Svo.CustomGuid] = 42,
             });
@@ -118,7 +119,7 @@ public class Supports_JSON_serialization
     [Test]
     public void System_Text_JSON_serialization_of_dictionary_keys()
     {
-        var dictionary = new Dictionary<CustomGuid, int>() 
+        var dictionary = new Dictionary<CustomGuid, int>()
         {
             [default] = 17,
             [Svo.CustomGuid] = 42,
@@ -126,8 +127,8 @@ public class Supports_JSON_serialization
         System.Text.Json.JsonSerializer.Serialize(dictionary)
             .Should().Be(@"{"""":17,""8a1a8c42-d2ff-e254-e26e-b6abcbf19420"":42}");
     }
-#endif
 }
+#endif
 
 public class Supports_binary_serialization
 {

--- a/specs/Qowaiv.Specs/Text/Unparsable_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Unparsable_specs.cs
@@ -18,3 +18,17 @@ public class Communicates
             });
     }
 }
+
+public class Is_serializable
+{
+    internal static readonly Exception Exception = Unparsable.ForValue<int>("fourty-two", "Not a number,").InnerException!;
+
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void Binary()
+    {
+        var roundtrip = SerializeDeserialize.Binary(Exception);
+        roundtrip.Should().NotBeSameAs(Exception)
+            .And.Subject.Should().BeEquivalentTo(Exception);
+    }
+}

--- a/specs/Qowaiv.Specs/Text/Unparsable_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Unparsable_specs.cs
@@ -1,0 +1,20 @@
+﻿namespace Text.Unparsable_specs;
+
+public class Communicates
+{
+    [Test]
+    public void attempted_value_and_type()
+    {
+        using var _ = TestCultures.En_GB.Scoped();
+        
+        "no_guid".Invoking(CustomGuid.Parse)
+            .Should().Throw<FormatException>()
+            .WithMessage("Not a valid identifier.")
+            .And.InnerException.Should().BeOfType<Unparsable>()
+            .And.Subject.Should().BeEquivalentTo(new 
+            {
+                Value = "no_guid",
+                Type = "Qowaiv.Identifiers.Id<Qowaiv.TestTools.ForGuid>"
+            });
+    }
+}

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -191,7 +191,9 @@ public partial struct Timestamp
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Timestamp Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionTimestamp);
+    public static Timestamp Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Timestamp>(s, QowaivMessages.FormatExceptionTimestamp);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv.Data.SqlClient/Properties/GlobalUsings.cs
+++ b/src/Qowaiv.Data.SqlClient/Properties/GlobalUsings.cs
@@ -2,6 +2,7 @@
 global using Qowaiv.Formatting;
 global using Qowaiv.Hashing;
 global using Qowaiv.Json;
+global using Qowaiv.Text;
 global using System;
 global using System.Collections;
 global using System.Collections.Generic;

--- a/src/Qowaiv/EmailAddressCollection.cs
+++ b/src/Qowaiv/EmailAddressCollection.cs
@@ -312,13 +312,9 @@ public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSer
     /// </exception>
     [Pure]
     public static EmailAddressCollection Parse(string? s, IFormatProvider? formatProvider)
-    {
-        if (TryParse(s, formatProvider, out EmailAddressCollection val))
-        {
-            return val;
-        }
-        throw new FormatException(QowaivMessages.FormatExceptionEmailAddressCollection);
-    }
+        => TryParse(s, formatProvider, out EmailAddressCollection val)
+        ? val
+        : throw Unparsable.ForValue<EmailAddressCollection>(s, QowaivMessages.FormatExceptionEmailAddressCollection);
 
     /// <summary>Converts the string to an email address collection.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -23,7 +23,7 @@ public partial struct CasRegistryNumber
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the CAS Registry Number is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the CAS Registry Number is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct CasRegistryNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static CasRegistryNumber Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionCasRegistryNumber);
+    public static CasRegistryNumber Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<CasRegistryNumber>(s, QowaivMessages.FormatExceptionCasRegistryNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="CasRegistryNumber"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -182,7 +182,9 @@ public partial struct Date
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Date Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionDate);
+    public static Date Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Date>(s, QowaivMessages.FormatExceptionDate);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -177,7 +177,9 @@ public partial struct DateSpan
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static DateSpan Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionDateSpan);
+    public static DateSpan Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<DateSpan>(s, QowaivMessages.FormatExceptionDateSpan);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -23,7 +23,7 @@ public partial struct EmailAddress
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the email address is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the email address is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct EmailAddress
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static EmailAddress Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionEmailAddress);
+    public static EmailAddress Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<EmailAddress>(s, QowaivMessages.FormatExceptionEmailAddress);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -191,7 +191,9 @@ public partial struct Amount
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Amount Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionFinancialAmount);
+    public static Amount Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Amount>(s, QowaivMessages.FormatExceptionFinancialAmount);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -23,7 +23,7 @@ public partial struct BusinessIdentifierCode
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the BIC is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the BIC is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct BusinessIdentifierCode
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static BusinessIdentifierCode Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionBusinessIdentifierCode);
+    public static BusinessIdentifierCode Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<BusinessIdentifierCode>(s, QowaivMessages.FormatExceptionBusinessIdentifierCode);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -23,7 +23,7 @@ public partial struct Currency
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the currency is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the currency is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct Currency
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Currency Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionCurrency);
+    public static Currency Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Currency>(s, QowaivMessages.FormatExceptionCurrency);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -23,7 +23,7 @@ public partial struct InternationalBankAccountNumber
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the IBAN is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the IBAN is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct InternationalBankAccountNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static InternationalBankAccountNumber Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionInternationalBankAccountNumber);
+    public static InternationalBankAccountNumber Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<InternationalBankAccountNumber>(s, QowaivMessages.FormatExceptionInternationalBankAccountNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -150,7 +150,9 @@ public partial struct Money
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Money Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionMoney);
+    public static Money Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Money>(s, QowaivMessages.FormatExceptionMoney);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -23,7 +23,7 @@ public partial struct Gender
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the gender is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the gender is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct Gender
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Gender Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionGender);
+    public static Gender Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Gender>(s, QowaivMessages.FormatExceptionGender);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Gender"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -23,7 +23,7 @@ public partial struct Country
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the country is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the country is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct Country
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Country Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionCountry);
+    public static Country Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Country>(s, QowaivMessages.FormatExceptionCountry);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -23,7 +23,7 @@ public partial struct HouseNumber
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the house number is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the house number is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -211,7 +211,9 @@ public partial struct HouseNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static HouseNumber Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionHouseNumber);
+    public static HouseNumber Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<HouseNumber>(s, QowaivMessages.FormatExceptionHouseNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -161,7 +161,9 @@ public partial struct StreamSize
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static StreamSize Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionStreamSize);
+    public static StreamSize Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<StreamSize>(s, QowaivMessages.FormatExceptionStreamSize);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -182,7 +182,9 @@ public partial struct LocalDateTime
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static LocalDateTime Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionLocalDateTime);
+    public static LocalDateTime Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<LocalDateTime>(s, QowaivMessages.FormatExceptionLocalDateTime);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -150,7 +150,9 @@ public partial struct Fraction
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Fraction Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionFraction);
+    public static Fraction Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Fraction>(s, QowaivMessages.FormatExceptionFraction);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -23,7 +23,7 @@ public partial struct Month
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the month is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the month is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct Month
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Month Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionMonth);
+    public static Month Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Month>(s, QowaivMessages.FormatExceptionMonth);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -191,7 +191,9 @@ public partial struct MonthSpan
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static MonthSpan Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionMonthSpan);
+    public static MonthSpan Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<MonthSpan>(s, QowaivMessages.FormatExceptionMonthSpan);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -191,7 +191,9 @@ public partial struct Percentage
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Percentage Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionPercentage);
+    public static Percentage Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Percentage>(s, QowaivMessages.FormatExceptionPercentage);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -23,7 +23,7 @@ public partial struct PostalCode
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the postal code is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the postal code is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct PostalCode
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static PostalCode Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionPostalCode);
+    public static PostalCode Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<PostalCode>(s, QowaivMessages.FormatExceptionPostalCode);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -23,7 +23,7 @@ public partial struct Sex
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the sex is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the sex is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct Sex
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Sex Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionSex);
+    public static Sex Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Sex>(s, QowaivMessages.FormatExceptionSex);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -191,7 +191,9 @@ public partial struct Elo
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Elo Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionElo);
+    public static Elo Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Elo>(s, QowaivMessages.FormatExceptionElo);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
+++ b/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
@@ -23,7 +23,7 @@ public partial struct EnergyLabel
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the EU energy label is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the EU energy label is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct EnergyLabel
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static EnergyLabel Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionEnergyLabel);
+    public static EnergyLabel Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<EnergyLabel>(s, QowaivMessages.FormatExceptionEnergyLabel);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EnergyLabel"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -185,7 +185,9 @@ public partial struct Uuid
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Uuid Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionUuid);
+    public static Uuid Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Uuid>(s, QowaivMessages.FormatExceptionUuid);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -23,7 +23,7 @@ public partial struct InternetMediaType
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the Internet media type is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the Internet media type is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct InternetMediaType
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static InternetMediaType Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionInternetMediaType);
+    public static InternetMediaType Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<InternetMediaType>(s, QowaivMessages.FormatExceptionInternetMediaType);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -164,7 +164,9 @@ public partial struct WeekDate
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static WeekDate Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionWeekDate);
+    public static WeekDate Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<WeekDate>(s, QowaivMessages.FormatExceptionWeekDate);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -23,7 +23,7 @@ public partial struct Year
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the year is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the year is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct Year
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Year Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionYear);
+    public static Year Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<Year>(s, QowaivMessages.FormatExceptionYear);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -23,7 +23,7 @@ public partial struct YesNo
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool HasValue => m_Value != default;
 
-    /// <summary>False if the yes-no is empty or unknown, otherwise false.</summary>
+    /// <summary>False if the yes-no is empty or unknown, otherwise true.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
 
@@ -197,7 +197,9 @@ public partial struct YesNo
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static YesNo Parse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider) ?? throw new FormatException(QowaivMessages.FormatExceptionYesNo);
+    public static YesNo Parse(string? s, IFormatProvider? formatProvider) 
+        => TryParse(s, formatProvider) 
+        ?? throw Unparsable.ForValue<YesNo>(s, QowaivMessages.FormatExceptionYesNo);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -245,11 +245,9 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     /// </exception>
     [Pure]
     public static Id<TIdentifier> Parse(string? s)
-    {
-        return TryParse(s, out Id<TIdentifier> val)
-            ? val
-            : throw new FormatException();
-    }
+        => TryParse(s, out Id<TIdentifier> val)
+        ? val
+        : throw Unparsable.ForValue<Id<TIdentifier>>(s, "Not a valid identifier.");
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Id{TIdentifier}"/>.</summary>
     /// <param name="s">

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -8,6 +8,8 @@
     <Version>6.5.4</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
+ToBeReleased
+- Detailed information on failing parsing.
 v6.5.4
 - SVO's can be used as keys when applying JSON serialization. #334
 v6.5.3

--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -635,5 +635,14 @@ namespace Qowaiv {
                 return ResourceManager.GetString("OverflowException_Fraction", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not parse &apos;{0}&apos; for {1}..
+        /// </summary>
+        public static string Unparsable {
+            get {
+                return ResourceManager.GetString("Unparsable", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -201,4 +201,7 @@
   <data name="OverflowException_Fraction" xml:space="preserve">
     <value>Value was either too large or too small for a Fraction.</value>
   </data>
+  <data name="Unparsable" xml:space="preserve">
+    <value>Could not parse '{0}' for {1}.</value>
+  </data>
 </root>

--- a/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
+++ b/src/Qowaiv/Security/Cryptography/CryptographicSeed.cs
@@ -87,7 +87,7 @@ public readonly struct CryptographicSeed : IEquatable<CryptographicSeed>
     public static CryptographicSeed Parse(string? str)
         => TryParse(str, out var seed)
         ? seed
-        : throw new FormatException(QowaivMessages.FormatExceptionCryptographicSeed);
+        : throw Unparsable.ForValue<CryptographicSeed>(str, QowaivMessages.FormatExceptionCryptographicSeed);
 
     /// <summary>Converts the string to a cryptographic seed.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Text/Base32.cs
+++ b/src/Qowaiv/Text/Base32.cs
@@ -99,7 +99,7 @@ public static class Base32
         {
             return bytes;
         }
-        throw new FormatException(QowaivMessages.FormatExceptionBase32);
+        throw Unparsable.ForValue(s, QowaivMessages.FormatExceptionBase32, typeof(Base32));
     }
 
     /// <summary>Tries to get the corresponding bytes of the Base32 string.</summary>

--- a/src/Qowaiv/Text/Unparsable.cs
+++ b/src/Qowaiv/Text/Unparsable.cs
@@ -1,0 +1,56 @@
+﻿namespace Qowaiv.Text;
+
+/// <summary>The exception that is thrown when a value could not be parsed.</summary>
+/// <remarks>
+/// This child type allows to specify the string value and the target type involved.
+/// </remarks>
+public class Unparsable : FormatException
+{
+    /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
+    public Unparsable() { }
+
+    /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
+    public Unparsable(string? message) : base(message) { }
+
+    /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
+    public Unparsable(string? message, Exception? innerException) : base(message, innerException) { }
+
+    /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
+    protected Unparsable(SerializationInfo info, StreamingContext context) : base(info, context) 
+    {
+        Type = info.GetString(nameof(Type));
+        Value = info.GetString(nameof(Value));
+    }
+
+    /// <inheritdoc />
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        base.GetObjectData(info, context);
+        info.AddValue(nameof(Type), Type);
+        info.AddValue(nameof(Value), Value);
+    }
+
+    /// <summary>The target type.</summary>
+    public string? Type { get; init; }
+
+    /// <summary>The value that could not be parsed.</summary>
+    public string? Value { get; init; }
+
+    /// <summary>Creates an <see cref="Unparsable"/> </summary>
+    /// <typeparam name="TTarget">
+    /// The target type.
+    /// </typeparam>
+    /// <param name="value">
+    /// The string value to parse.
+    /// </param>
+    /// <param name="message">
+    /// The exception message.
+    /// </param>
+    [Pure]
+    public static Unparsable ForValue<TTarget>(string? value, string message)
+        => new(message)
+        {
+            Type = typeof(TTarget).ToCSharpString(),
+            Value = value,
+        };
+}

--- a/src/Qowaiv/Text/Unparsable.cs
+++ b/src/Qowaiv/Text/Unparsable.cs
@@ -48,11 +48,16 @@ public class Unparsable : FormatException
     /// </param>
     [Pure]
     public static FormatException ForValue<TTarget>(string? value, string message)
+        => ForValue(value, message, typeof(TTarget));
+
+    /// <summary>Creates an <see cref="Unparsable"/> </summary>
+    [Pure]
+    internal static FormatException ForValue(string? value, string message, Type type)
     {
-        var type = typeof(TTarget).ToCSharpString(withNamespace: true);
-        var inner = new Unparsable(string.Format(QowaivMessages.Unparsable, value, type))
+        var typed = type.ToCSharpString(withNamespace: true);
+        var inner = new Unparsable(string.Format(QowaivMessages.Unparsable, value, typed))
         {
-            Type = type ,
+            Type = typed,
             Value = value,
         };
 

--- a/src/Qowaiv/Text/Unparsable.cs
+++ b/src/Qowaiv/Text/Unparsable.cs
@@ -16,7 +16,7 @@ public class Unparsable : FormatException
     public Unparsable(string? message, Exception? innerException) : base(message, innerException) { }
 
     /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
-    protected Unparsable(SerializationInfo info, StreamingContext context) : base(info, context) 
+    protected Unparsable(SerializationInfo info, StreamingContext context) : base(info, context)
     {
         Type = info.GetString(nameof(Type));
         Value = info.GetString(nameof(Value));
@@ -47,10 +47,15 @@ public class Unparsable : FormatException
     /// The exception message.
     /// </param>
     [Pure]
-    public static Unparsable ForValue<TTarget>(string? value, string message)
-        => new(message)
+    public static FormatException ForValue<TTarget>(string? value, string message)
+    {
+        var type = typeof(TTarget).ToCSharpString(withNamespace: true);
+        var inner = new Unparsable(string.Format(QowaivMessages.Unparsable, value, type))
         {
-            Type = typeof(TTarget).ToCSharpString(),
+            Type = type ,
             Value = value,
         };
+
+        return new(message, inner);
+    }
 }

--- a/src/Qowaiv/Text/Unparsable.cs
+++ b/src/Qowaiv/Text/Unparsable.cs
@@ -4,20 +4,24 @@
 /// <remarks>
 /// This child type allows to specify the string value and the target type involved.
 /// </remarks>
+[Serializable]
 public class Unparsable : FormatException
 {
     /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
+    [ExcludeFromCodeCoverage/* Justification = Required for extensibility. */]
     public Unparsable() { }
 
     /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
     public Unparsable(string? message) : base(message) { }
 
-    /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
+    [ExcludeFromCodeCoverage/* Justification = Required for extensibility. */]
     public Unparsable(string? message, Exception? innerException) : base(message, innerException) { }
 
     /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
     protected Unparsable(SerializationInfo info, StreamingContext context) : base(info, context)
     {
+        Guard.NotNull(info);
+
         Type = info.GetString(nameof(Type));
         Value = info.GetString(nameof(Value));
     }
@@ -25,6 +29,8 @@ public class Unparsable : FormatException
     /// <inheritdoc />
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
+        Guard.NotNull(info);
+
         base.GetObjectData(info, context);
         info.AddValue(nameof(Type), Type);
         info.AddValue(nameof(Value), Value);

--- a/src/Qowaiv/Text/Unparsable.cs
+++ b/src/Qowaiv/Text/Unparsable.cs
@@ -14,6 +14,7 @@ public class Unparsable : FormatException
     /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
     public Unparsable(string? message) : base(message) { }
 
+    /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
     [ExcludeFromCodeCoverage/* Justification = Required for extensibility. */]
     public Unparsable(string? message, Exception? innerException) : base(message, innerException) { }
 
@@ -42,7 +43,7 @@ public class Unparsable : FormatException
     /// <summary>The value that could not be parsed.</summary>
     public string? Value { get; init; }
 
-    /// <summary>Creates an <see cref="Unparsable"/> </summary>
+    /// <summary>Creates an <see cref="Unparsable"/>.</summary>
     /// <typeparam name="TTarget">
     /// The target type.
     /// </typeparam>
@@ -56,7 +57,7 @@ public class Unparsable : FormatException
     public static FormatException ForValue<TTarget>(string? value, string message)
         => ForValue(value, message, typeof(TTarget));
 
-    /// <summary>Creates an <see cref="Unparsable"/> </summary>
+    /// <summary>Creates an <see cref="Unparsable"/>.</summary>
     [Pure]
     internal static FormatException ForValue(string? value, string message, Type type)
     {


### PR DESCRIPTION
When parsing fails, it might be useful to have detailed information on which string value could not be parsed to which type. The latter is particularly useful when applied to generics such as `Id<T>` .

To prevent different exceptions being thrown, and messages changes, this is solved with adding an inner exception that contains this extra information. By doing so, the `ToString()` of the exception is extended with this information, but the default message and type are kept the same.