### PR TITLE
ICustomFormatProvider should only be applied when it does not return null

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ or what suits the SVO best.
 ### Support
 Multiple scenarios are supported:
 * Parsing
-* Formatting
+* Formatting (including `ICustomFormatter`)
 * Validation
 * Serialization (JSON, XML, in-memory)
 * Model binding
@@ -700,242 +700,242 @@ SVO's. To make this as simple as possible, Qowaiv SVO's are decorated with the
 and if the data type is nullable, all when applicable.
 
 ``` json
-    {
-      "Date": {
-        "description": "Full-date notation as defined by RFC 3339, section 5.6.",
-        "example": "2017-06-10",
-        "type": "string",
-        "format": "date",
-        "nullabe": false
-      },
-      "DateSpan": {
-        "description": "Date span, specified in years, months and days.",
-        "example": "1Y+10M+16D",
-        "type": "string",
-        "format": "date-span",
-        "pattern": "[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D",
-        "nullabe": false
-      },
-      "EmailAddress": {
-        "description": "Email notation as defined by RFC 5322.",
-        "example": "svo@qowaiv.org",
-        "type": "string",
-        "format": "email",
-        "nullabe": true
-      },
-      "EmailAddressCollection": {
-        "description": "Comma separated list of email addresses defined by RFC 5322.",
-        "example": "info@qowaiv.org,test@test.com",
-        "type": "string",
-        "format": "email-collection",
-        "nullabe": true
-      },
-      "HouseNumber": {
-        "description": "House number notation.",
-        "example": "13",
-        "type": "string",
-        "format": "house-number",
-        "nullabe": true
-      },
-      "LocalDateTime": {
-        "description": "Date-time notation as defined by RFC 3339, without time zone information.",
-        "example": "2017-06-10 15:00",
-        "type": "string",
-        "format": "local-date-time",
-        "nullabe": false
-      },
-      "Month": {
-        "description": "Month(-only) notation.",
-        "example": "Jun",
-        "type": "string",
-        "format": "month",
-        "nullabe": true,
-        "enum": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "?"]
-      },
-      "MonthSpan": {
-        "description": "Month span, specified in years and months.",
-        "example": "1Y+10M",
-        "type": "string",
-        "format": "month-span",
-        "pattern": "[+-]?[0-9]+Y[+-][0-9]+M",
-        "nullabe": false
-      },
-      "Percentage": {
-        "description": "Ratio expressed as a fraction of 100 denoted using the percent sign '%'.",
-        "example": "13.76%",
-        "type": "string",
-        "format": "percentage",
-        "pattern": "-?[0-9]+(\\.[0-9]+)?%",
-        "nullabe": false
-      },
-      "PostalCode": {
-        "description": "Postal code notation.",
-        "example": "2624DP",
-        "type": "string",
-        "format": "postal-code",
-        "nullabe": true
-      },
-      "Sex": {
-        "description": "Sex as specified by ISO/IEC 5218.",
-        "example": "female",
-        "type": "string",
-        "format": "sex",
-        "nullabe": true,
-        "enum": ["NotKnown", "Male", "Female", "NotApplicable"]
-      },
-      "Uuid": {
-        "description": "Universally unique identifier, Base64 encoded.",
-        "example": "lmZO_haEOTCwGsCcbIZFFg",
-        "type": "string",
-        "format": "uuid-base64",
-        "nullabe": true
-      },
-      "WeekDate": {
-        "description": "Full-date notation as defined by ISO 8601.",
-        "example": "1997-W14-6",
-        "type": "string",
-        "format": "date-weekbased",
-        "nullabe": false
-      },
-      "Year": {
-        "description": "Year(-only) notation.",
-        "example": 1983,
-        "type": "integer",
-        "format": "year",
-        "nullabe": true
-      },
-      "YesNo": {
-        "description": "Yes-No notation.",
-        "example": "yes",
-        "type": "string",
-        "format": "yes-no",
-        "nullabe": true,
-        "enum": ["yes", "no", "?"]
-      },
-      "Chemistry.CasRegistryNumber": {
-        "description": "CAS Registry Number",
-        "example": "7732-18-5",
-        "type": "string",
-        "format": "cas-nr",
-        "pattern": "[1-9][0-9]+\\-[0-9]{2}\\-[0-9]",
-        "nullabe": true
-      },
-      "Financial.Amount": {
-        "description": "Decimal representation of a currency amount.",
-        "example": 15.95,
-        "type": "number",
-        "format": "amount",
-        "nullabe": false
-      },
-      "Financial.BusinessIdentifierCode": {
-        "description": "Business Identifier Code, as defined by ISO 9362.",
-        "example": "DEUTDEFF",
-        "type": "string",
-        "format": "bic",
-        "nullabe": true
-      },
-      "Financial.Currency": {
-        "description": "Currency notation as defined by ISO 4217.",
-        "example": "EUR",
-        "type": "string",
-        "format": "currency",
-        "nullabe": true
-      },
-      "Financial.InternationalBankAccountNumber": {
-        "description": "International Bank Account Number notation as defined by ISO 13616:2007.",
-        "example": "BE71096123456769.",
-        "type": "string",
-        "format": "iban",
-        "nullabe": true
-      },
-      "Financial.Money": {
-        "description": "Combined currency and amount notation as defined by ISO 4217.",
-        "example": "EUR12.47",
-        "type": "string",
-        "format": "money",
-        "pattern": "[A-Z]{3} -?[0-9]+(\\.[0-9]+)?",
-        "nullabe": false
-      },
-      "Globalization.Country": {
-        "description": "Country notation as defined by ISO 3166-1 alpha-2.",
-        "example": "NL",
-        "type": "string",
-        "format": "country",
-        "nullabe": true
-      },
-      "Identifiers.GuidBehavior": {
-        "description": "GUID based identifier",
-        "example": "8a1a8c42-d2ff-e254-e26e-b6abcbf19420",
-        "type": "string",
-        "format": "guid",
-        "nullabe": true
-      },
-      "Identifiers.Int32IdBehavior": {
-        "description": "Int32 based identifier",
-        "example": 17,
-        "type": "integer",
-        "format": "identifier",
-        "nullabe": true
-      },
-      "Identifiers.Int64IdBehavior": {
-        "description": "Int64 based identifier",
-        "example": 17,
-        "type": "integer",
-        "format": "identifier",
-        "nullabe": true
-      },
-      "Identifiers.StringIdBehavior": {
-        "description": "String based identifier",
-        "example": "Order-UK-2022-215",
-        "type": "string",
-        "format": "identifier",
-        "nullabe": true
-      },
-      "Identifiers.UuidBehavior": {
-        "description": "UUID based identifier",
-        "example": "lmZO_haEOTCwGsCcbIZFFg",
-        "type": "string",
-        "format": "uuid-base64",
-        "nullabe": true
-      },
-      "IO.StreamSize": {
-        "description": "Stream size notation (in byte).",
-        "example": 1024,
-        "type": "integer",
-        "format": "stream-size",
-        "nullabe": false
-      },
-      "Mathematics.Fraction": {
-        "description": "Faction",
-        "example": "13/42",
-        "type": "string",
-        "format": "faction",
-        "pattern": "-?[0-9]+(/[0-9]+)?",
-        "nullabe": false
-      },
-      "Statistics.Elo": {
-        "description": "Elo rating system notation.",
-        "example": 1600.0,
-        "type": "number",
-        "format": "elo",
-        "nullabe": false
-      },
-      "Sustainability.EnergyLabel": {
-        "description": "EU energy label",
-        "example": "A++",
-        "type": "string",
-        "format": "energy-label",
-        "pattern": "[A-H]|A\\+{1,4}",
-        "nullabe": true
-      },
-      "Web.InternetMediaType": {
-        "description": "Media type notation as defined by RFC 6838.",
-        "example": "text/html",
-        "type": "string",
-        "format": "internet-media-type",
-        "nullabe": true
-      }
-    }
+{
+  "Date": {
+    "description": "Full-date notation as defined by RFC 3339, section 5.6.",
+    "example": "2017-06-10",
+    "type": "string",
+    "format": "date",
+    "nullabe": false
+  },
+  "DateSpan": {
+    "description": "Date span, specified in years, months and days.",
+    "example": "1Y+10M+16D",
+    "type": "string",
+    "format": "date-span",
+    "pattern": "[+-]?[0-9]+Y[+-][0-9]+M[+-][0-9]+D",
+    "nullabe": false
+  },
+  "EmailAddress": {
+    "description": "Email notation as defined by RFC 5322.",
+    "example": "svo@qowaiv.org",
+    "type": "string",
+    "format": "email",
+    "nullabe": true
+  },
+  "EmailAddressCollection": {
+    "description": "Comma separated list of email addresses defined by RFC 5322.",
+    "example": "info@qowaiv.org,test@test.com",
+    "type": "string",
+    "format": "email-collection",
+    "nullabe": true
+  },
+  "HouseNumber": {
+    "description": "House number notation.",
+    "example": "13",
+    "type": "string",
+    "format": "house-number",
+    "nullabe": true
+  },
+  "LocalDateTime": {
+    "description": "Date-time notation as defined by RFC 3339, without time zone information.",
+    "example": "2017-06-10 15:00",
+    "type": "string",
+    "format": "local-date-time",
+    "nullabe": false
+  },
+  "Month": {
+    "description": "Month(-only) notation.",
+    "example": "Jun",
+    "type": "string",
+    "format": "month",
+    "nullabe": true,
+    "enum": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "?"]
+  },
+  "MonthSpan": {
+    "description": "Month span, specified in years and months.",
+    "example": "1Y+10M",
+    "type": "string",
+    "format": "month-span",
+    "pattern": "[+-]?[0-9]+Y[+-][0-9]+M",
+    "nullabe": false
+  },
+  "Percentage": {
+    "description": "Ratio expressed as a fraction of 100 denoted using the percent sign '%'.",
+    "example": "13.76%",
+    "type": "string",
+    "format": "percentage",
+    "pattern": "-?[0-9]+(\\.[0-9]+)?%",
+    "nullabe": false
+  },
+  "PostalCode": {
+    "description": "Postal code notation.",
+    "example": "2624DP",
+    "type": "string",
+    "format": "postal-code",
+    "nullabe": true
+  },
+  "Sex": {
+    "description": "Sex as specified by ISO/IEC 5218.",
+    "example": "female",
+    "type": "string",
+    "format": "sex",
+    "nullabe": true,
+    "enum": ["NotKnown", "Male", "Female", "NotApplicable"]
+  },
+  "Uuid": {
+    "description": "Universally unique identifier, Base64 encoded.",
+    "example": "lmZO_haEOTCwGsCcbIZFFg",
+    "type": "string",
+    "format": "uuid-base64",
+    "nullabe": true
+  },
+  "WeekDate": {
+    "description": "Full-date notation as defined by ISO 8601.",
+    "example": "1997-W14-6",
+    "type": "string",
+    "format": "date-weekbased",
+    "nullabe": false
+  },
+  "Year": {
+    "description": "Year(-only) notation.",
+    "example": 1983,
+    "type": "integer",
+    "format": "year",
+    "nullabe": true
+  },
+  "YesNo": {
+    "description": "Yes-No notation.",
+    "example": "yes",
+    "type": "string",
+    "format": "yes-no",
+    "nullabe": true,
+    "enum": ["yes", "no", "?"]
+  },
+  "Chemistry.CasRegistryNumber": {
+    "description": "CAS Registry Number",
+    "example": "7732-18-5",
+    "type": "string",
+    "format": "cas-nr",
+    "pattern": "[1-9][0-9]+\\-[0-9]{2}\\-[0-9]",
+    "nullabe": true
+  },
+  "Financial.Amount": {
+    "description": "Decimal representation of a currency amount.",
+    "example": 15.95,
+    "type": "number",
+    "format": "amount",
+    "nullabe": false
+  },
+  "Financial.BusinessIdentifierCode": {
+    "description": "Business Identifier Code, as defined by ISO 9362.",
+    "example": "DEUTDEFF",
+    "type": "string",
+    "format": "bic",
+    "nullabe": true
+  },
+  "Financial.Currency": {
+    "description": "Currency notation as defined by ISO 4217.",
+    "example": "EUR",
+    "type": "string",
+    "format": "currency",
+    "nullabe": true
+  },
+  "Financial.InternationalBankAccountNumber": {
+    "description": "International Bank Account Number notation as defined by ISO 13616:2007.",
+    "example": "BE71096123456769.",
+    "type": "string",
+    "format": "iban",
+    "nullabe": true
+  },
+  "Financial.Money": {
+    "description": "Combined currency and amount notation as defined by ISO 4217.",
+    "example": "EUR12.47",
+    "type": "string",
+    "format": "money",
+    "pattern": "[A-Z]{3} -?[0-9]+(\\.[0-9]+)?",
+    "nullabe": false
+  },
+  "Globalization.Country": {
+    "description": "Country notation as defined by ISO 3166-1 alpha-2.",
+    "example": "NL",
+    "type": "string",
+    "format": "country",
+    "nullabe": true
+  },
+  "Identifiers.GuidBehavior": {
+    "description": "GUID based identifier",
+    "example": "8a1a8c42-d2ff-e254-e26e-b6abcbf19420",
+    "type": "string",
+    "format": "guid",
+    "nullabe": true
+  },
+  "Identifiers.Int32IdBehavior": {
+    "description": "Int32 based identifier",
+    "example": 17,
+    "type": "integer",
+    "format": "identifier",
+    "nullabe": true
+  },
+  "Identifiers.Int64IdBehavior": {
+    "description": "Int64 based identifier",
+    "example": 17,
+    "type": "integer",
+    "format": "identifier",
+    "nullabe": true
+  },
+  "Identifiers.StringIdBehavior": {
+    "description": "String based identifier",
+    "example": "Order-UK-2022-215",
+    "type": "string",
+    "format": "identifier",
+    "nullabe": true
+  },
+  "Identifiers.UuidBehavior": {
+    "description": "UUID based identifier",
+    "example": "lmZO_haEOTCwGsCcbIZFFg",
+    "type": "string",
+    "format": "uuid-base64",
+    "nullabe": true
+  },
+  "IO.StreamSize": {
+    "description": "Stream size notation (in byte).",
+    "example": 1024,
+    "type": "integer",
+    "format": "stream-size",
+    "nullabe": false
+  },
+  "Mathematics.Fraction": {
+    "description": "Faction",
+    "example": "13/42",
+    "type": "string",
+    "format": "faction",
+    "pattern": "-?[0-9]+(/[0-9]+)?",
+    "nullabe": false
+  },
+  "Statistics.Elo": {
+    "description": "Elo rating system notation.",
+    "example": 1600.0,
+    "type": "number",
+    "format": "elo",
+    "nullabe": false
+  },
+  "Sustainability.EnergyLabel": {
+    "description": "EU energy label",
+    "example": "A++",
+    "type": "string",
+    "format": "energy-label",
+    "pattern": "[A-H]|A\\+{1,4}",
+    "nullabe": true
+  },
+  "Web.InternetMediaType": {
+    "description": "Media type notation as defined by RFC 6838.",
+    "example": "text/html",
+    "type": "string",
+    "format": "internet-media-type",
+    "nullabe": true
+  }
+}
 ```
   
 #### Open API using Swagger 
