### PR TITLE
Add .NET 8.0 compilation

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '7.0.x'
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '8.0.x'
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,14 +10,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Setup .NET 7.0
+      - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "7.0.x"
+          dotnet-version: "8.0.x"
       - name: Generate coverage report
-        run: dotnet test ./specs/Qowaiv.Specs -f net7.0 /p:CollectCoverage=true /p:ThresholdType=branch /p:CoverletOutputFormat=lcov
+        run: dotnet test ./specs/Qowaiv.Specs -f net8.0 /p:CollectCoverage=true /p:ThresholdType=branch /p:CoverletOutputFormat=lcov
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./specs/Qowaiv.Specs/coverage.net7.0.info
+          path-to-lcov: ./specs/Qowaiv.Specs/coverage.net8.0.info

--- a/Qowaiv.sln
+++ b/Qowaiv.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		dictionary.dic = dictionary.dic
 		LICENSE.txt = LICENSE.txt
 		README.Custom.SVO.md = README.Custom.SVO.md
 		README.md = README.md

--- a/dictionary.dic
+++ b/dictionary.dic
@@ -29,6 +29,7 @@ mille
 Mongo
 namespace
 namespaces
+NL
 nr
 nullable
 nullables
@@ -51,6 +52,7 @@ tebibyte
 tebibytes
 terabyte
 terabytes
+unparsable
 UTC
 UUID
 wildcard

--- a/props/common.props
+++ b/props/common.props
@@ -37,7 +37,7 @@
     </PackageTags>
     <Company>Qowaiv community</Company>
     <Copyright>Copyright © Qowaiv community 2013-current</Copyright>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <!-- We ship package versions for obsolete target frameworks too -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>

--- a/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
+++ b/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
@@ -461,6 +461,8 @@ public class Is_Open_API_data_type
         => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(CasRegistryNumber))!.Matches(input).Should().BeTrue();
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -478,6 +480,7 @@ public class Supports_binary_serialization
         info.GetInt64("Value").Should().Be(10028_14_5L);
     }
 }
+#endif
 
 public class Debugger
 {

--- a/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
@@ -371,7 +371,7 @@ public class Supports_JSON_serialization
     [TestCase("QOWAIV", "QOWAIV")]
     public void System_Text_JSON_deserialization(object json, CustomSvo svo)
         => JsonTester.Read_System_Text_JSON<CustomSvo>(json).Should().Be(svo);
-    
+
     [TestCase(null, null)]
     [TestCase("QOWAIV", "QOWAIV")]
     public void System_Text_JSON_serialization(CustomSvo svo, object json)
@@ -389,7 +389,7 @@ public class Supports_JSON_serialization
     public void convention_based_deserialization(object json, CustomSvo svo)
        => JsonTester.Read<CustomSvo>(json).Should().Be(svo);
 
-    
+
     [TestCase(null, null)]
     [TestCase("QOWAIV", "QOWAIV")]
     public void convention_based_serialization(CustomSvo svo, object json)
@@ -457,6 +457,8 @@ public class Is_Open_API_data_type
            pattern: null));
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -466,7 +468,6 @@ public class Supports_binary_serialization
         var round_tripped = SerializeDeserialize.Binary(Svo.CustomSvo);
         Svo.CustomSvo.Should().Be(round_tripped);
     }
-
     [Test]
     public void storing_string_in_SerializationInfo()
     {
@@ -474,7 +475,7 @@ public class Supports_binary_serialization
         info.GetString("Value").Should().Be("QOWAIV");
     }
 }
-
+#endif
 public class Debugger
 {
     [TestCase("{empty}", "")]

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -18,7 +18,7 @@ public class With_domain_logic
 
     [TestCase(15, "info@qowaiv.org")]
     public void has_length(int length, EmailAddress svo) => svo.Length.Should().Be(length);
-    
+
     [TestCase(false, "info@qowaiv.org")]
     [TestCase(false, "?")]
     [TestCase(true, "")]
@@ -444,6 +444,8 @@ public class Is_Open_API_data_type
            nullable: true));
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -461,6 +463,7 @@ public class Supports_binary_serialization
         Assert.AreEqual("info@qowaiv.org", info.GetString("Value"));
     }
 }
+#endif
 
 public class Debugger
 {

--- a/specs/Qowaiv.Specs/Gender_specs.cs
+++ b/specs/Qowaiv.Specs/Gender_specs.cs
@@ -528,6 +528,8 @@ public class Is_Open_API_data_type
     }
 }
 
+#if NET8_0_OR_GREATER
+#else
 [Obsolete("Will be dropped in version 7. Use Qowaiv.Sex instead.")]
 public class Supports_binary_serialization
 {
@@ -545,6 +547,7 @@ public class Supports_binary_serialization
         Assert.AreEqual((byte)4, info.GetByte("Value"));
     }
 }
+#endif
 
 [Obsolete("Will be dropped in version 7. Use Qowaiv.Sex instead.")]
 public class Debugger

--- a/specs/Qowaiv.Specs/Globalization/Country_specs.cs
+++ b/specs/Qowaiv.Specs/Globalization/Country_specs.cs
@@ -169,6 +169,8 @@ public class Supports_JSON_serialization
     }
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -186,3 +188,4 @@ public class Supports_binary_serialization
         info.GetString("Value").Should().Be("VA");
     }
 }
+#endif

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -130,6 +130,8 @@ public class Supports_JSON_serialization
 }
 #endif
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -147,6 +149,7 @@ public class Supports_binary_serialization
         info.GetValue("Value", typeof(Guid)).Should().Be(Guid.Parse("8A1A8C42-D2FF-E254-E26E-B6ABCBF19420"));
     }
 }
+#endif
 
 public class Is_Open_API_data_type
 {

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
@@ -85,6 +85,8 @@ public class Supports_type_conversion
         => Converting.To<int>().From(Svo.Int32Id).Should().Be(17);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -102,6 +104,7 @@ public class Supports_binary_serialization
         info.GetInt32("Value").Should().Be(17);
     }
 }
+#endif
 
 public class Is_Open_API_data_type
 {

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -126,6 +126,8 @@ public class Supports_type_conversion
     }
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -143,6 +145,7 @@ public class Supports_binary_serialization
         info.GetInt64("Value").Should().Be(987654321L);
     }
 }
+#endif
 
 public class Is_Open_API_data_type
 {

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_String_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_String_specs.cs
@@ -1,4 +1,4 @@
-﻿    namespace Identifiers.Id_for_String_specs;
+﻿namespace Identifiers.Id_for_String_specs;
 
 public class Is_comparable
 {
@@ -78,6 +78,8 @@ public class Supports_type_conversion
     }
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -95,6 +97,7 @@ public class Supports_binary_serialization
         info.GetString("Value").Should().Be("Qowaiv-ID");
     }
 }
+#endif
 
 public class Is_Open_API_data_type
 {

--- a/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
+++ b/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
@@ -39,7 +39,7 @@ public class Can_be_parsed
     [TestCase(23, 47, "23/₄₇")]
     public void from_sub_script_denominator(long numerator, long denominator, string subScript)
         => Fraction.Parse(subScript).Should().Be(numerator.DividedBy(denominator));
-   
+
     [TestCase(1, 3, "+1/3")]
     [TestCase(-1, 3, "-1/3")]
     [TestCase(11, 43, "11/43")]
@@ -101,14 +101,14 @@ public class Can_be_created
     [TestCase(1, 1, 0.6, 0.5)]
     public void from_decimals_with_error(long numerator, long denominator, decimal number, decimal error)
         => Fraction.Create(number, error).Should().Be(numerator.DividedBy(denominator));
-    
+
     [TestCase(100)]
     public void from_decimals_without_precision_loss(int runs)
     {
         var rnd = new Random();
         var failures = new List<Fraction>(runs);
 
-        foreach(var fraction in Enumerable.Range(0, runs).Select(i => rnd.Next(int.MinValue, int.MaxValue).DividedBy(rnd.Next(3, int.MaxValue))))
+        foreach (var fraction in Enumerable.Range(0, runs).Select(i => rnd.Next(int.MinValue, int.MaxValue).DividedBy(rnd.Next(3, int.MaxValue))))
         {
             var created = Fraction.Create((decimal)fraction);
             if (created != fraction)
@@ -280,6 +280,8 @@ public class Supports_JSON_serialization
     }
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -298,6 +300,7 @@ public class Supports_binary_serialization
         info.GetInt64("denominator").Should().Be(17);
     }
 }
+#endif
 
 public class Is_Open_API_data_type
 {

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -552,6 +552,8 @@ public class Is_Open_API_data_type
             nullable: true));
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -569,6 +571,7 @@ public class Supports_binary_serialization
         Assert.AreEqual((byte)2, info.GetByte("Value"));
     }
 }
+#endif
 
 public class Debugger
 {

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -369,7 +369,7 @@ public class Casts
         var casted = (Percentage)0.1751m;
         Assert.AreEqual(Svo.Percentage, casted);
     }
-   
+
     [Test]
     public void explicitly_to_decimal()
     {
@@ -1190,10 +1190,12 @@ public class Is_Open_API_data_type
     [TestCase("-4.1%")]
     [TestCase("-0.1%")]
     [TestCase("31%")]
-    public void pattern_matches(string input) 
+    public void pattern_matches(string input)
         => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(Percentage))!.Matches(input).Should().BeTrue();
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -1211,6 +1213,7 @@ public class Supports_binary_serialization
         Assert.AreEqual(0.1751m, info.GetDecimal("Value"));
     }
 }
+#endif
 
 public class Debugger
 {

--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -487,6 +487,8 @@ public class Is_Open_API_data_type
             nullable: true));
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -504,6 +506,7 @@ public class Supports_binary_serialization
         Assert.AreEqual("H0H0H0", info.GetString("Value"));
     }
 }
+#endif
 
 public class Not_supported_by
 {

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/specs/Qowaiv.Specs/SVO_contract_specs.cs
+++ b/specs/Qowaiv.Specs/SVO_contract_specs.cs
@@ -14,8 +14,13 @@ public class Implements : SingleValueObjectSpecs
     [TestCaseSource(nameof(AllSvos))]
     public void IFormattable(Type type) => type.Should().Implement<IFormattable>();
 
+
     [TestCaseSource(nameof(AllSvos))]
+#if NET8_0_OR_GREATER
+    public void Not_ISerializable(Type type) => type.Should().NotImplement<ISerializable>();
+#else
     public void ISerializable(Type type) => type.Should().Implement<ISerializable>();
+#endif
 
     [TestCaseSource(nameof(AllSvos))]
     public void IXmlSerializable(Type type) => type.Should().Implement<IXmlSerializable>();

--- a/specs/Qowaiv.Specs/Sex_specs.cs
+++ b/specs/Qowaiv.Specs/Sex_specs.cs
@@ -457,6 +457,8 @@ public class Is_Open_API_data_type
            nullable: true));
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -474,6 +476,7 @@ public class Supports_binary_serialization
         info.GetByte("Value").Should().Be((byte)4);
     }
 }