@@ -1060,7 +1060,12 @@ debugger display attribute refers to a property instead.
 ## Qowaiv Formatting
 Formatting is an important part of the functionality in Qowaiv. All SVO's 
 implement IFormattable, and have custom formatting. For details, see the 
-different remarks at the ToString(string, IFormatProvider).
+different remarks at the `ToString(string, IFormatProvider)`.
+
+All SVO's support the `ICustomFormatter` interface; if the `IFormatProvider`
+returns an `ICustomFormatter` on the `GetFormat(Type? type)` call and the
+custom formatter actually returns a non-null string that formatted result is
+returned by `ToString(string, IFormatProvider)`.
 
 ### Formatting arguments
 The formatting arguments object, is a container object (struct) of the format 

--- a/specs/Qowaiv.Specs/Formatting/String_formatter_specs.cs
+++ b/specs/Qowaiv.Specs/Formatting/String_formatter_specs.cs
@@ -1,0 +1,40 @@
+﻿namespace String_formatter_specs;
+
+public class TryApplyCustomFormatter
+{
+    [Test]
+    public void false_if_no_customformatter_could_be_found()
+    {
+        StringFormatter.TryApplyCustomFormatter("", 42, CultureInfo.InvariantCulture, out var formatted)
+            .Should().BeFalse();
+
+        formatted.Should().Be(string.Empty);
+    }
+
+    [Test]
+    public void false_if_customformatter_could_be_found_but_returns_null()
+    {
+        StringFormatter.TryApplyCustomFormatter("", 42, new CustomFormatter(), out var formatted)
+            .Should().BeFalse();
+
+        formatted.Should().Be(string.Empty);
+    }
+
+    [Test]
+    public void true_if_customformatter_could_be_found()
+    {
+        StringFormatter.TryApplyCustomFormatter("", -42, new CustomFormatter(), out var formatted)
+            .Should().BeTrue();
+
+        formatted.Should().Be("-42");
+    }
+
+    private sealed class CustomFormatter : IFormatProvider, ICustomFormatter
+    {
+        public string? Format(string? format, object? arg, IFormatProvider? formatProvider)
+            => arg is int n && n < 0 ? n.ToString() : null;
+
+        public object? GetFormat(Type? formatType)
+            => formatType == typeof(ICustomFormatter) ? this : null;
+    }
+}

--- a/specs/Qowaiv.Specs/Formatting/String_formatter_specs.cs
+++ b/specs/Qowaiv.Specs/Formatting/String_formatter_specs.cs
@@ -31,8 +31,8 @@ public class TryApplyCustomFormatter
 
     private sealed class CustomFormatter : IFormatProvider, ICustomFormatter
     {
-        public string? Format(string? format, object? arg, IFormatProvider? formatProvider)
-            => arg is int n && n < 0 ? n.ToString() : null;
+        public string Format(string? format, object? arg, IFormatProvider? formatProvider)
+            => arg is int n && n < 0 ? n.ToString() : null!;
 
         public object? GetFormat(Type? formatType)
             => formatType == typeof(ICustomFormatter) ? this : null;

--- a/src/Qowaiv/Formatting/StringFormatter.cs
+++ b/src/Qowaiv/Formatting/StringFormatter.cs
@@ -118,9 +118,9 @@ public static class StringFormatter
     /// </returns>
     public static bool TryApplyCustomFormatter(string? format, object obj, IFormatProvider? formatProvider, out string formatted)
     {
-        if (formatProvider.TryGetCustomFormatter() is { } customFormatter)
+        if (formatProvider.TryGetCustomFormatter()?.Format(format, obj, formatProvider) is { } customFormatted)
         {
-            formatted = customFormatter.Format(format, obj, formatProvider);
+            formatted = customFormatted;
             return true;
         }
         else

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,8 +9,9 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 ToBeReleased
+- TryApplyCustomFormatter should return false if the provider returns null. #340
 - Extend API with overloads for DateOnly. #339
-- Detailed information on failing parsing.
+- Detailed information on failing parsing. #336
 v6.5.4
 - SVO's can be used as keys when applying JSON serialization. #334
 v6.5.3

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,7 +9,7 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 ToBeReleased
-- TryApplyCustomFormatter should return false if the provider returns null. #340
+- TryApplyCustomFormatter should return false if the provider returns null. #341
 - Extend API with overloads for DateOnly. #339
 - Detailed information on failing parsing. #336
 v6.5.4


### PR DESCRIPTION
An `ICustomFormatProvider` should  not be enforced to know how to format all types. It can indicate this be return `null`.