+#endif
 
 public class Debugger
 {

--- a/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
+++ b/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
@@ -110,7 +110,7 @@ public class Has_constant
 
     [Test]
     public void C() => EnergyLabel.C.Should().Be(EnergyLabel.Parse("C"));
-    
+
     [Test]
     public void D() => EnergyLabel.D.Should().Be(EnergyLabel.Parse("D"));
 
@@ -298,7 +298,7 @@ public class Has_custom_formatting
 
         [Test]
         public void formats_empty() => $"{EnergyLabel.Empty}".Should().BeEmpty();
-        
+
         [Test]
         public void formats_unknown() => $"{EnergyLabel.Unknown}".Should().Be("?");
 
@@ -534,6 +534,8 @@ public class Is_Open_API_data_type
         => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(EnergyLabel))!.Matches(input).Should().BeTrue();
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -551,6 +553,7 @@ public class Supports_binary_serialization
         info.GetInt32("Value").Should().Be(9);
     }
 }
+#endif
 
 public class Debugger
 {

--- a/specs/Qowaiv.Specs/TestTools/Serialize_deserialize_helper_specs.cs
+++ b/specs/Qowaiv.Specs/TestTools/Serialize_deserialize_helper_specs.cs
@@ -2,6 +2,8 @@
 
 public class Fails_on
 {
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void binary_round_trip_null()
@@ -9,4 +11,5 @@ public class Fails_on
         Func<object> roundtrip = () => SerializeDeserialize.Binary<object>(null!);
         roundtrip.Should().Throw<ArgumentNullException>();
     }
+#endif
 }

--- a/specs/Qowaiv.Specs/Text/Unparsable_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Unparsable_specs.cs
@@ -19,12 +19,12 @@ public class Communicates
     }
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Is_serializable
 {
     internal static readonly Exception Exception = Unparsable.ForValue<int>("fourty-two", "Not a number,").InnerException!;
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void Binary()
@@ -33,5 +33,5 @@ public class Is_serializable
         roundtrip.Should().NotBeSameAs(Exception)
             .And.Subject.Should().BeEquivalentTo(Exception);
     }
-#endif
 }
+#endif

--- a/specs/Qowaiv.Specs/Text/Unparsable_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Unparsable_specs.cs
@@ -6,12 +6,12 @@ public class Communicates
     public void attempted_value_and_type()
     {
         using var _ = TestCultures.En_GB.Scoped();
-        
+
         "no_guid".Invoking(CustomGuid.Parse)
             .Should().Throw<FormatException>()
             .WithMessage("Not a valid identifier.")
             .And.InnerException.Should().BeOfType<Unparsable>()
-            .And.Subject.Should().BeEquivalentTo(new 
+            .And.Subject.Should().BeEquivalentTo(new
             {
                 Value = "no_guid",
                 Type = "Qowaiv.Identifiers.Id<Qowaiv.TestTools.ForGuid>"
@@ -23,6 +23,8 @@ public class Is_serializable
 {
     internal static readonly Exception Exception = Unparsable.ForValue<int>("fourty-two", "Not a number,").InnerException!;
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void Binary()
@@ -31,4 +33,5 @@ public class Is_serializable
         roundtrip.Should().NotBeSameAs(Exception)
             .And.Subject.Should().BeEquivalentTo(Exception);
     }
+#endif
 }

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -542,6 +542,8 @@ public class Is_Open_API_data_type
            nullable: true));
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -566,6 +568,7 @@ public class Supports_binary_serialization
         Assert.AreEqual(((Guid)Svo.Uuid).ToByteArray(), bytes);
     }
 }
+#endif
 
 public class Debugger
 {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
@@ -89,6 +89,8 @@ public class DateSpanTest
         Assert.AreEqual(532575944699UL, info.GetUInt64("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -98,6 +100,8 @@ public class DateSpanTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -115,6 +119,8 @@ public class DateSpanTest
         Assert.AreEqual(exp, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_DateSpanSerializeObject_AreEqual()
@@ -136,6 +142,8 @@ public class DateSpanTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_DateSpanSerializeObject_AreEqual()
     {
@@ -177,6 +185,8 @@ public class DateSpanTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -198,6 +208,8 @@ public class DateSpanTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Default_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
@@ -78,7 +78,8 @@ public class DateSpanTest
 
     #region (XML) (De)serialization tests
 
-
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -89,8 +90,6 @@ public class DateSpanTest
         Assert.AreEqual(532575944699UL, info.GetUInt64("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
@@ -100,6 +100,8 @@ public class DateTest
         Assert.AreEqual(new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), info.GetDateTime("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -109,6 +111,8 @@ public class DateTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -133,6 +137,8 @@ public class DateTest
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_DateSerializeObject_AreEqual()
@@ -154,6 +160,8 @@ public class DateTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_DateSerializeObject_AreEqual()
     {
@@ -195,6 +203,8 @@ public class DateTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_MinValue_AreEqual()
@@ -216,6 +226,8 @@ public class DateTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {
@@ -439,7 +451,7 @@ public class DateTest
     {
         DateTime exp = TestStruct;
         DateTime act = new(1970, 02, 14, 00, 00, 000, DateTimeKind.Local);
-        
+
         Assert.AreEqual(exp, act);
     }
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
@@ -90,6 +90,8 @@ public class DateTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -100,8 +102,6 @@ public class DateTest
         Assert.AreEqual(new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), info.GetDateTime("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
@@ -3,7 +3,7 @@
 [TestFixture]
 public class EmailAddressCollectionTest
 {
-    public static EmailAddressCollection GetTestInstance() 
+    public static EmailAddressCollection GetTestInstance()
         => EmailAddressCollection.Parse("info@qowaiv.org,test@qowaiv.org");
 
     #region (XML) (De)serialization tests
@@ -18,6 +18,8 @@ public class EmailAddressCollectionTest
         Assert.AreEqual("info@qowaiv.org,test@qowaiv.org", info.GetString("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -27,6 +29,8 @@ public class EmailAddressCollectionTest
         var act = SerializeDeserialize.Binary(input);
         CollectionAssert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -47,11 +51,12 @@ public class EmailAddressCollectionTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<EmailAddressCollection>("info@qowaiv.org,test@qowaiv.org");
+        var act = Deserialize.Xml<EmailAddressCollection>("info@qowaiv.org,test@qowaiv.org");
         Assert.AreEqual(GetTestInstance(), act);
     }
 
-
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_EmailAddressSerializeObject_AreEqual()
@@ -73,6 +78,8 @@ public class EmailAddressCollectionTest
         CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_EmailAddressSerializeObject_AreEqual()
     {
@@ -114,6 +121,8 @@ public class EmailAddressCollectionTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Empty_AreEqual()
@@ -135,6 +144,8 @@ public class EmailAddressCollectionTest
         CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
@@ -8,6 +8,8 @@ public class EmailAddressCollectionTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -18,8 +20,6 @@ public class EmailAddressCollectionTest
         Assert.AreEqual("info@qowaiv.org,test@qowaiv.org", info.GetString("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
@@ -92,6 +92,8 @@ public class AmountTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -102,8 +104,6 @@ public class AmountTest
         Assert.AreEqual(42.17m, info.GetDecimal("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
@@ -102,6 +102,8 @@ public class AmountTest
         Assert.AreEqual(42.17m, info.GetDecimal("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -111,6 +113,8 @@ public class AmountTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -131,11 +135,12 @@ public class AmountTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<Amount>("42.17");
+        var act = Deserialize.Xml<Amount>("42.17");
         Assert.AreEqual(TestStruct, act);
     }
 
-
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_AmountSerializeObject_AreEqual()
@@ -157,6 +162,8 @@ public class AmountTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_AmountSerializeObject_AreEqual()
     {
@@ -198,6 +205,8 @@ public class AmountTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -219,6 +228,8 @@ public class AmountTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {
@@ -337,7 +348,7 @@ public class AmountTest
         var exp = "12#345#678*2350";
         Assert.AreEqual(exp, act);
     }
-  
+
     #endregion
 
     #region IEquatable tests
@@ -810,7 +821,7 @@ public class AmountTest
     {
         var amount = (Amount)123.4567m;
         var rounded = amount.Round(1);
-        Assert.AreEqual((Amount)123.5m , rounded);
+        Assert.AreEqual((Amount)123.5m, rounded);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
@@ -169,6 +169,8 @@ public class BusinessIdentifierCodeTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -179,8 +181,6 @@ public class BusinessIdentifierCodeTest
         Assert.AreEqual(TestStruct.ToString(), info.GetString("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
@@ -179,6 +179,8 @@ public class BusinessIdentifierCodeTest
         Assert.AreEqual(TestStruct.ToString(), info.GetString("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -188,6 +190,8 @@ public class BusinessIdentifierCodeTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -208,10 +212,12 @@ public class BusinessIdentifierCodeTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<BusinessIdentifierCode>("AEGONL2UXXX");
+        var act = Deserialize.Xml<BusinessIdentifierCode>("AEGONL2UXXX");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
@@ -233,6 +239,8 @@ public class BusinessIdentifierCodeTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
     {
@@ -274,6 +282,8 @@ public class BusinessIdentifierCodeTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Empty_AreEqual()
@@ -295,6 +305,8 @@ public class BusinessIdentifierCodeTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
@@ -226,6 +226,8 @@ public class CurrencyTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -236,8 +238,6 @@ public class CurrencyTest
         Assert.AreEqual("EUR", info.GetString("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
@@ -236,6 +236,8 @@ public class CurrencyTest
         Assert.AreEqual("EUR", info.GetString("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -245,6 +247,8 @@ public class CurrencyTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -269,6 +273,8 @@ public class CurrencyTest
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_CurrencySerializeObject_AreEqual()
@@ -290,6 +296,8 @@ public class CurrencyTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_CurrencySerializeObject_AreEqual()
     {
@@ -331,6 +339,8 @@ public class CurrencyTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Empty_AreEqual()
@@ -352,6 +362,8 @@ public class CurrencyTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
@@ -115,6 +115,8 @@ public class InternationalBankAccountNumberTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -124,6 +126,8 @@ public class InternationalBankAccountNumberTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -144,10 +148,12 @@ public class InternationalBankAccountNumberTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<InternationalBankAccountNumber>("NL20INGB0001234567");
+        var act = Deserialize.Xml<InternationalBankAccountNumber>("NL20INGB0001234567");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()
@@ -169,6 +175,8 @@ public class InternationalBankAccountNumberTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_InternationalBankAccountNumberSerializeObject_AreEqual()
     {
@@ -210,6 +218,8 @@ public class InternationalBankAccountNumberTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Empty_AreEqual()
@@ -231,6 +241,8 @@ public class InternationalBankAccountNumberTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
@@ -108,6 +108,8 @@ public class MoneyTest
         Assert.AreEqual("EUR", info.GetString("Currency"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -117,6 +119,8 @@ public class MoneyTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -137,10 +141,12 @@ public class MoneyTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<Money>("EUR42.17");
+        var act = Deserialize.Xml<Money>("EUR42.17");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_MoneySerializeObject_AreEqual()
@@ -162,6 +168,8 @@ public class MoneyTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_MoneySerializeObject_AreEqual()
     {
@@ -203,6 +211,8 @@ public class MoneyTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -224,6 +234,8 @@ public class MoneyTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
@@ -97,6 +97,8 @@ public class MoneyTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -108,8 +110,6 @@ public class MoneyTest
         Assert.AreEqual("EUR", info.GetString("Currency"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsTest.cs
@@ -30,6 +30,8 @@ public class FormattingArgumentsTest
         Assert.AreEqual(new CultureInfo("fr-BE"), info.GetValue("FormatProvider", typeof(IFormatProvider)));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -51,6 +53,8 @@ public class FormattingArgumentsTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {
@@ -71,7 +75,6 @@ public class FormattingArgumentsTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
-  
 
     #endregion
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsTest.cs
@@ -19,6 +19,8 @@ public class FormattingArgumentsTest
 
     #region (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -30,8 +32,6 @@ public class FormattingArgumentsTest
         Assert.AreEqual(new CultureInfo("fr-BE"), info.GetValue("FormatProvider", typeof(IFormatProvider)));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -247,11 +247,12 @@ public class CountryTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<Country>("VA");
+        var act = Deserialize.Xml<Country>("VA");
         Assert.AreEqual(TestStruct, act);
     }
 
-
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_CountrySerializeObject_AreEqual()
@@ -273,6 +274,8 @@ public class CountryTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_CountrySerializeObject_AreEqual()
     {
@@ -314,6 +317,8 @@ public class CountryTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Empty_AreEqual()
@@ -335,6 +340,8 @@ public class CountryTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
@@ -220,6 +220,8 @@ public class HouseNumberTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -230,8 +232,6 @@ public class HouseNumberTest
         Assert.AreEqual(123456789, info.GetInt32("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
@@ -230,6 +230,8 @@ public class HouseNumberTest
         Assert.AreEqual(123456789, info.GetInt32("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -239,6 +241,8 @@ public class HouseNumberTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -259,10 +263,12 @@ public class HouseNumberTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<HouseNumber>("123456789");
+        var act = Deserialize.Xml<HouseNumber>("123456789");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_HouseNumberSerializeObject_AreEqual()
@@ -284,6 +290,8 @@ public class HouseNumberTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_HouseNumberSerializeObject_AreEqual()
     {
@@ -325,6 +333,8 @@ public class HouseNumberTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Empty_AreEqual()
@@ -346,6 +356,8 @@ public class HouseNumberTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
@@ -99,6 +99,8 @@ public class StreamSizeTest
         Assert.AreEqual((long)123456789, info.GetInt64("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -108,6 +110,8 @@ public class StreamSizeTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -128,10 +132,12 @@ public class StreamSizeTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<StreamSize>("123456789 byte");
+        var act = Deserialize.Xml<StreamSize>("123456789 byte");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_StreamSizeSerializeObject_AreEqual()
@@ -153,6 +159,8 @@ public class StreamSizeTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_StreamSizeSerializeObject_AreEqual()
     {
@@ -194,6 +202,8 @@ public class StreamSizeTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -215,6 +225,8 @@ public class StreamSizeTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
@@ -89,6 +89,8 @@ public class StreamSizeTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -99,8 +101,6 @@ public class StreamSizeTest
         Assert.AreEqual((long)123456789, info.GetInt64("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
@@ -162,10 +162,12 @@ public class IdForGuidTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<Id<ForGuid>>("0F5AB5AB-12CB-4629-878D-B18B88B9A504");
+        var act = Deserialize.Xml<Id<ForGuid>>("0F5AB5AB-12CB-4629-878D-B18B88B9A504");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_IdForGuidSerializeObject_AreEqual()
@@ -175,22 +177,19 @@ public class IdForGuidTest
             Id = 17,
             Obj = TestStruct,
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
-        }
-
-        ;
+        };
         var exp = new IdForGuidSerializeObject
         {
             Id = 17,
             Obj = TestStruct,
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
-        }
-
-        ;
+        };
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp.Id, act.Id, "Id");
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_IdForGuidSerializeObject_AreEqual()
@@ -242,6 +241,8 @@ public class IdForGuidTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -267,6 +268,7 @@ public class IdForGuidTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_Default_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
@@ -156,10 +156,12 @@ public class IdForInt32Test
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<Id<ForInt32>>("123456789");
+        var act = Deserialize.Xml<Id<ForInt32>>("123456789");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_IdForInt32SerializeObject_AreEqual()
@@ -185,6 +187,7 @@ public class IdForInt32Test
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_IdForInt32SerializeObject_AreEqual()
@@ -236,6 +239,8 @@ public class IdForInt32Test
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -261,6 +266,7 @@ public class IdForInt32Test
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_Default_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
@@ -156,10 +156,12 @@ public class IdForInt64Test
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<Id<ForInt64>>("123456789");
+        var act = Deserialize.Xml<Id<ForInt64>>("123456789");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_IdForInt64SerializeObject_AreEqual()
@@ -185,6 +187,7 @@ public class IdForInt64Test
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_IdForInt64SerializeObject_AreEqual()
@@ -236,6 +239,8 @@ public class IdForInt64Test
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -261,6 +266,7 @@ public class IdForInt64Test
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_Default_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
@@ -115,10 +115,12 @@ public class IdForStringTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<Id<ForString>>("Qowaiv-ID");
+        var act = Deserialize.Xml<Id<ForString>>("Qowaiv-ID");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_IdForStringSerializeObject_AreEqual()
@@ -144,6 +146,7 @@ public class IdForStringTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_IdForStringSerializeObject_AreEqual()
@@ -195,6 +198,8 @@ public class IdForStringTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -212,14 +217,14 @@ public class IdForStringTest
             Id = 17,
             Obj = default,
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
-        }
+        };
 
-        ;
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp.Id, act.Id, "Id");
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_Default_AreEqual()
@@ -353,7 +358,7 @@ public class IdForStringTest
     [Test]
     public void Next_NotSupported()
     {
-        Assert.Throws<NotSupportedException>(()=> Id<ForString>.Next());
+        Assert.Throws<NotSupportedException>(() => Id<ForString>.Next());
     }
 
     [TestCase(null)]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
@@ -68,6 +68,9 @@ public class LocalDateTimeTest
 
     #region (XML) (De)serialization tests
 
+
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -78,8 +81,6 @@ public class LocalDateTimeTest
         info.GetDateTime("Value").Should().Be(new DateTime(1988, 06, 13, 22, 10, 05, 001, DateTimeKind.Local));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
@@ -78,6 +78,8 @@ public class LocalDateTimeTest
         info.GetDateTime("Value").Should().Be(new DateTime(1988, 06, 13, 22, 10, 05, 001, DateTimeKind.Local));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -87,6 +89,8 @@ public class LocalDateTimeTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -107,10 +111,12 @@ public class LocalDateTimeTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<LocalDateTime>("1988-06-13 22:10:05.001");
+        var act = Deserialize.Xml<LocalDateTime>("1988-06-13 22:10:05.001");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
@@ -132,6 +138,8 @@ public class LocalDateTimeTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
@@ -69,6 +69,8 @@ public class FractionTest
         Assert.AreEqual(expected, actual, description);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -78,6 +80,7 @@ public class FractionTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
 
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
@@ -99,10 +102,12 @@ public class FractionTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<Fraction>("-69/17");
+        var act = Deserialize.Xml<Fraction>("-69/17");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_FractionSerializeObject_AreEqual()
@@ -114,6 +119,7 @@ public class FractionTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_FractionSerializeObject_AreEqual()
@@ -137,6 +143,8 @@ public class FractionTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -148,6 +156,7 @@ public class FractionTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_Default_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -116,6 +116,8 @@ public class MonthSpanTest
         Assert.AreEqual(69, info.GetValue("Value", typeof(int)));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -125,6 +127,7 @@ public class MonthSpanTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
 
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
@@ -146,10 +149,12 @@ public class MonthSpanTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<MonthSpan>("69");
+        var act = Deserialize.Xml<MonthSpan>("69");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_MonthSpanSerializeObject_AreEqual()
@@ -161,6 +166,7 @@ public class MonthSpanTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_MonthSpanSerializeObject_AreEqual()
@@ -184,6 +190,8 @@ public class MonthSpanTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -195,6 +203,7 @@ public class MonthSpanTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
 
     [Test]
     public void XmlSerializeDeserialize_Default_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -100,6 +100,8 @@ public class MonthSpanTest
         Assert.AreEqual(MonthSpan.FromMonths(69), ctor);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_NulSerializationInfo_Throws()
     {
@@ -116,8 +118,6 @@ public class MonthSpanTest
         Assert.AreEqual(69, info.GetValue("Value", typeof(int)));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
@@ -70,6 +70,8 @@ public class TimestampTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -80,8 +82,6 @@ public class TimestampTest
         Assert.AreEqual((long)123456789, info.GetInt64("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
@@ -80,15 +80,18 @@ public class TimestampTest
         Assert.AreEqual((long)123456789, info.GetInt64("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
-        =>  SerializeDeserialize.Binary(TestStruct).Should().Be(TestStruct);
+        => SerializeDeserialize.Binary(TestStruct).Should().Be(TestStruct);
+#endif
 
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
         => SerializeDeserialize.DataContract(TestStruct).Should().Be(TestStruct);
-    
+
     [Test]
     public void XmlSerialize_TestStruct_AreEqual()
     {
@@ -104,6 +107,8 @@ public class TimestampTest
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TimestampSerializeObject_AreEqual()
@@ -125,6 +130,8 @@ public class TimestampTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_TimestampSerializeObject_AreEqual()
     {
@@ -166,6 +173,8 @@ public class TimestampTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Default_AreEqual()
@@ -187,6 +196,8 @@ public class TimestampTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
@@ -91,6 +91,8 @@
             Assert.AreEqual(1732.4000000000001, info.GetDouble("Value"));
         }
 
+#if NET8_0_OR_GREATER
+#else
         [Test]
         [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()
@@ -100,6 +102,8 @@
             var act = SerializeDeserialize.Binary(input);
             Assert.AreEqual(exp, act);
         }
+#endif
+
         [Test]
         public void DataContractSerializeDeserialize_TestStruct_AreEqual()
         {
@@ -120,10 +124,12 @@
         [Test]
         public void XmlDeserialize_XmlString_AreEqual()
         {
-            var act =Deserialize.Xml<Elo>("1732.4");
+            var act = Deserialize.Xml<Elo>("1732.4");
             Assert.AreEqual(TestStruct, act);
         }
 
+#if NET8_0_OR_GREATER
+#else
         [Test]
         [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_EloSerializeObject_AreEqual()
@@ -145,6 +151,8 @@
             Assert.AreEqual(exp.Obj, act.Obj, "Obj");
             Assert.AreEqual(exp.Date, act.Date, "Date");
         }
+#endif
+
         [Test]
         public void XmlSerializeDeserialize_EloSerializeObject_AreEqual()
         {
@@ -186,6 +194,8 @@
             Assert.AreEqual(exp.Date, act.Date, "Date");
         }
 
+#if NET8_0_OR_GREATER
+#else
         [Test]
         [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_Zero_AreEqual()
@@ -207,6 +217,7 @@
             Assert.AreEqual(exp.Obj, act.Obj, "Obj");
             Assert.AreEqual(exp.Date, act.Date, "Date");
         }
+#endif
 
         [Test]
         public void GetSchema_None_IsNull()
@@ -412,7 +423,7 @@
         #endregion
 
         #region Casting tests
-        
+
         [Test]
         public void Implicit_DoubleToElo_AreEqual()
         {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
@@ -81,6 +81,8 @@
 
         #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
         [Test]
         public void GetObjectData_SerializationInfo_AreEqual()
         {
@@ -91,8 +93,6 @@
             Assert.AreEqual(1732.4000000000001, info.GetDouble("Value"));
         }
 
-#if NET8_0_OR_GREATER
-#else
         [Test]
         [Obsolete("Usage of the binary formatter is considered harmful.")]
         public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
@@ -51,12 +51,12 @@ public class WildcardPatternTest
     [TestCase("ge?ks", "geeks", true, WildcardPatternOptions.SingleOrTrailing)]
     [TestCase("gee_ks", "geeks", true, WildcardPatternOptions.SingleOrTrailing | WildcardPatternOptions.SqlWildcards)]
     [TestCase("ge_ks", "geeks", true, WildcardPatternOptions.SingleOrTrailing | WildcardPatternOptions.SqlWildcards)]
-    [TestCase("g*ks", "Geeks", true, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase,  "tr-TR")]
-    [TestCase("g*Ks", "geeks", true, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase,  "tr-TR")]
-    [TestCase("Ig*ks", "iGeeks", true, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase,  "tr-TR")]
-    [TestCase("ig*ks", "IGeeks", true, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase,  "tr-TR")]
-    [TestCase("Ig*ks", "ıGeeks", false, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase,  "tr-TR")]
-    [TestCase("ıg*ks", "IGeeks", false, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase,  "tr-TR")]
+    [TestCase("g*ks", "Geeks", true, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase, "tr-TR")]
+    [TestCase("g*Ks", "geeks", true, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase, "tr-TR")]
+    [TestCase("Ig*ks", "iGeeks", true, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase, "tr-TR")]
+    [TestCase("ig*ks", "IGeeks", true, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase, "tr-TR")]
+    [TestCase("Ig*ks", "ıGeeks", false, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase, "tr-TR")]
+    [TestCase("ıg*ks", "IGeeks", false, WildcardPatternOptions.None, StringComparison.InvariantCultureIgnoreCase, "tr-TR")]
     [TestCase("g*ks", "Geeks", true, WildcardPatternOptions.None, StringComparison.CurrentCultureIgnoreCase, "tr-TR")]
     [TestCase("g*Ks", "geeks", true, WildcardPatternOptions.None, StringComparison.CurrentCultureIgnoreCase, "tr-TR")]
     [TestCase("Ig*ks", "iGeeks", false, WildcardPatternOptions.None, StringComparison.CurrentCultureIgnoreCase, "tr-TR")]
@@ -92,6 +92,8 @@ public class WildcardPatternTest
         Assert.AreEqual((int)StringComparison.Ordinal, info.GetInt32("ComparisonType"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -99,6 +101,8 @@ public class WildcardPatternTest
         var act = SerializeDeserialize.Binary(TestPattern);
         act.Should().HaveDebuggerDisplay("{t?st*}, SingleOrTrailing, Ordinal");
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
@@ -80,6 +80,8 @@ public class WildcardPatternTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -92,8 +94,6 @@ public class WildcardPatternTest
         Assert.AreEqual((int)StringComparison.Ordinal, info.GetInt32("ComparisonType"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
@@ -190,6 +190,8 @@ public class InternetMediaTypeTest
         Assert.AreEqual("application/x-chess-pgn", info.GetString("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -199,6 +201,8 @@ public class InternetMediaTypeTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -219,10 +223,12 @@ public class InternetMediaTypeTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<InternetMediaType>("application/x-chess-pgn");
+        var act = Deserialize.Xml<InternetMediaType>("application/x-chess-pgn");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_InternetMediaTypeSerializeObject_AreEqual()
@@ -244,6 +250,8 @@ public class InternetMediaTypeTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_InternetMediaTypeSerializeObject_AreEqual()
     {
@@ -285,6 +293,8 @@ public class InternetMediaTypeTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_Empty_AreEqual()
@@ -306,6 +316,8 @@ public class InternetMediaTypeTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
@@ -180,6 +180,8 @@ public class InternetMediaTypeTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -190,8 +192,6 @@ public class InternetMediaTypeTest
         Assert.AreEqual("application/x-chess-pgn", info.GetString("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
@@ -74,6 +74,8 @@ public class WeekDateTest
 
     #region (XML) (De)serialization tests
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     public void GetObjectData_SerializationInfo_AreEqual()
     {
@@ -84,8 +86,6 @@ public class WeekDateTest
         Assert.AreEqual((DateTime)TestStruct, info.GetDateTime("Value"));
     }
 
-#if NET8_0_OR_GREATER
-#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
@@ -84,6 +84,8 @@ public class WeekDateTest
         Assert.AreEqual((DateTime)TestStruct, info.GetDateTime("Value"));
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_TestStruct_AreEqual()
@@ -93,6 +95,8 @@ public class WeekDateTest
         var act = SerializeDeserialize.Binary(input);
         Assert.AreEqual(exp, act);
     }
+#endif
+
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -113,10 +117,12 @@ public class WeekDateTest
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
-        var act =Deserialize.Xml<WeekDate>("1997-W14-6");
+        var act = Deserialize.Xml<WeekDate>("1997-W14-6");
         Assert.AreEqual(TestStruct, act);
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_WeekDateSerializeObject_AreEqual()
@@ -138,6 +144,8 @@ public class WeekDateTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_WeekDateSerializeObject_AreEqual()
     {
@@ -179,6 +187,8 @@ public class WeekDateTest
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
 
+#if NET8_0_OR_GREATER
+#else
     [Test]
     [Obsolete("Usage of the binary formatter is considered harmful.")]
     public void SerializeDeserialize_MinValue_AreEqual()
@@ -200,6 +210,8 @@ public class WeekDateTest
         Assert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
+#endif
+
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()
     {

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -86,20 +86,20 @@ public class Has_constant
         Assert.AreEqual(default(Year), Year.Empty);
     }
 
-        [Test]
-        public void MinValue_represents_1()
-        {
-            Year min = 1.CE();
-            Assert.AreEqual(min, Year.MinValue);
-        }
-
-        [Test]
-        public void MaxValue_represents_9999()
-        {
-            Year max = 9999.CE();
-            Assert.AreEqual(max, Year.MaxValue);
-        }
+    [Test]
+    public void MinValue_represents_1()
+    {
+        Year min = 1.CE();
+        Assert.AreEqual(min, Year.MinValue);
     }
+
+    [Test]
+    public void MaxValue_represents_9999()
+    {
+        Year max = 9999.CE();
+        Assert.AreEqual(max, Year.MaxValue);
+    }
+}
 
 public class Is_equal_by_value
 {
@@ -115,42 +115,42 @@ public class Is_equal_by_value
         Assert.IsFalse(Svo.Year.Equals(new object()));
     }
 
-        [Test]
-        public void not_equal_to_different_value()
-        {
-            Year other = 2017.CE();
-            Assert.IsFalse(Svo.Year.Equals(other));
-        }
+    [Test]
+    public void not_equal_to_different_value()
+    {
+        Year other = 2017.CE();
+        Assert.IsFalse(Svo.Year.Equals(other));
+    }
 
-        [Test]
-        public void equal_to_same_value()
-        {
-            Assert.IsTrue(Svo.Year.Equals(1979.CE()));
-        }
+    [Test]
+    public void equal_to_same_value()
+    {
+        Assert.IsTrue(Svo.Year.Equals(1979.CE()));
+    }
 
-        [Test]
-        public void equal_operator_returns_true_for_same_values()
-        {
-            Assert.IsTrue(Svo.Year == 1979.CE());
-        }
+    [Test]
+    public void equal_operator_returns_true_for_same_values()
+    {
+        Assert.IsTrue(Svo.Year == 1979.CE());
+    }
 
-        [Test]
-        public void equal_operator_returns_false_for_different_values()
-        {
-            Assert.IsFalse(Svo.Year == 2017.CE());
-        }
+    [Test]
+    public void equal_operator_returns_false_for_different_values()
+    {
+        Assert.IsFalse(Svo.Year == 2017.CE());
+    }
 
-        [Test]
-        public void not_equal_operator_returns_false_for_same_values()
-        {
-            Assert.IsFalse(Svo.Year != 1979.CE());
-        }
+    [Test]
+    public void not_equal_operator_returns_false_for_same_values()
+    {
+        Assert.IsFalse(Svo.Year != 1979.CE());
+    }
 
-        [Test]
-        public void not_equal_operator_returns_true_for_different_values()
-        {
-            Assert.IsTrue(Svo.Year != 2017.CE());
-        }
+    [Test]
+    public void not_equal_operator_returns_true_for_different_values()
+    {
+        Assert.IsTrue(Svo.Year != 2017.CE());
+    }
 
     [TestCase("", 0)]
     [TestCase("1979", 665629288)]
@@ -319,16 +319,16 @@ public class Is_comparable
                 1972.CE(),
                 Year.Unknown,
             };
-            var list = new List<Year> { sorted[3], sorted[5], sorted[4], sorted[2], sorted[0], sorted[1] };
-            list.Sort();
-            Assert.AreEqual(sorted, list);
-        }
-    
-        [Test]
-        public void by_operators_for_different_values()
-        {
-            Year smaller = 1979.CE();
-            Year bigger = 2017.CE();
+        var list = new List<Year> { sorted[3], sorted[5], sorted[4], sorted[2], sorted[0], sorted[1] };
+        list.Sort();
+        Assert.AreEqual(sorted, list);
+    }
+
+    [Test]
+    public void by_operators_for_different_values()
+    {
+        Year smaller = 1979.CE();
+        Year bigger = 2017.CE();
 
         Assert.IsTrue(smaller < bigger);
         Assert.IsTrue(smaller <= bigger);
@@ -336,11 +336,11 @@ public class Is_comparable
         Assert.IsFalse(smaller >= bigger);
     }
 
-        [Test]
-        public void by_operators_for_equal_values()
-        {
-            Year left = 2071.CE();
-            Year right = 2071.CE();
+    [Test]
+    public void by_operators_for_equal_values()
+    {
+        Year left = 2071.CE();
+        Year right = 2071.CE();
 
         Assert.IsFalse(left < right);
         Assert.IsTrue(left <= right);
@@ -515,12 +515,14 @@ public class Is_Open_API_data_type
       .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
           dataType: typeof(Year),
           description: "Year(-only) notation.",
-          example: 1983, 
+          example: 1983,
           type: "integer",
           format: "year",
           nullable: true));
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -538,6 +540,7 @@ public class Supports_binary_serialization
         Assert.AreEqual((short)1979, info.GetInt16("Value"));
     }
 }
+#endif
 
 public class Debugger
 {

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -529,6 +529,8 @@ public class Is_Open_API_data_type
             nullable: true));
 }
 
+#if NET8_0_OR_GREATER
+#else
 public class Supports_binary_serialization
 {
     [Test]
@@ -546,6 +548,7 @@ public class Supports_binary_serialization
         Assert.AreEqual((byte)2, info.GetByte("Value"));
     }
 }
+#endif
 
 public class Debugger
 {

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -101,6 +101,8 @@ public partial struct Timestamp : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Timestamp : ISerializable
 {
     /// <summary>Initializes a new instance of the timestamp based on the serialization info.</summary>
@@ -118,6 +120,7 @@ public partial struct Timestamp : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Timestamp
 {

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -150,7 +150,7 @@ public partial struct Timestamp : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the timestamp to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv.Data.SqlClient/Qowaiv.Data.SqlClient.csproj
+++ b/src/Qowaiv.Data.SqlClient/Qowaiv.Data.SqlClient.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>6.4.0</Version>
     <PackageId>Qowaiv.Data.SqlClient</PackageId>

--- a/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
+++ b/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
@@ -10,7 +10,7 @@
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.TimestampJsonConverter))]
 #endif
-public readonly partial struct Timestamp : ISerializable, IXmlSerializable, IFormattable, IEquatable<Timestamp>, IComparable, IComparable<Timestamp>
+public readonly partial struct Timestamp : IXmlSerializable, IFormattable, IEquatable<Timestamp>, IComparable, IComparable<Timestamp>
 {
     /// <summary>Gets the minimum value of a timestamp.</summary>
     public static readonly Timestamp MinValue;

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>6.4.0</Version>
     <PackageId>Qowaiv.TestTools</PackageId>

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -9,6 +9,7 @@
     <PackageId>Qowaiv.TestTools</PackageId>
     <PackageReleaseNotes>
 Next release
+- No Serializer.Binary for .NET 8.
 - Introduction of the EmptyTestClass attribute.
 v6.4.0
 - Support .NET 7.0. #261

--- a/src/Qowaiv.TestTools/Serialize.cs
+++ b/src/Qowaiv.TestTools/Serialize.cs
@@ -13,11 +13,14 @@ public static class Serialize
     /// <param name="instance">
     /// The instance to retrieve the object data from.
     /// </param>
+#if NET8_0_OR_GREATER
+    [Obsolete("Formatter-based serialization is obsolete and should not be used.", error: true)]
+#endif
     [Pure]
     public static SerializationInfo GetInfo<T>(T instance) where T : ISerializable
     {
         ISerializable obj = instance;
-        var info = new SerializationInfo(typeof(YesNo), new FormatterConverter());
+        var info = new SerializationInfo(typeof(T), new FormatterConverter());
         obj.GetObjectData(info, default);
         return info;
     }

--- a/src/Qowaiv.TestTools/SerializeDeserialize.cs
+++ b/src/Qowaiv.TestTools/SerializeDeserialize.cs
@@ -9,6 +9,8 @@ namespace Qowaiv.TestTools;
 /// <summary>Helps with testing serialization code.</summary>
 public static class SerializeDeserialize
 {
+#if NET8_0_OR_GREATER
+#else
     /// <summary>Serializes and deserializes an instance using <see cref="BinaryFormatter"/>.</summary>
     /// <typeparam name="T">
     /// Type of the instance.
@@ -26,6 +28,7 @@ public static class SerializeDeserialize
         buffer.Position = 0;
         return (T)formatter.Deserialize(buffer)!;
     }
+#endif
 
     /// <summary>Serializes and deserializes an instance using a <see cref="DataContractSerializer"/>.</summary>
     /// <typeparam name="T">

--- a/src/Qowaiv.TestTools/SerializeDeserialize.cs
+++ b/src/Qowaiv.TestTools/SerializeDeserialize.cs
@@ -9,8 +9,6 @@ namespace Qowaiv.TestTools;
 /// <summary>Helps with testing serialization code.</summary>
 public static class SerializeDeserialize
 {
-#if NET8_0_OR_GREATER
-#else
     /// <summary>Serializes and deserializes an instance using <see cref="BinaryFormatter"/>.</summary>
     /// <typeparam name="T">
     /// Type of the instance.
@@ -19,7 +17,11 @@ public static class SerializeDeserialize
     /// The instance to serialize and deserialize.
     /// </param>
     [Pure]
+#if NET8_0_OR_GREATER
+    [Obsolete("Usage of the binary formatter is considered harmful and not longer supported.", error: true)]
+#else
     [Obsolete("Usage of the binary formatter is considered harmful.")]
+#endif
     public static T Binary<T>(T instance)
     {
         using var buffer = new MemoryStream();
@@ -28,7 +30,6 @@ public static class SerializeDeserialize
         buffer.Position = 0;
         return (T)formatter.Deserialize(buffer)!;
     }
-#endif
 
     /// <summary>Serializes and deserializes an instance using a <see cref="DataContractSerializer"/>.</summary>
     /// <typeparam name="T">

--- a/src/Qowaiv/Chemistry/CasRegistryNumber.cs
+++ b/src/Qowaiv/Chemistry/CasRegistryNumber.cs
@@ -19,7 +19,7 @@ namespace Qowaiv.Chemistry;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Chemistry.CasRegistryNumberJsonConverter))]
 #endif
-public readonly partial struct CasRegistryNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<CasRegistryNumber>, IComparable, IComparable<CasRegistryNumber>
+public readonly partial struct CasRegistryNumber : IXmlSerializable, IFormattable, IEquatable<CasRegistryNumber>, IComparable, IComparable<CasRegistryNumber>
 {
     /// <summary>Represents an empty/not set CAS Registry Number.</summary>
     public static readonly CasRegistryNumber Empty;

--- a/src/Qowaiv/Customization/Svo.cs
+++ b/src/Qowaiv/Customization/Svo.cs
@@ -184,7 +184,7 @@ public readonly struct Svo<TSvoBehavior> : IXmlSerializable, IFormattable, IEqua
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the Single Value Object to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Customization/Svo.cs
+++ b/src/Qowaiv/Customization/Svo.cs
@@ -17,10 +17,14 @@ namespace Qowaiv.Customization;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Customization.GenericSvoJsonConverter))]
 #endif
-public readonly struct Svo<TSvoBehavior> : ISerializable, IXmlSerializable, IFormattable, IEquatable<Svo<TSvoBehavior>>, IComparable, IComparable<Svo<TSvoBehavior>>
+public readonly struct Svo<TSvoBehavior> : IXmlSerializable, IFormattable, IEquatable<Svo<TSvoBehavior>>, IComparable, IComparable<Svo<TSvoBehavior>>
 #if NET7_0_OR_GREATER
 , IEqualityOperators<Svo<TSvoBehavior>, Svo<TSvoBehavior>, bool>
 , IParsable<Svo<TSvoBehavior>>
+#endif
+#if NET8_0_OR_GREATER
+#else
+, ISerializable
 #endif
     where TSvoBehavior : SvoBehavior, new()
 {
@@ -37,6 +41,8 @@ public readonly struct Svo<TSvoBehavior> : ISerializable, IXmlSerializable, IFor
     /// <summary>Initializes a new instance of the <see cref="Svo{TSvoBehavior}"/> struct.</summary>
     private Svo(string? value) => m_Value = value;
 
+#if NET8_0_OR_GREATER
+#else
     /// <summary>Initializes a new instance of the <see cref="Svo{TSvoBehavior}"/> struct.</summary>
     /// <param name="info">The serialization info.</param>
     /// <param name="context">The streaming context.</param>
@@ -51,6 +57,7 @@ public readonly struct Svo<TSvoBehavior> : ISerializable, IXmlSerializable, IFor
     /// <param name="context">The streaming context.</param>
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
+#endif
 
     /// <summary>The inner value of the Single Value Object.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -10,7 +10,7 @@
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.DateJsonConverter))]
 #endif
-public readonly partial struct Date : ISerializable, IXmlSerializable, IFormattable, IEquatable<Date>, IComparable, IComparable<Date>
+public readonly partial struct Date : IXmlSerializable, IFormattable, IEquatable<Date>, IComparable, IComparable<Date>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Date>, IDecrementOperators<Date>
     , IAdditionOperators<Date, TimeSpan, Date>, ISubtractionOperators<Date, TimeSpan, Date>

--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -10,7 +10,7 @@ namespace Qowaiv;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.DateSpanJsonConverter))]
 #endif
-public readonly partial struct DateSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<DateSpan>, IComparable, IComparable<DateSpan>
+public readonly partial struct DateSpan : IXmlSerializable, IFormattable, IEquatable<DateSpan>, IComparable, IComparable<DateSpan>
 #if NET7_0_OR_GREATER
     , IUnaryPlusOperators<DateSpan, DateSpan>, IUnaryNegationOperators<DateSpan, DateSpan>
     , IAdditionOperators<DateSpan, DateSpan, DateSpan>, ISubtractionOperators<DateSpan, DateSpan, DateSpan>

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -15,7 +15,7 @@ namespace Qowaiv;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.EmailAddressJsonConverter))]
 #endif
-public readonly partial struct EmailAddress : ISerializable, IXmlSerializable, IFormattable, IEquatable<EmailAddress>, IComparable, IComparable<EmailAddress>
+public readonly partial struct EmailAddress : IXmlSerializable, IFormattable, IEquatable<EmailAddress>, IComparable, IComparable<EmailAddress>
 {
     /// <summary>An email address must not exceed 254 characters.</summary>
     /// <remarks>

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -12,7 +12,7 @@ namespace Qowaiv.Financial;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.AmountJsonConverter))]
 #endif
-public readonly partial struct Amount : ISerializable, IXmlSerializable, IFormattable, IEquatable<Amount>, IComparable, IComparable<Amount>
+public readonly partial struct Amount : IXmlSerializable, IFormattable, IEquatable<Amount>, IComparable, IComparable<Amount>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Amount>, IDecrementOperators<Amount>
     , IUnaryPlusOperators<Amount, Amount>, IUnaryNegationOperators<Amount, Amount>

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -28,7 +28,7 @@ namespace Qowaiv.Financial;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.BusinessIdentifierCodeJsonConverter))]
 #endif
-public readonly partial struct BusinessIdentifierCode : ISerializable, IXmlSerializable, IFormattable, IEquatable<BusinessIdentifierCode>, IComparable, IComparable<BusinessIdentifierCode>
+public readonly partial struct BusinessIdentifierCode : IXmlSerializable, IFormattable, IEquatable<BusinessIdentifierCode>, IComparable, IComparable<BusinessIdentifierCode>
 {
     /// <remarks>
     /// http://www.codeproject.com/KB/recipes/bicRegexValidator.aspx.

--- a/src/Qowaiv/Financial/Currency.cs
+++ b/src/Qowaiv/Financial/Currency.cs
@@ -27,7 +27,7 @@ namespace Qowaiv.Financial;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.CurrencyJsonConverter))]
 #endif
-public readonly partial struct Currency : ISerializable, IXmlSerializable, IFormattable, IFormatProvider, IEquatable<Currency>, IComparable, IComparable<Currency>
+public readonly partial struct Currency : IXmlSerializable, IFormattable, IFormatProvider, IEquatable<Currency>, IComparable, IComparable<Currency>
 {
     /// <summary>Represents an empty/not set currency.</summary>
     public static readonly Currency Empty;

--- a/src/Qowaiv/Financial/CurrencyMismatchException.cs
+++ b/src/Qowaiv/Financial/CurrencyMismatchException.cs
@@ -17,6 +17,9 @@ public class CurrencyMismatchException : Exception
     public CurrencyMismatchException(Currency cur0, Currency cur1, string operation)
         : this(string.Format(QowaivMessages.CurrencyMismatchException, operation, cur0, cur1)) { }
 
+#if NET8_0_OR_GREATER
+#else
     /// <summary>Initializes a new instance of the <see cref="CurrencyMismatchException"/> class.</summary>
     protected CurrencyMismatchException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -24,7 +24,7 @@ namespace Qowaiv.Financial;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.InternationalBankAccountNumberJsonConverter))]
 #endif
-public readonly partial struct InternationalBankAccountNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<InternationalBankAccountNumber>, IComparable, IComparable<InternationalBankAccountNumber>
+public readonly partial struct InternationalBankAccountNumber : IXmlSerializable, IFormattable, IEquatable<InternationalBankAccountNumber>, IComparable, IComparable<InternationalBankAccountNumber>
 {
     /// <summary>Represents the pattern of a (potential) valid IBAN.</summary>
     /// <remarks>

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -12,7 +12,7 @@ namespace Qowaiv.Financial;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Financial.MoneyJsonConverter))]
 #endif
-public readonly partial struct Money : ISerializable, IXmlSerializable, IFormattable, IEquatable<Money>, IComparable, IComparable<Money>
+public readonly partial struct Money : IXmlSerializable, IFormattable, IEquatable<Money>, IComparable, IComparable<Money>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Money>, IDecrementOperators<Money>
     , IUnaryPlusOperators<Money, Money>, IUnaryNegationOperators<Money, Money>
@@ -27,6 +27,10 @@ public readonly partial struct Money : ISerializable, IXmlSerializable, IFormatt
     , IMultiplyOperators<Money, ulong, Money>, IDivisionOperators<Money, ulong, Money>
     , IMultiplyOperators<Money, uint, Money>, IDivisionOperators<Money, uint, Money>
     , IMultiplyOperators<Money, ushort, Money>, IDivisionOperators<Money, ushort, Money>
+#endif
+#if NET8_0_OR_GREATER
+#else
+, ISerializable
 #endif
 {
     /// <summary>Represents an Amount of zero.</summary>
@@ -433,6 +437,8 @@ public readonly partial struct Money : ISerializable, IXmlSerializable, IFormatt
         ? l.Currency
         : throw new CurrencyMismatchException(l.Currency, r.Currency, operation);
 
+#if NET8_0_OR_GREATER
+#else
     /// <summary>Initializes a new instance of the <see cref="Money"/> struct.</summary>
     /// <param name="info">The serialization info.</param>
     /// <param name="context">The streaming context.</param>
@@ -452,6 +458,7 @@ public readonly partial struct Money : ISerializable, IXmlSerializable, IFormatt
         info.AddValue("Value", m_Value);
         info.AddValue(nameof(Currency), m_Currency.Name);
     }
+#endif
 
     /// <summary>Deserializes the money from a JSON number.</summary>
     /// <param name="json">

--- a/src/Qowaiv/Gender.cs
+++ b/src/Qowaiv/Gender.cs
@@ -28,7 +28,7 @@ namespace Qowaiv;
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.GenderJsonConverter))]
 #endif
 [Obsolete("Will be dropped in version 7. Use Qowaiv.Sex instead.")]
-public readonly partial struct Gender : ISerializable, IXmlSerializable, IFormattable, IEquatable<Gender>, IComparable, IComparable<Gender>
+public readonly partial struct Gender : IXmlSerializable, IFormattable, IEquatable<Gender>, IComparable, IComparable<Gender>
 {
     /// <summary>Represents an empty/not set Gender.</summary>
     public static readonly Gender Empty;

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -156,7 +156,7 @@ public partial struct CasRegistryNumber : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the CAS Registry Number to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -107,6 +107,8 @@ public partial struct CasRegistryNumber : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct CasRegistryNumber : ISerializable
 {
     /// <summary>Initializes a new instance of the CAS Registry Number based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct CasRegistryNumber : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct CasRegistryNumber
 {

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -92,6 +92,8 @@ public partial struct Date : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Date : ISerializable
 {
     /// <summary>Initializes a new instance of the date based on the serialization info.</summary>
@@ -109,6 +111,7 @@ public partial struct Date : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Date
 {

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -141,7 +141,7 @@ public partial struct Date : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the date to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -136,7 +136,7 @@ public partial struct DateSpan : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the date span to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -87,6 +87,8 @@ public partial struct DateSpan : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct DateSpan : ISerializable
 {
     /// <summary>Initializes a new instance of the date span based on the serialization info.</summary>
@@ -104,6 +106,7 @@ public partial struct DateSpan : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct DateSpan
 {

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -156,7 +156,7 @@ public partial struct EmailAddress : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the email address to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -107,6 +107,8 @@ public partial struct EmailAddress : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct EmailAddress : ISerializable
 {
     /// <summary>Initializes a new instance of the email address based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct EmailAddress : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct EmailAddress
 {

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -101,6 +101,8 @@ public partial struct Amount : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Amount : ISerializable
 {
     /// <summary>Initializes a new instance of the amount based on the serialization info.</summary>
@@ -118,6 +120,7 @@ public partial struct Amount : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Amount
 {

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -150,7 +150,7 @@ public partial struct Amount : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the amount to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -107,6 +107,8 @@ public partial struct BusinessIdentifierCode : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct BusinessIdentifierCode : ISerializable
 {
     /// <summary>Initializes a new instance of the BIC based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct BusinessIdentifierCode : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct BusinessIdentifierCode
 {

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -156,7 +156,7 @@ public partial struct BusinessIdentifierCode : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the BIC to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -156,7 +156,7 @@ public partial struct Currency : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the currency to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -107,6 +107,8 @@ public partial struct Currency : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Currency : ISerializable
 {
     /// <summary>Initializes a new instance of the currency based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct Currency : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Currency
 {

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -107,6 +107,8 @@ public partial struct InternationalBankAccountNumber : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct InternationalBankAccountNumber : ISerializable
 {
     /// <summary>Initializes a new instance of the IBAN based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct InternationalBankAccountNumber : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct InternationalBankAccountNumber
 {

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -156,7 +156,7 @@ public partial struct InternationalBankAccountNumber : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the IBAN to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -106,7 +106,7 @@ public partial struct Money : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the money to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -156,7 +156,7 @@ public partial struct Gender : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the gender to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -107,6 +107,8 @@ public partial struct Gender : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Gender : ISerializable
 {
     /// <summary>Initializes a new instance of the gender based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct Gender : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Gender
 {

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -107,6 +107,8 @@ public partial struct Country : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Country : ISerializable
 {
     /// <summary>Initializes a new instance of the country based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct Country : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Country
 {

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -156,7 +156,7 @@ public partial struct Country : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the country to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -170,7 +170,7 @@ public partial struct HouseNumber : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the house number to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -121,6 +121,8 @@ public partial struct HouseNumber : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct HouseNumber : ISerializable
 {
     /// <summary>Initializes a new instance of the house number based on the serialization info.</summary>
@@ -138,6 +140,7 @@ public partial struct HouseNumber : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct HouseNumber
 {

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -120,7 +120,7 @@ public partial struct StreamSize : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the stream size to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -71,6 +71,8 @@ public partial struct StreamSize : IComparable, IComparable<StreamSize>
     public static bool operator >=(StreamSize l, StreamSize r) => l.CompareTo(r) >= 0;
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct StreamSize : ISerializable
 {
     /// <summary>Initializes a new instance of the stream size based on the serialization info.</summary>
@@ -88,6 +90,7 @@ public partial struct StreamSize : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct StreamSize
 {

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -92,6 +92,8 @@ public partial struct LocalDateTime : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct LocalDateTime : ISerializable
 {
     /// <summary>Initializes a new instance of the local date time based on the serialization info.</summary>
@@ -109,6 +111,7 @@ public partial struct LocalDateTime : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct LocalDateTime
 {

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -141,7 +141,7 @@ public partial struct LocalDateTime : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the local date time to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -106,7 +106,7 @@ public partial struct Fraction : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the fraction to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -156,7 +156,7 @@ public partial struct Month : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the month to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -107,6 +107,8 @@ public partial struct Month : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Month : ISerializable
 {
     /// <summary>Initializes a new instance of the month based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct Month : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Month
 {

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -150,7 +150,7 @@ public partial struct MonthSpan : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the month span to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -101,6 +101,8 @@ public partial struct MonthSpan : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct MonthSpan : ISerializable
 {
     /// <summary>Initializes a new instance of the month span based on the serialization info.</summary>
@@ -118,6 +120,7 @@ public partial struct MonthSpan : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct MonthSpan
 {

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -150,7 +150,7 @@ public partial struct Percentage : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the percentage to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -101,6 +101,8 @@ public partial struct Percentage : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Percentage : ISerializable
 {
     /// <summary>Initializes a new instance of the percentage based on the serialization info.</summary>
@@ -118,6 +120,7 @@ public partial struct Percentage : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Percentage
 {

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -107,6 +107,8 @@ public partial struct PostalCode : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct PostalCode : ISerializable
 {
     /// <summary>Initializes a new instance of the postal code based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct PostalCode : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct PostalCode
 {

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -156,7 +156,7 @@ public partial struct PostalCode : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the postal code to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -156,7 +156,7 @@ public partial struct Sex : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the sex to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -107,6 +107,8 @@ public partial struct Sex : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Sex : ISerializable
 {
     /// <summary>Initializes a new instance of the sex based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct Sex : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Sex
 {

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -101,6 +101,8 @@ public partial struct Elo : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Elo : ISerializable
 {
     /// <summary>Initializes a new instance of the elo based on the serialization info.</summary>
@@ -118,6 +120,7 @@ public partial struct Elo : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Elo
 {

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -150,7 +150,7 @@ public partial struct Elo : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the elo to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
+++ b/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
@@ -107,6 +107,8 @@ public partial struct EnergyLabel : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct EnergyLabel : ISerializable
 {
     /// <summary>Initializes a new instance of the EU energy label based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct EnergyLabel : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct EnergyLabel
 {

--- a/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
+++ b/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
@@ -156,7 +156,7 @@ public partial struct EnergyLabel : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the EU energy label to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -95,6 +95,8 @@ public partial struct Uuid : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Uuid : ISerializable
 {
     /// <summary>Initializes a new instance of the UUID based on the serialization info.</summary>
@@ -112,6 +114,7 @@ public partial struct Uuid : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Uuid
 {

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -144,7 +144,7 @@ public partial struct Uuid : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the UUID to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -156,7 +156,7 @@ public partial struct InternetMediaType : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the Internet media type to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -107,6 +107,8 @@ public partial struct InternetMediaType : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct InternetMediaType : ISerializable
 {
     /// <summary>Initializes a new instance of the Internet media type based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct InternetMediaType : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct InternetMediaType
 {

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -120,7 +120,7 @@ public partial struct WeekDate : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the week date to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -107,6 +107,8 @@ public partial struct Year : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct Year : ISerializable
 {
     /// <summary>Initializes a new instance of the year based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct Year : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct Year
 {

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -156,7 +156,7 @@ public partial struct Year : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the year to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -107,6 +107,8 @@ public partial struct YesNo : IFormattable
     public string ToString(IFormatProvider? provider) => ToString(format: null, provider);
 }
 
+#if NET8_0_OR_GREATER
+#else
 public partial struct YesNo : ISerializable
 {
     /// <summary>Initializes a new instance of the yes-no based on the serialization info.</summary>
@@ -124,6 +126,7 @@ public partial struct YesNo : ISerializable
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         => Guard.NotNull(info).AddValue("Value", m_Value);
 }
+#endif
 
 public partial struct YesNo
 {

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -156,7 +156,7 @@ public partial struct YesNo : IXmlSerializable
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Writes the yes-no to an <see href="XmlWriter" />.</summary>

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -18,7 +18,7 @@ namespace Qowaiv.Globalization;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Globalization.CountryJsonConverter))]
 #endif
-public readonly partial struct Country : ISerializable, IXmlSerializable, IFormattable, IEquatable<Country>, IComparable, IComparable<Country>
+public readonly partial struct Country : IXmlSerializable, IFormattable, IEquatable<Country>, IComparable, IComparable<Country>
 {
     /// <summary>Represents an empty/not set country.</summary>
     public static readonly Country Empty;

--- a/src/Qowaiv/Hashing/HashingNotSupported.cs
+++ b/src/Qowaiv/Hashing/HashingNotSupported.cs
@@ -16,6 +16,9 @@ public class HashingNotSupported : NotSupportedException
     /// <summary>Initializes a new instance of the <see cref="HashingNotSupported"/> class.</summary>
     public HashingNotSupported(string message, Exception innerException) : base(message, innerException) { }
 
+#if NET8_0_OR_GREATER
+#else
     /// <summary>Initializes a new instance of the <see cref="HashingNotSupported"/> class.</summary>
     protected HashingNotSupported(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -10,7 +10,7 @@
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(HouseNumberJsonConverter))]
 #endif
-public readonly partial struct HouseNumber : ISerializable, IXmlSerializable, IFormattable, IEquatable<HouseNumber>, IComparable, IComparable<HouseNumber>
+public readonly partial struct HouseNumber : IXmlSerializable, IFormattable, IEquatable<HouseNumber>, IComparable, IComparable<HouseNumber>
 {
     /// <summary>Represents an empty/not set house number.</summary>
     public static readonly HouseNumber Empty;

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -21,7 +21,7 @@ namespace Qowaiv.IO;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.IO.StreamSizeJsonConverter))]
 #endif
-public readonly partial struct StreamSize : ISerializable, IXmlSerializable, IFormattable, IEquatable<StreamSize>, IComparable, IComparable<StreamSize>
+public readonly partial struct StreamSize : IXmlSerializable, IFormattable, IEquatable<StreamSize>, IComparable, IComparable<StreamSize>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<StreamSize>, IDecrementOperators<StreamSize>
     , IUnaryPlusOperators<StreamSize, StreamSize>, IUnaryNegationOperators<StreamSize, StreamSize>

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -182,7 +182,7 @@ public readonly struct Id<TIdentifier> : IXmlSerializable, IFormattable, IEquata
     {
         Guard.NotNull(reader);
         var xml = reader.ReadElementString();
-        System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml);
+        System.Runtime.CompilerServices.Unsafe.AsRef(in this) = Parse(xml);
     }
 
     /// <summary>Writes the identifier to an <see href = "XmlWriter"/>.</summary>

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -18,9 +18,13 @@ namespace Qowaiv.Identifiers;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Identifiers.IdJsonConverter))]
 #endif
-public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IFormattable, IEquatable<Id<TIdentifier>>, IComparable, IComparable<Id<TIdentifier>>
+public readonly struct Id<TIdentifier> : IXmlSerializable, IFormattable, IEquatable<Id<TIdentifier>>, IComparable, IComparable<Id<TIdentifier>>
 #if NET7_0_OR_GREATER
 , IEqualityOperators<Id<TIdentifier>, Id<TIdentifier>, bool>
+#endif
+#if NET8_0_OR_GREATER
+#else
+, ISerializable
 #endif
     where TIdentifier : IIdentifierBehavior, new()
 {
@@ -33,6 +37,8 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
     /// <summary>Initializes a new instance of the <see cref="Id{TIdentifier}"/> struct.</summary>
     private Id(object? value) => m_Value = value;
 
+#if NET8_0_OR_GREATER
+#else
     /// <summary>Initializes a new instance of the <see cref="Id{TIdentifier}"/> struct.</summary>
     /// <param name="info">The serialization info.</param>
     /// <param name="context">The streaming context.</param>
@@ -41,6 +47,16 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
         Guard.NotNull(info);
         m_Value = info.GetValue("Value", typeof(object));
     }
+
+    /// <summary>Adds the underlying property of the identifier to the serialization info.</summary>
+    /// <param name="info">The serialization info.</param>
+    /// <param name="context">The streaming context.</param>
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        Guard.NotNull(info);
+        info.AddValue("Value", m_Value);
+    }
+#endif
 
     /// <summary>The inner value of the identifier.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -151,15 +167,6 @@ public readonly struct Id<TIdentifier> : ISerializable, IXmlSerializable, IForma
             return formatted;
         }
         else return IsEmpty() ? string.Empty : behavior.ToString(m_Value, format, formatProvider);
-    }
-
-    /// <summary>Adds the underlying property of the identifier to the serialization info.</summary>
-    /// <param name="info">The serialization info.</param>
-    /// <param name="context">The streaming context.</param>
-    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
-    {
-        Guard.NotNull(info);
-        info.AddValue("Value", m_Value);
     }
 
     /// <summary>Gets the <see href = "XmlSchema"/> to XML (de)serialize the identifier.</summary>

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -10,7 +10,7 @@
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.LocalDateTimeJsonConverter))]
 #endif
-public readonly partial struct LocalDateTime : ISerializable, IXmlSerializable, IFormattable, IEquatable<LocalDateTime>, IComparable, IComparable<LocalDateTime>
+public readonly partial struct LocalDateTime : IXmlSerializable, IFormattable, IEquatable<LocalDateTime>, IComparable, IComparable<LocalDateTime>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<LocalDateTime>, IDecrementOperators<LocalDateTime>
     , IAdditionOperators<LocalDateTime, TimeSpan, LocalDateTime>, ISubtractionOperators<LocalDateTime, TimeSpan, LocalDateTime>

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -14,7 +14,7 @@ namespace Qowaiv.Mathematics;
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Mathematics.FractionJsonConverter))]
 #endif
 [StructLayout(LayoutKind.Sequential)]
-public readonly partial struct Fraction : ISerializable, IXmlSerializable, IFormattable, IEquatable<Fraction>, IComparable, IComparable<Fraction>
+public readonly partial struct Fraction : IXmlSerializable, IFormattable, IEquatable<Fraction>, IComparable, IComparable<Fraction>
 #if NET7_0_OR_GREATER
     , IAdditionOperators<Fraction, Fraction, Fraction>, ISubtractionOperators<Fraction, Fraction, Fraction>
     , IUnaryPlusOperators<Fraction, Fraction>, IUnaryNegationOperators<Fraction, Fraction>
@@ -22,6 +22,10 @@ public readonly partial struct Fraction : ISerializable, IXmlSerializable, IForm
     , IAdditionOperators<Fraction, int, Fraction>, ISubtractionOperators<Fraction, int, Fraction>
     , IMultiplyOperators<Fraction, long, Fraction>, IDivisionOperators<Fraction, long, Fraction>
     , IMultiplyOperators<Fraction, int, Fraction>, IDivisionOperators<Fraction, int, Fraction>
+#endif
+#if NET8_0_OR_GREATER
+#else
+, ISerializable
 #endif
 {
     /// <summary>Represents the zero (0) <see cref="Fraction"/> value.</summary>
@@ -515,6 +519,8 @@ public readonly partial struct Fraction : ISerializable, IXmlSerializable, IForm
         return self.CompareTo(othr);
     }
 
+#if NET8_0_OR_GREATER
+#else
     /// <summary>Initializes a new instance of the <see cref="Fraction"/> struct.</summary>
     /// <param name="info">The serialization info.</param>
     /// <param name="context">The streaming context.</param>
@@ -542,6 +548,7 @@ public readonly partial struct Fraction : ISerializable, IXmlSerializable, IForm
         info.AddValue(nameof(numerator), numerator);
         info.AddValue(nameof(denominator), denominator);
     }
+#endif
 
     /// <summary>Gets an XML string representation of the fraction.</summary>
     [Pure]

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -12,7 +12,7 @@ namespace Qowaiv;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.MonthJsonConverter))]
 #endif
-public readonly partial struct Month : ISerializable, IXmlSerializable, IFormattable, IEquatable<Month>, IComparable, IComparable<Month>
+public readonly partial struct Month : IXmlSerializable, IFormattable, IEquatable<Month>, IComparable, IComparable<Month>
 {
     /// <summary>Represents an empty/not set month.</summary>
     public static readonly Month Empty;

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -10,7 +10,7 @@
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.MonthSpanJsonConverter))]
 #endif
-public readonly partial struct MonthSpan : ISerializable, IXmlSerializable, IFormattable, IEquatable<MonthSpan>, IComparable, IComparable<MonthSpan>
+public readonly partial struct MonthSpan : IXmlSerializable, IFormattable, IEquatable<MonthSpan>, IComparable, IComparable<MonthSpan>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<MonthSpan>, IDecrementOperators<MonthSpan>
     , IUnaryPlusOperators<MonthSpan, MonthSpan>, IUnaryNegationOperators<MonthSpan, MonthSpan>

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -10,7 +10,7 @@
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.PercentageJsonConverter))]
 #endif
-public readonly partial struct Percentage : ISerializable, IXmlSerializable, IFormattable, IEquatable<Percentage>, IComparable, IComparable<Percentage>
+public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEquatable<Percentage>, IComparable, IComparable<Percentage>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Percentage>, IDecrementOperators<Percentage>
     , IUnaryPlusOperators<Percentage, Percentage>, IUnaryNegationOperators<Percentage, Percentage>

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -15,7 +15,7 @@ namespace Qowaiv;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(PostalCodeJsonConverter))]
 #endif
-public readonly partial struct PostalCode : ISerializable, IXmlSerializable, IFormattable, IEquatable<PostalCode>, IComparable, IComparable<PostalCode>
+public readonly partial struct PostalCode : IXmlSerializable, IFormattable, IEquatable<PostalCode>, IComparable, IComparable<PostalCode>
 {
     /// <summary>Represents an empty/not set postal code.</summary>
     public static readonly PostalCode Empty;

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>6.5.4</Version>
     <PackageId>Qowaiv</PackageId>

--- a/src/Qowaiv/Sex.cs
+++ b/src/Qowaiv/Sex.cs
@@ -30,7 +30,7 @@ namespace Qowaiv;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.SexJsonConverter))]
 #endif
-public readonly partial struct Sex : ISerializable, IXmlSerializable, IFormattable, IEquatable<Sex>, IComparable, IComparable<Sex>
+public readonly partial struct Sex : IXmlSerializable, IFormattable, IEquatable<Sex>, IComparable, IComparable<Sex>
 {
     /// <summary>Represents an empty/not set Sex.</summary>
     public static readonly Sex Empty;

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -22,7 +22,7 @@ namespace Qowaiv.Statistics;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Statistics.EloJsonConverter))]
 #endif
-public readonly partial struct Elo : ISerializable, IXmlSerializable, IFormattable, IEquatable<Elo>, IComparable, IComparable<Elo>
+public readonly partial struct Elo : IXmlSerializable, IFormattable, IEquatable<Elo>, IComparable, IComparable<Elo>
 #if NET7_0_OR_GREATER
     , IIncrementOperators<Elo>, IDecrementOperators<Elo>
     , IUnaryPlusOperators<Elo, Elo>, IUnaryNegationOperators<Elo, Elo>

--- a/src/Qowaiv/Sustainability/EnergyLabel.cs
+++ b/src/Qowaiv/Sustainability/EnergyLabel.cs
@@ -24,7 +24,7 @@
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Sustainability.EnergyLabelJsonConverter))]
 #endif
-public readonly partial struct EnergyLabel : ISerializable, IXmlSerializable, IEquatable<EnergyLabel>, IComparable, IComparable<EnergyLabel>
+public readonly partial struct EnergyLabel : IXmlSerializable, IEquatable<EnergyLabel>, IComparable, IComparable<EnergyLabel>
 #if NET6_0_OR_GREATER
     , ISpanFormattable
 #else

--- a/src/Qowaiv/Text/Unparsable.cs
+++ b/src/Qowaiv/Text/Unparsable.cs
@@ -18,6 +18,8 @@ public class Unparsable : FormatException
     [ExcludeFromCodeCoverage/* Justification = Required for extensibility. */]
     public Unparsable(string? message, Exception? innerException) : base(message, innerException) { }
 
+#if NET8_0_OR_GREATER
+#else
     /// <summary>Initializes a new instance of the <see cref="Unparsable"/> class.</summary>
     protected Unparsable(SerializationInfo info, StreamingContext context) : base(info, context)
     {
@@ -36,6 +38,7 @@ public class Unparsable : FormatException
         info.AddValue(nameof(Type), Type);
         info.AddValue(nameof(Value), Value);
     }
+#endif
 
     /// <summary>The target type.</summary>
     public string? Type { get; init; }

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -25,7 +25,7 @@ namespace Qowaiv;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.UuidJsonConverter))]
 #endif
-public readonly partial struct Uuid : ISerializable, IXmlSerializable, IFormattable, IEquatable<Uuid>, IComparable, IComparable<Uuid>
+public readonly partial struct Uuid : IXmlSerializable, IFormattable, IEquatable<Uuid>, IComparable, IComparable<Uuid>
 {
     private static readonly UuidBehavior behavior = UuidBehavior.Instance;
 

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -44,7 +44,7 @@ namespace Qowaiv.Web;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Web.InternetMediaTypeJsonConverter))]
 #endif
-public readonly partial struct InternetMediaType : ISerializable, IXmlSerializable, IFormattable, IEquatable<InternetMediaType>, IComparable, IComparable<InternetMediaType>
+public readonly partial struct InternetMediaType : IXmlSerializable, IFormattable, IEquatable<InternetMediaType>, IComparable, IComparable<InternetMediaType>
 {
     /// <summary>Represents the pattern of a (potential) valid Internet media type.</summary>
     private static readonly Regex Pattern = new(

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -36,7 +36,11 @@
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.WeekDateJsonConverter))]
 #endif
-public readonly partial struct WeekDate : ISerializable, IXmlSerializable, IFormattable, IEquatable<WeekDate>, IComparable, IComparable<WeekDate>
+public readonly partial struct WeekDate : IXmlSerializable, IFormattable, IEquatable<WeekDate>, IComparable, IComparable<WeekDate>
+#if NET8_0_OR_GREATER
+#else
+, ISerializable
+#endif
 {
     /// <summary>Represents the pattern of a (potential) valid week date.</summary>
     private static readonly Regex Pattern = new(
@@ -140,6 +144,8 @@ public readonly partial struct WeekDate : ISerializable, IXmlSerializable, IForm
         return start.AddDays(-adddays);
     }
 
+#if NET8_0_OR_GREATER
+#else
     /// <summary>Initializes a new instance of the <see cref="WeekDate"/> struct.</summary>
     /// <param name="info">The serialization info.</param>
     /// <param name="context">The streaming context.</param>
@@ -157,6 +163,7 @@ public readonly partial struct WeekDate : ISerializable, IXmlSerializable, IForm
         Guard.NotNull(info);
         info.AddValue("Value", m_Value);
     }
+#endif
 
     /// <summary>Serializes the week date to a JSON node.</summary>
     /// <returns>

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -10,7 +10,7 @@
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(YearJsonConverter))]
 #endif
-public readonly partial struct Year : ISerializable, IXmlSerializable, IFormattable, IEquatable<Year>, IComparable, IComparable<Year>
+public readonly partial struct Year : IXmlSerializable, IFormattable, IEquatable<Year>, IComparable, IComparable<Year>
 {
     /// <summary>Represents an empty/not set year.</summary>
     public static readonly Year Empty;

--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -21,7 +21,7 @@ namespace Qowaiv;
 #if NET5_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.YesNoJsonConverter))]
 #endif
-public readonly partial struct YesNo : ISerializable, IXmlSerializable, IFormattable, IEquatable<YesNo>, IComparable, IComparable<YesNo>
+public readonly partial struct YesNo : IXmlSerializable, IFormattable, IEquatable<YesNo>, IComparable, IComparable<YesNo>
 {
     /// <summary>Represents an empty/not set yes-no.</summary>
     public static readonly YesNo Empty;


### PR DESCRIPTION
Add target frameworks, adjust build, and disable not longer supported binary serialization tests for .NET 8.