### PR TITLE
Reduce usage of Assert.*

### DIFF
--- a/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
+++ b/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="NUnit" Version="3.*" />
+    <PackageReference Include="NUnit" Version="4.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.*" PrivateAssets="all" />
   </ItemGroup>
 

--- a/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/TypeConverterModelBinderTest.cs
+++ b/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/TypeConverterModelBinderTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using NUnit.Framework;
 using Qowaiv.TestTools.Globalization;
 using System;
@@ -24,12 +25,14 @@ public class TypeConverterModelBinderTest
 
             await binder.BindModelAsync(context);
 
-            Assert.AreEqual(ModelValidationState.Invalid, context.ModelState.ValidationState);
+            context.ModelState.ValidationState.Should().Be(ModelValidationState.Invalid);
 
-            var error = context.ModelState[TheModelName].Errors.FirstOrDefault();
-
-            Assert.AreEqual("Geen geldige datum", error.ErrorMessage);
-            Assert.IsNull(error.Exception);
+            context.ModelState[TheModelName].Errors.FirstOrDefault()
+                .Should().BeEquivalentTo(new
+                {
+                    ErrorMessage = "Geen geldige datum",
+                    Exception = (Exception?)null,
+                });
         }
     }
 
@@ -43,8 +46,8 @@ public class TypeConverterModelBinderTest
 
         await binder.BindModelAsync(context);
 
-        Assert.AreEqual(ModelValidationState.Unvalidated, context.ModelState.ValidationState);
-        Assert.IsNull(context.Result.Model);
+        context.ModelState.ValidationState.Should().Be(ModelValidationState.Unvalidated);
+        context.Result.Model.Should().BeNull();
     }
 
     [Test]
@@ -57,8 +60,8 @@ public class TypeConverterModelBinderTest
 
         await binder.BindModelAsync(context);
 
-        Assert.AreEqual(ModelValidationState.Unvalidated, context.ModelState.ValidationState);
-        Assert.AreEqual(new Date(2017, 06, 11), context.Result.Model);
+        context.ModelState.ValidationState.Should().Be(ModelValidationState.Unvalidated);
+        context.Result.Model.Should().Be(new Date(2017, 06, 11));
     }
 
     private static DefaultModelBindingContext GetBindingContext(Type modelType)

--- a/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/TypeConverterModelBinderTest.cs
+++ b/example/Qowaiv.AspNetCore.Mvc.ModelBinding.UnitTests/TypeConverterModelBinderTest.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿#nullable enable
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using NUnit.Framework;
 using Qowaiv.TestTools.Globalization;

--- a/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
+++ b/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
@@ -256,7 +256,7 @@ public class Is_comparable
     public void to_CasRegistryNumber_as_object()
     {
         object obj = Svo.CasRegistryNumber;
-        Assert.AreEqual(0, Svo.CasRegistryNumber.CompareTo(obj));
+        Svo.CasRegistryNumber.CompareTo(obj).Should().Be(0);
     }
 
     [Test]
@@ -281,7 +281,7 @@ public class Is_comparable
         var list = new List<CasRegistryNumber> { sorted[3], sorted[4], sorted[5], sorted[2], sorted[0], sorted[1] };
         list.Sort();
 
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 }
 

--- a/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
+++ b/specs/Qowaiv.Specs/Chemistry/CAS_Registry_Number_specs.cs
@@ -470,7 +470,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.CasRegistryNumber);
-        Svo.CasRegistryNumber.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.CasRegistryNumber);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
@@ -466,7 +466,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.CustomSvo);
-        Svo.CustomSvo.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.CustomSvo);
     }
     [Test]
     public void storing_string_in_SerializationInfo()

--- a/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
@@ -249,7 +249,7 @@ public class Has_custom_formatting
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(expected);
         }
     }
 
@@ -260,7 +260,7 @@ public class Has_custom_formatting
             culture: TestCultures.Nl_NL,
             cultureUI: TestCultures.En_GB))
         {
-            Assert.AreEqual("QOWAIV", Svo.CustomSvo.ToString(provider: null));
+            Svo.CustomSvo.ToString(provider: null).Should().Be("QOWAIV");
         }
     }
 }
@@ -274,7 +274,7 @@ public class Is_comparable
     public void to_Svo_as_object()
     {
         object obj = Svo.CustomSvo;
-        Assert.AreEqual(0, Svo.CustomSvo.CompareTo(obj));
+        Svo.CustomSvo.CompareTo(obj).Should().Be(0);
     }
 
     [Test]
@@ -299,7 +299,7 @@ public class Is_comparable
         var list = new List<CustomSvo> { sorted[3], sorted[4], sorted[5], sorted[2], sorted[0], sorted[1] };
         list.Sort();
 
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 }
 

--- a/specs/Qowaiv.Specs/Date_span_specs.cs
+++ b/specs/Qowaiv.Specs/Date_span_specs.cs
@@ -95,6 +95,21 @@ public class Supports_JSON_serialization
     }
 }
 
+#if NET8_0_OR_GREATER
+#else
+public class Supports_binary_serialization
+{
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void using_BinaryFormatter()
+        => SerializeDeserialize.Binary(Svo.DateSpan).Should().Be(Svo.DateSpan);
+
+    [Test]
+    public void storing_string_in_SerializationInfo()
+        => Serialize.GetInfo(Svo.DateSpan).GetUInt64("Value").Should().Be(532575944699UL);
+}
+#endif
+
 public class Is_Open_API_data_type
 {
     [Test]

--- a/specs/Qowaiv.Specs/Email_address_collection_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_collection_specs.cs
@@ -1,0 +1,21 @@
+﻿namespace Email_address_collection_specs;
+
+#if NET8_0_OR_GREATER
+#else
+public class Supports_binary_serialization
+{
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void using_BinaryFormatter()
+    {
+        var round_tripped = SerializeDeserialize.Binary(Svo.EmailAddressCollection);
+        round_tripped.Should().BeEquivalentTo(Svo.EmailAddressCollection);
+    }
+    [Test]
+    public void storing_string_in_SerializationInfo()
+    {
+        var info = Serialize.GetInfo(Svo.EmailAddressCollection);
+        info.GetString("Value").Should().Be("info@qowaiv.org,test@qowaiv.org");
+    }
+}
+#endif

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -70,9 +70,7 @@ public class Has_constant
 {
     [Test]
     public void Empty_represent_default_value()
-    {
-        EmailAddress.Empty.Should().Be(default(EmailAddress));
-    }
+        => EmailAddress.Empty.Should().Be(default);
 }
 
 public class Is_equal_by_value

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -71,7 +71,7 @@ public class Has_constant
     [Test]
     public void Empty_represent_default_value()
     {
-        Assert.AreEqual(default(EmailAddress), EmailAddress.Empty);
+        EmailAddress.Empty.Should().Be(default(EmailAddress));
     }
 }
 
@@ -141,19 +141,19 @@ public class Can_be_parsed
     [Test]
     public void from_null_string_represents_Empty()
     {
-        Assert.AreEqual(EmailAddress.Empty, EmailAddress.Parse(null));
+        EmailAddress.Parse(null).Should().Be(EmailAddress.Empty);
     }
 
     [Test]
     public void from_empty_string_represents_Empty()
     {
-        Assert.AreEqual(EmailAddress.Empty, EmailAddress.Parse(string.Empty));
+        EmailAddress.Parse(string.Empty).Should().Be(EmailAddress.Empty);
     }
 
     [Test]
     public void from_question_mark_represents_Unknown()
     {
-        Assert.AreEqual(EmailAddress.Unknown, EmailAddress.Parse("?"));
+        EmailAddress.Parse("?").Should().Be(EmailAddress.Unknown);
     }
 
     [TestCase("en", "info@qowaiv.org")]
@@ -162,7 +162,7 @@ public class Can_be_parsed
         using (culture.Scoped())
         {
             var parsed = EmailAddress.Parse(input);
-            Assert.AreEqual(Svo.EmailAddress, parsed);
+            parsed.Should().Be(Svo.EmailAddress);
         }
     }
 
@@ -172,7 +172,7 @@ public class Can_be_parsed
         using (TestCultures.En_GB.Scoped())
         {
             var exception = Assert.Throws<FormatException>(() => EmailAddress.Parse("invalid input"));
-            Assert.AreEqual("Not a valid email address", exception.Message);
+            exception.Message.Should().Be("Not a valid email address");
         }
     }
 
@@ -189,7 +189,7 @@ public class Can_be_parsed
     [Test]
     public void with_TryParse_returns_SVO()
     {
-        Assert.AreEqual(Svo.EmailAddress, EmailAddress.TryParse("info@qowaiv.org"));
+        EmailAddress.TryParse("info@qowaiv.org").Should().Be(Svo.EmailAddress);
     }
 }
 
@@ -200,7 +200,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual("info@qowaiv.org", Svo.EmailAddress.ToString());
+            Svo.EmailAddress.ToString().Should().Be("info@qowaiv.org");
         }
     }
 
@@ -209,7 +209,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.EmailAddress.ToString(), Svo.EmailAddress.ToString(default(string)));
+            Svo.EmailAddress.ToString(default(string)).Should().Be(Svo.EmailAddress.ToString());
         }
     }
 
@@ -218,20 +218,20 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.EmailAddress.ToString(), Svo.EmailAddress.ToString(string.Empty));
+            Svo.EmailAddress.ToString(string.Empty).Should().Be(Svo.EmailAddress.ToString());
         }
     }
 
     [Test]
     public void default_value_is_represented_as_string_empty()
     {
-        Assert.AreEqual(string.Empty, default(EmailAddress).ToString());
+        default(EmailAddress).ToString().Should().Be(string.Empty);
     }
 
     [Test]
     public void unknown_value_is_represented_as_unknown()
     {
-        Assert.AreEqual("?", EmailAddress.Unknown.ToString());
+        EmailAddress.Unknown.ToString().Should().Be("?");
     }
 
     [Test]
@@ -247,7 +247,7 @@ public class Has_custom_formatting
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(expected);
         }
     }
 
@@ -256,7 +256,7 @@ public class Has_custom_formatting
     {
         using (new CultureInfoScope(culture: TestCultures.Nl_NL, cultureUI: TestCultures.En_GB))
         {
-            Assert.AreEqual("info@qowaiv.org", Svo.EmailAddress.ToString(provider: null));
+            Svo.EmailAddress.ToString(provider: null).Should().Be("info@qowaiv.org");
         }
     }
 
@@ -284,7 +284,7 @@ public class Is_comparable
     public void to_EmailAddress_as_object()
     {
         object obj = Svo.EmailAddress;
-        Assert.AreEqual(0, Svo.EmailAddress.CompareTo(obj));
+        Svo.EmailAddress.CompareTo(obj).Should().Be(0);
     }
 
     [Test]
@@ -307,7 +307,7 @@ public class Is_comparable
             };
         var list = new List<EmailAddress> { sorted[3], sorted[4], sorted[5], sorted[2], sorted[0], sorted[1] };
         list.Sort();
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 }
 
@@ -415,21 +415,21 @@ public class Supports_XML_serialization
     public void using_XmlSerializer_to_serialize()
     {
         var xml = Serialize.Xml(Svo.EmailAddress);
-        Assert.AreEqual("info@qowaiv.org", xml);
+        xml.Should().Be("info@qowaiv.org");
     }
 
     [Test]
     public void using_XmlSerializer_to_deserialize()
     {
         var svo = Deserialize.Xml<EmailAddress>("info@qowaiv.org");
-        Assert.AreEqual(Svo.EmailAddress, svo);
+        svo.Should().Be(Svo.EmailAddress);
     }
 
     [Test]
     public void using_DataContractSerializer()
     {
         var round_tripped = SerializeDeserialize.DataContract(Svo.EmailAddress);
-        Assert.AreEqual(Svo.EmailAddress, round_tripped);
+        round_tripped.Should().Be(Svo.EmailAddress);
     }
 
     [Test]
@@ -437,7 +437,7 @@ public class Supports_XML_serialization
     {
         var structure = XmlStructure.New(Svo.EmailAddress);
         var round_tripped = SerializeDeserialize.Xml(structure);
-        Assert.AreEqual(structure, round_tripped);
+        round_tripped.Should().Be(structure);
     }
 
     [Test]
@@ -478,7 +478,7 @@ public class Supports_binary_serialization
     public void storing_string_in_SerializationInfo()
     {
         var info = Serialize.GetInfo(Svo.EmailAddress);
-        Assert.AreEqual("info@qowaiv.org", info.GetString("Value"));
+        info.GetString("Value").Should().Be("info@qowaiv.org");
     }
 }
 #endif

--- a/specs/Qowaiv.Specs/Email_address_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_specs.cs
@@ -471,7 +471,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.EmailAddress);
-        Assert.AreEqual(Svo.EmailAddress, round_tripped);
+        round_tripped.Should().Be(Svo.EmailAddress);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
@@ -112,8 +112,8 @@ public class Supported
                 Country.XK,
             };
 
-        Assert.AreEqual(supported, InternationalBankAccountNumber.Supported.OrderBy(c => c.IsoAlpha2Code));
-        Assert.AreEqual(103, InternationalBankAccountNumber.Supported.Count);
+        InternationalBankAccountNumber.Supported.OrderBy(c => c.IsoAlpha2Code).Should().BeEquivalentTo(supported);
+        InternationalBankAccountNumber.Supported.Count.Should().Be(103);
     }
 }
 
@@ -252,7 +252,7 @@ public class Input_is_valid
         {
             Assert.IsTrue(InternationalBankAccountNumber.TryParse(input, out InternationalBankAccountNumber iban),
                 $"{input} is invalid for {country.EnglishName}.");
-            Assert.AreEqual(country, iban.Country);
+            iban.Country.Should().Be(country);
         }
     }
 
@@ -260,7 +260,7 @@ public class Input_is_valid
     public void for_country_has_tests_for_all_supported()
     {
         var supported = ValidForCountry.Select(array => array[0]).Cast<Country>();
-        Assert.AreEqual(supported, InternationalBankAccountNumber.Supported.OrderBy(c => c.IsoAlpha2Code));
+        InternationalBankAccountNumber.Supported.OrderBy(c => c.IsoAlpha2Code).Should().BeEquivalentTo(supported);
     }
 
     private static readonly object[][] ValidForCountry =

--- a/specs/Qowaiv.Specs/Gender_specs.cs
+++ b/specs/Qowaiv.Specs/Gender_specs.cs
@@ -537,7 +537,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Gender);
-        Assert.AreEqual(Svo.Gender, round_tripped);
+        round_tripped.Should().Be(Svo.Gender);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Gender_specs.cs
+++ b/specs/Qowaiv.Specs/Gender_specs.cs
@@ -21,7 +21,7 @@ public class With_domain_logic
     [TestCase(true, "")]
     public void IsEmpty_returns(bool result, Gender svo)
     {
-        Assert.AreEqual(result, svo.IsEmpty());
+        svo.IsEmpty().Should().Be(result);
     }
 
     [TestCase(false, "Male")]
@@ -30,7 +30,7 @@ public class With_domain_logic
     [TestCase(true, "")]
     public void IsEmptyOrUnknown_returns(bool result, Gender svo)
     {
-        Assert.AreEqual(result, svo.IsEmptyOrUnknown());
+        svo.IsEmptyOrUnknown().Should().Be(result);
     }
 
     [TestCase(false, "Male")]
@@ -39,7 +39,7 @@ public class With_domain_logic
     [TestCase(false, "")]
     public void IsUnknown_returns(bool result, Gender svo)
     {
-        Assert.AreEqual(result, svo.IsUnknown());
+        svo.IsUnknown().Should().Be(result);
     }
 
     [TestCase(true, "Male")]
@@ -48,7 +48,7 @@ public class With_domain_logic
     [TestCase(false, "")]
     public void IsMaleOrFemale_returns(bool result, Gender svo)
     {
-        Assert.AreEqual(result, svo.IsMaleOrFemale());
+        svo.IsMaleOrFemale().Should().Be(result);
     }
 }
 
@@ -60,14 +60,14 @@ public class Display_name
     {
         using (TestCultures.Nl_BE.Scoped())
         {
-            Assert.AreEqual("Vrouwelijk", Svo.Gender.DisplayName);
+            Svo.Gender.DisplayName.Should().Be("Vrouwelijk");
         }
     }
 
     [Test]
     public void for_custom_culture_if_specified()
     {
-        Assert.AreEqual("Mujer", Svo.Gender.GetDisplayName(TestCultures.Es_EC));
+        Svo.Gender.GetDisplayName(TestCultures.Es_EC).Should().Be("Mujer");
     }
 }
 
@@ -140,7 +140,7 @@ public class Has_constant
     [Test]
     public void Empty_represent_default_value()
     {
-        Assert.AreEqual(default(Gender), Gender.Empty);
+        Gender.Empty.Should().Be(default(Gender));
     }
 }
 
@@ -213,19 +213,19 @@ public class Can_be_parsed
     [Test]
     public void from_null_string_represents_Empty()
     {
-        Assert.AreEqual(Gender.Empty, Gender.Parse(null));
+        Gender.Parse(null).Should().Be(Gender.Empty);
     }
 
     [Test]
     public void from_empty_string_represents_Empty()
     {
-        Assert.AreEqual(Gender.Empty, Gender.Parse(string.Empty));
+        Gender.Parse(string.Empty).Should().Be(Gender.Empty);
     }
 
     [Test]
     public void from_question_mark_represents_Unknown()
     {
-        Assert.AreEqual(Gender.Unknown, Gender.Parse("?"));
+        Gender.Parse("?").Should().Be(Gender.Unknown);
     }
 
     [TestCase("en", "Female")]
@@ -234,7 +234,7 @@ public class Can_be_parsed
         using (culture.Scoped())
         {
             var parsed = Gender.Parse(input);
-            Assert.AreEqual(Svo.Gender, parsed);
+            parsed.Should().Be(Svo.Gender);
         }
     }
 
@@ -244,7 +244,7 @@ public class Can_be_parsed
         using (TestCultures.En_GB.Scoped())
         {
             var exception = Assert.Throws<FormatException>(() => Gender.Parse("invalid input"));
-            Assert.AreEqual("Not a valid gender", exception.Message);
+            exception.Message.Should().Be("Not a valid gender");
         }
     }
 
@@ -261,7 +261,7 @@ public class Can_be_parsed
     [Test]
     public void with_TryParse_returns_SVO()
     {
-        Assert.AreEqual(Svo.Gender, Gender.TryParse("Female"));
+        Gender.TryParse("Female").Should().Be(Svo.Gender);
     }
 }
 
@@ -273,7 +273,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual("Female", Svo.Gender.ToString());
+            Svo.Gender.ToString().Should().Be("Female");
         }
     }
 
@@ -282,7 +282,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.Gender.ToString(), Svo.Gender.ToString(default(string)));
+            Svo.Gender.ToString(default(string)).Should().Be(Svo.Gender.ToString());
         }
     }
 
@@ -291,14 +291,14 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.Gender.ToString(), Svo.Gender.ToString(string.Empty));
+            Svo.Gender.ToString(string.Empty).Should().Be(Svo.Gender.ToString());
         }
     }
 
     [Test]
     public void default_value_is_represented_as_string_empty()
     {
-        Assert.AreEqual(string.Empty, default(Gender).ToString());
+        default(Gender).ToString().Should().Be(string.Empty);
     }
 
     [Test]
@@ -318,7 +318,7 @@ public class Has_custom_formatting
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(expected);
         }
     }
 
@@ -327,7 +327,7 @@ public class Has_custom_formatting
     {
         using (new CultureInfoScope(culture: TestCultures.Nl_NL, cultureUI: TestCultures.En_GB))
         {
-            Assert.AreEqual("Vrouwelijk", Svo.Gender.ToString(provider: null));
+            Svo.Gender.ToString(provider: null).Should().Be("Vrouwelijk");
         }
     }
 }
@@ -342,7 +342,7 @@ public class Is_comparable
     public void to_Gender_as_object()
     {
         object obj = Svo.Gender;
-        Assert.AreEqual(0, Svo.Gender.CompareTo(obj));
+        Svo.Gender.CompareTo(obj).Should().Be(0);
     }
 
     [Test]
@@ -364,7 +364,7 @@ public class Is_comparable
             };
         var list = new List<Gender> { sorted[3], sorted[4], sorted[2], sorted[0], sorted[1] };
         list.Sort();
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 }
 
@@ -375,21 +375,21 @@ public class Casts
     public void explicitly_to_byte()
     {
         var casted = (byte)Svo.Gender;
-        Assert.AreEqual((byte)2, casted);
+        casted.Should().Be((byte)2);
     }
 
     [Test]
     public void explicitly_to_int()
     {
         var casted = (int)Svo.Gender;
-        Assert.AreEqual(2, casted);
+        casted.Should().Be(2);
     }
 
     [TestCase(2, "Female")]
     [TestCase(null, "?")]
     public void explicitly_to_nullable_int(int casted, Gender gender)
     {
-        Assert.AreEqual(casted, (int?)gender);
+        ((int?)gender).Should().Be(casted);
     }
 
     [TestCase("Female", 2)]
@@ -397,7 +397,7 @@ public class Casts
     public void implicitly_from_nullable_int(Gender casted, int? value)
     {
         Gender gender = value;
-        Assert.AreEqual(casted, gender);
+        gender.Should().Be(casted);
     }
 
     [TestCase("Female", 2)]
@@ -405,7 +405,7 @@ public class Casts
     public void implicitly_from_int(Gender casted, int value)
     {
         Gender gender = value;
-        Assert.AreEqual(casted, gender);
+        gender.Should().Be(casted);
     }
 }
 
@@ -430,14 +430,14 @@ public class Supports_JSON_serialization
     public void convention_based_deserialization(Gender expected, object json)
     {
         var actual = JsonTester.Read<Gender>(json);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [TestCase(null, "")]
     public void convention_based_serialization(object expected, Gender svo)
     {
         var serialized = JsonTester.Write(svo);
-        Assert.AreEqual(expected, serialized);
+        serialized.Should().Be(expected);
     }
 
     [TestCase("Invalid input", typeof(FormatException))]
@@ -459,21 +459,21 @@ public class Supports_XML_serialization
     [TestCase("Female", "F")]
     public void using_XmlSerializer_to_serialize(string xml, Gender gender)
     {
-        Assert.AreEqual(xml, Serialize.Xml(gender));
+        Serialize.Xml(gender).Should().Be(xml);
     }
 
     [Test]
     public void using_XmlSerializer_to_deserialize()
     {
         var svo = Deserialize.Xml<Gender>("Female");
-        Assert.AreEqual(Svo.Gender, svo);
+        svo.Should().Be(Svo.Gender);
     }
 
     [Test]
     public void using_DataContractSerializer()
     {
         var round_tripped = SerializeDeserialize.DataContract(Svo.Gender);
-        Assert.AreEqual(Svo.Gender, round_tripped);
+        round_tripped.Should().Be(Svo.Gender);
     }
 
     [Test]
@@ -481,7 +481,7 @@ public class Supports_XML_serialization
     {
         var structure = XmlStructure.New(Svo.Gender);
         var round_tripped = SerializeDeserialize.Xml(structure);
-        Assert.AreEqual(structure, round_tripped);
+        round_tripped.Should().Be(structure);
     }
 
     [Test]
@@ -506,13 +506,13 @@ public class Is_Open_API_data_type
     [Test]
     public void has_type()
     {
-        Assert.AreEqual("string", Attribute.Type);
+        Attribute.Type.Should().Be("string");
     }
 
     [Test]
     public void has_format()
     {
-        Assert.AreEqual("gender", Attribute.Format);
+        Attribute.Format.Should().Be("gender");
     }
 
     [Test]
@@ -544,7 +544,7 @@ public class Supports_binary_serialization
     public void storing_byte_in_SerializationInfo()
     {
         var info = Serialize.GetInfo(Svo.Gender);
-        Assert.AreEqual((byte)4, info.GetByte("Value"));
+        info.GetByte("Value").Should().Be((byte)4);
     }
 }
 #endif

--- a/specs/Qowaiv.Specs/Globalization/Country_specs.cs
+++ b/specs/Qowaiv.Specs/Globalization/Country_specs.cs
@@ -199,7 +199,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Country);
-        Svo.Country.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.Country);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -139,7 +139,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.CustomGuid);
-        Svo.CustomGuid.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.CustomGuid);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
@@ -129,7 +129,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Int32Id);
-        Svo.Int32Id.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.Int32Id);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -135,7 +135,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Int64Id);
-        Svo.Int64Id.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.Int64Id);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_String_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_String_specs.cs
@@ -87,7 +87,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.StringId);
-        Svo.StringId.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.StringId);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
+++ b/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
@@ -289,7 +289,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Fraction);
-        Svo.Fraction.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.Fraction);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -561,7 +561,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Month);
-        Assert.AreEqual(Svo.Month, round_tripped);
+        round_tripped.Should().Be(Svo.Month);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -17,7 +17,7 @@ public class With_domain_logic
     [TestCase(true, "")]
     public void IsEmpty_returns(bool result, Month svo)
     {
-        Assert.AreEqual(result, svo.IsEmpty());
+        svo.IsEmpty().Should().Be(result);
     }
 
     [TestCase(false, "February")]
@@ -25,7 +25,7 @@ public class With_domain_logic
     [TestCase(true, "")]
     public void IsEmptyOrUnknown_returns(bool result, Month svo)
     {
-        Assert.AreEqual(result, svo.IsEmptyOrUnknown());
+        svo.IsEmptyOrUnknown().Should().Be(result);
     }
 
     [TestCase(false, "February")]
@@ -33,7 +33,7 @@ public class With_domain_logic
     [TestCase(false, "")]
     public void IsUnknown_returns(bool result, Month svo)
     {
-        Assert.AreEqual(result, svo.IsUnknown());
+        svo.IsUnknown().Should().Be(result);
     }
 }
 
@@ -47,7 +47,7 @@ public class Days
     [TestCase(30, "November", 2020)]
     public void per_year(int days, Month month, Year year)
     {
-        Assert.AreEqual(days, month.Days(year));
+        month.Days(year).Should().Be(days);
     }
 }
 
@@ -56,25 +56,25 @@ public class Short_name
     [Test]
     public void is_string_empty_for_empty()
     {
-        Assert.AreEqual(string.Empty, Month.Empty.ShortName);
+        Month.Empty.ShortName.Should().Be(string.Empty);
     }
     [Test]
     public void is_question_mark_for_unknown()
     {
-        Assert.AreEqual("?", Month.Unknown.ShortName);
+        Month.Unknown.ShortName.Should().Be("?");
     }
     [Test]
     public void picks_current_culture()
     {
         using (TestCultures.Nl_BE.Scoped())
         {
-            Assert.AreEqual("feb.", Svo.Month.ShortName);
+            Svo.Month.ShortName.Should().Be("feb.");
         }
     }
     [Test]
     public void supports_custom_culture()
     {
-        Assert.AreEqual("feb.", Svo.Month.GetShortName(TestCultures.Nl_BE));
+        Svo.Month.GetShortName(TestCultures.Nl_BE).Should().Be("feb.");
     }
 }
 
@@ -83,25 +83,25 @@ public class Full_name
     [Test]
     public void is_string_empty_for_empty()
     {
-        Assert.AreEqual(string.Empty, Month.Empty.FullName);
+        Month.Empty.FullName.Should().Be(string.Empty);
     }
     [Test]
     public void is_question_mark_for_unknown()
     {
-        Assert.AreEqual("?", Month.Unknown.FullName);
+        Month.Unknown.FullName.Should().Be("?");
     }
     [Test]
     public void picks_current_culture()
     {
         using (TestCultures.Nl_BE.Scoped())
         {
-            Assert.AreEqual("februari", Svo.Month.FullName);
+            Svo.Month.FullName.Should().Be("februari");
         }
     }
     [Test]
     public void supports_custom_culture()
     {
-        Assert.AreEqual("februari", Svo.Month.GetFullName(TestCultures.Nl_BE));
+        Svo.Month.GetFullName(TestCultures.Nl_BE).Should().Be("februari");
     }
 }
 
@@ -110,7 +110,7 @@ public class Has_constant
     [Test]
     public void Empty_represent_default_value()
     {
-        Assert.AreEqual(default(Month), Month.Empty);
+        Month.Empty.Should().Be(default(Month));
     }
 }
 
@@ -180,19 +180,19 @@ public class Can_be_parsed
     [Test]
     public void from_null_string_represents_Empty()
     {
-        Assert.AreEqual(Month.Empty, Month.Parse(null));
+        Month.Parse(null).Should().Be(Month.Empty);
     }
 
     [Test]
     public void from_empty_string_represents_Empty()
     {
-        Assert.AreEqual(Month.Empty, Month.Parse(string.Empty));
+        Month.Parse(string.Empty).Should().Be(Month.Empty);
     }
 
     [Test]
     public void from_question_mark_represents_Unknown()
     {
-        Assert.AreEqual(Month.Unknown, Month.Parse("?"));
+        Month.Parse("?").Should().Be(Month.Unknown);
     }
 
     [TestCase("en", "February")]
@@ -203,7 +203,7 @@ public class Can_be_parsed
         using (culture.Scoped())
         {
             var parsed = Month.Parse(input);
-            Assert.AreEqual(Svo.Month, parsed);
+            parsed.Should().Be(Svo.Month);
         }
     }
 
@@ -213,7 +213,7 @@ public class Can_be_parsed
         using (TestCultures.En_GB.Scoped())
         {
             var exception = Assert.Throws<FormatException>(() => Month.Parse("invalid input"));
-            Assert.AreEqual("Not a valid month", exception.Message);
+            exception.Message.Should().Be("Not a valid month");
         }
     }
 
@@ -230,7 +230,7 @@ public class Can_be_parsed
     [Test]
     public void with_TryParse_returns_SVO()
     {
-        Assert.AreEqual(Svo.Month, Month.TryParse("February"));
+        Month.TryParse("February").Should().Be(Svo.Month);
     }
 }
 
@@ -239,12 +239,12 @@ public class Can_be_created
     [Test]
     public void with_TryCreate_returns_SVO()
     {
-        Assert.AreEqual(Svo.Month, Month.TryCreate(2));
+        Month.TryCreate(2).Should().Be(Svo.Month);
     }
     [Test]
     public void with_TryCreate_returns_Empty()
     {
-        Assert.AreEqual(Month.Empty, Month.TryCreate(null));
+        Month.TryCreate(null).Should().Be(Month.Empty);
     }
 }
 public class Has_custom_formatting
@@ -254,7 +254,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual("February", Svo.Month.ToString());
+            Svo.Month.ToString().Should().Be("February");
         }
     }
 
@@ -263,7 +263,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.Month.ToString(), Svo.Month.ToString(default(string)));
+            Svo.Month.ToString(default(string)).Should().Be(Svo.Month.ToString());
         }
     }
 
@@ -272,20 +272,20 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.Month.ToString(), Svo.Month.ToString(string.Empty));
+            Svo.Month.ToString(string.Empty).Should().Be(Svo.Month.ToString());
         }
     }
 
     [Test]
     public void default_value_is_represented_as_string_empty()
     {
-        Assert.AreEqual(string.Empty, default(Month).ToString());
+        default(Month).ToString().Should().Be(string.Empty);
     }
 
     [Test]
     public void unknown_value_is_represented_as_unknown()
     {
-        Assert.AreEqual("?", Month.Unknown.ToString());
+        Month.Unknown.ToString().Should().Be("?");
     }
 
     [Test]
@@ -306,7 +306,7 @@ public class Has_custom_formatting
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(expected);
         }
     }
 
@@ -315,7 +315,7 @@ public class Has_custom_formatting
     {
         using (new CultureInfoScope(culture: TestCultures.Nl_NL, cultureUI: TestCultures.En_GB))
         {
-            Assert.AreEqual("februari", Svo.Month.ToString(provider: null));
+            Svo.Month.ToString(provider: null).Should().Be("februari");
         }
     }
 }
@@ -329,7 +329,7 @@ public class Is_comparable
     public void to_Month_as_object()
     {
         object obj = Svo.Month;
-        Assert.AreEqual(0, Svo.Month.CompareTo(obj));
+        Svo.Month.CompareTo(obj).Should().Be(0);
     }
 
     [Test]
@@ -352,7 +352,7 @@ public class Is_comparable
             };
         var list = new List<Month> { sorted[3], sorted[4], sorted[5], sorted[2], sorted[0], sorted[1] };
         list.Sort();
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 
     [Test]
@@ -396,14 +396,14 @@ public class Casts
     public void explicitly_from_byte()
     {
         var casted = (Month)2;
-        Assert.AreEqual(Svo.Month, casted);
+        casted.Should().Be(Svo.Month);
     }
 
     [Test]
     public void explicitly_to_byte()
     {
         var casted = (byte)Svo.Month;
-        Assert.AreEqual(2, casted);
+        casted.Should().Be(2);
     }
 }
 
@@ -518,7 +518,7 @@ public class Supports_XML_serialization
     public void using_DataContractSerializer()
     {
         var round_tripped = SerializeDeserialize.DataContract(Svo.Month);
-        Assert.AreEqual(Svo.Month, round_tripped);
+        round_tripped.Should().Be(Svo.Month);
     }
 
     [Test]
@@ -526,7 +526,7 @@ public class Supports_XML_serialization
     {
         var structure = XmlStructure.New(Svo.Month);
         var round_tripped = SerializeDeserialize.Xml(structure);
-        Assert.AreEqual(structure, round_tripped);
+        round_tripped.Should().Be(structure);
     }
 
     [Test]
@@ -568,7 +568,7 @@ public class Supports_binary_serialization
     public void storing_byte_in_SerializationInfo()
     {
         var info = Serialize.GetInfo(Svo.Month);
-        Assert.AreEqual((byte)2, info.GetByte("Value"));
+        info.GetByte("Value").Should().Be((byte)2);
     }
 }
 #endif

--- a/specs/Qowaiv.Specs/Month_specs.cs
+++ b/specs/Qowaiv.Specs/Month_specs.cs
@@ -109,9 +109,7 @@ public class Has_constant
 {
     [Test]
     public void Empty_represent_default_value()
-    {
-        Month.Empty.Should().Be(default(Month));
-    }
+        => Month.Empty.Should().Be(default);
 }
 
 public class Is_equal_by_value

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -1203,7 +1203,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Percentage);
-        Assert.AreEqual(Svo.Percentage, round_tripped);
+        round_tripped.Should().Be(Svo.Percentage);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -41,7 +41,7 @@ public class Has_constant
     [Test]
     public void Zero_represent_default_value()
     {
-        Assert.AreEqual(default(Percentage), Percentage.Zero);
+        Percentage.Zero.Should().Be(default(Percentage));
     }
 
     [Test]
@@ -130,7 +130,7 @@ public class Can_be_parsed
         using (culture.Scoped())
         {
             var parsed = Percentage.Parse(input);
-            Assert.AreEqual(Svo.Percentage, parsed);
+            parsed.Should().Be(Svo.Percentage);
         }
     }
 
@@ -139,7 +139,7 @@ public class Can_be_parsed
     public void with_custom_culture_with_different_symbols(string input, CultureInfo culture)
     {
         var parsed = Percentage.Parse(input, culture.WithPercentageSymbols("#", "<>"));
-        Assert.AreEqual(Svo.Percentage, parsed);
+        parsed.Should().Be(Svo.Percentage);
     }
 
     [Test]
@@ -148,7 +148,7 @@ public class Can_be_parsed
         using (TestCultures.En_GB.Scoped())
         {
             var exception = Assert.Throws<FormatException>(() => Percentage.Parse("invalid input"));
-            Assert.AreEqual("Not a valid percentage", exception.Message);
+            exception.Message.Should().Be("Not a valid percentage");
         }
     }
 
@@ -167,7 +167,7 @@ public class Can_be_parsed
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.Percentage, Percentage.TryParse("17.51%"));
+            Percentage.TryParse("17.51%").Should().Be(Svo.Percentage);
         }
     }
 }
@@ -178,21 +178,21 @@ public class Can_be_created_with_percentage_extension
     public void from_int()
     {
         var p = 3.Percent();
-        Assert.AreEqual("3%", p.ToString(CultureInfo.InvariantCulture));
+        p.ToString(CultureInfo.InvariantCulture).Should().Be("3%");
     }
 
     [Test]
     public void from_double()
     {
         var p = 3.14.Percent();
-        Assert.AreEqual("3.14%", p.ToString(CultureInfo.InvariantCulture));
+        p.ToString(CultureInfo.InvariantCulture).Should().Be("3.14%");
     }
 
     [Test]
     public void from_decimal()
     {
         var p = 3.14m.Percent();
-        Assert.AreEqual("3.14%", p.ToString(CultureInfo.InvariantCulture));
+        p.ToString(CultureInfo.InvariantCulture).Should().Be("3.14%");
     }
 }
 
@@ -203,7 +203,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual("17.51%", Svo.Percentage.ToString());
+            Svo.Percentage.ToString().Should().Be("17.51%");
         }
     }
 
@@ -212,7 +212,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.Percentage.ToString(), Svo.Percentage.ToString(default(string)));
+            Svo.Percentage.ToString(default(string)).Should().Be(Svo.Percentage.ToString());
         }
     }
 
@@ -221,7 +221,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.Percentage.ToString(), Svo.Percentage.ToString(string.Empty));
+            Svo.Percentage.ToString(string.Empty).Should().Be(Svo.Percentage.ToString());
         }
     }
 
@@ -245,7 +245,7 @@ public class Has_custom_formatting
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(expected);
         }
     }
 
@@ -268,7 +268,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual("175.1‰", Svo.Percentage.ToString("PM"));
+            Svo.Percentage.ToString("PM").Should().Be("175.1‰");
         }
     }
 
@@ -277,7 +277,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual("1751‱", Svo.Percentage.ToString("PT"));
+            Svo.Percentage.ToString("PT").Should().Be("1751‱");
         }
     }
 
@@ -312,7 +312,7 @@ public class Is_comparable
     public void to_Percentage_as_object()
     {
         object obj = Svo.Percentage;
-        Assert.AreEqual(0, Svo.Percentage.CompareTo(obj));
+        Svo.Percentage.CompareTo(obj).Should().Be(0);
     }
 
     [Test]
@@ -335,7 +335,7 @@ public class Is_comparable
             };
         var list = new List<Percentage> { sorted[3], sorted[4], sorted[5], sorted[2], sorted[0], sorted[1] };
         list.Sort();
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 
     [Test]
@@ -367,28 +367,28 @@ public class Casts
     public void explicitly_from_decimal()
     {
         var casted = (Percentage)0.1751m;
-        Assert.AreEqual(Svo.Percentage, casted);
+        casted.Should().Be(Svo.Percentage);
     }
 
     [Test]
     public void explicitly_to_decimal()
     {
         var casted = (decimal)Svo.Percentage;
-        Assert.AreEqual(0.1751m, casted);
+        casted.Should().Be(0.1751m);
     }
 
     [Test]
     public void explicitly_from_double()
     {
         var casted = (Percentage)0.1751;
-        Assert.AreEqual(Svo.Percentage, casted);
+        casted.Should().Be(Svo.Percentage);
     }
 
     [Test]
     public void explicitly_to_double()
     {
         var casted = (double)Svo.Percentage;
-        Assert.AreEqual(0.1751, casted);
+        casted.Should().Be(0.1751);
     }
 }
 
@@ -398,70 +398,70 @@ public class Can_be_multiplied_by
     public void _percentage()
     {
         var multiplied = 17.Percent() * 42.Percent();
-        Assert.AreEqual(7.14.Percent(), multiplied);
+        multiplied.Should().Be(7.14.Percent());
     }
 
     [Test]
     public void _decimal()
     {
         var multiplied = 17.Percent() * 0.42m;
-        Assert.AreEqual(7.14.Percent(), multiplied);
+        multiplied.Should().Be(7.14.Percent());
     }
 
     [Test]
     public void _double()
     {
         var multiplied = 17.Percent() * 0.42;
-        Assert.AreEqual(7.14.Percent(), multiplied);
+        multiplied.Should().Be(7.14.Percent());
     }
 
     [Test]
     public void _float()
     {
         var multiplied = 17.Percent() * 0.42F;
-        Assert.AreEqual(7.14.Percent(), multiplied);
+        multiplied.Should().Be(7.14.Percent());
     }
 
     [Test]
     public void _int()
     {
         var multiplied = 17.Percent() * 2;
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 
     [Test]
     public void _uint()
     {
         var multiplied = 17.Percent() * 2U;
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 
     [Test]
     public void _long()
     {
         var multiplied = 17.Percent() * 2L;
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 
     [Test]
     public void _ulong()
     {
         var multiplied = 17.Percent() * 2UL;
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 
     [Test]
     public void _short()
     {
         var multiplied = 17.Percent() * ((short)2);
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 
     [Test]
     public void _ushort()
     {
         var multiplied = 17.Percent() * ((ushort)2);
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 }
 
@@ -471,70 +471,70 @@ public class Can_be_divided_by
     public void _percentage()
     {
         var multiplied = 17.Percent() / 50.Percent();
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 
     [Test]
     public void _decimal()
     {
         var multiplied = 17.Percent() / 0.5m;
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 
     [Test]
     public void _double()
     {
         var multiplied = 17.Percent() / 0.5;
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 
     [Test]
     public void _float()
     {
         var multiplied = 17.Percent() / 0.5F;
-        Assert.AreEqual(34.Percent(), multiplied);
+        multiplied.Should().Be(34.Percent());
     }
 
     [Test]
     public void _int()
     {
         var multiplied = 17.Percent() / 2;
-        Assert.AreEqual(8.5.Percent(), multiplied);
+        multiplied.Should().Be(8.5.Percent());
     }
 
     [Test]
     public void _uint()
     {
         var multiplied = 17.Percent() / 2U;
-        Assert.AreEqual(8.5.Percent(), multiplied);
+        multiplied.Should().Be(8.5.Percent());
     }
 
     [Test]
     public void _long()
     {
         var multiplied = 17.Percent() / 2L;
-        Assert.AreEqual(8.5.Percent(), multiplied);
+        multiplied.Should().Be(8.5.Percent());
     }
 
     [Test]
     public void _ulong()
     {
         var multiplied = 17.Percent() / 2UL;
-        Assert.AreEqual(8.5.Percent(), multiplied);
+        multiplied.Should().Be(8.5.Percent());
     }
 
     [Test]
     public void _short()
     {
         var multiplied = 17.Percent() / ((short)2);
-        Assert.AreEqual(8.5.Percent(), multiplied);
+        multiplied.Should().Be(8.5.Percent());
     }
 
     [Test]
     public void _ushort()
     {
         var multiplied = 17.Percent() / ((ushort)2);
-        Assert.AreEqual(8.5.Percent(), multiplied);
+        multiplied.Should().Be(8.5.Percent());
     }
 }
 
@@ -544,14 +544,14 @@ public class Can_be_added_to
     public void _percentage()
     {
         var addition = 13.Percent() + 34.Percent();
-        Assert.AreEqual(47.Percent(), addition);
+        addition.Should().Be(47.Percent());
     }
 
     [Test]
     public void _amount()
     {
         var addition = (Amount)44 + 50.Percent();
-        Assert.AreEqual((Amount)66, addition);
+        addition.Should().Be((Amount)66);
     }
 
     [Test]
@@ -565,7 +565,7 @@ public class Can_be_added_to
     public void _decimal()
     {
         var addition = 34.586m + 75.Percent();
-        Assert.AreEqual(60.5255m, addition);
+        addition.Should().Be(60.5255m);
     }
 
     [Test]
@@ -586,42 +586,42 @@ public class Can_be_added_to
     public void _int()
     {
         var addition = 400 + 17.Percent();
-        Assert.AreEqual(468, addition);
+        addition.Should().Be(468);
     }
 
     [Test]
     public void _uint()
     {
         var addition = 400U + 17.Percent();
-        Assert.AreEqual(468U, addition);
+        addition.Should().Be(468U);
     }
 
     [Test]
     public void _long()
     {
         var addition = 400L + 17.Percent();
-        Assert.AreEqual(468L, addition);
+        addition.Should().Be(468L);
     }
 
     [Test]
     public void _ulong()
     {
         var addition = 400UL + 17.Percent();
-        Assert.AreEqual(468UL, addition);
+        addition.Should().Be(468UL);
     }
 
     [Test]
     public void _short()
     {
         var addition = ((short)400) + 17.Percent();
-        Assert.AreEqual((short)468, addition);
+        addition.Should().Be((short)468);
     }
 
     [Test]
     public void _ushort()
     {
         var addition = ((ushort)400) + 17.Percent();
-        Assert.AreEqual((ushort)468, addition);
+        addition.Should().Be((ushort)468);
     }
 }
 
@@ -638,7 +638,7 @@ public class Can_be_subtracted_from
     public void _amount()
     {
         var addition = (Amount)44.6 - 50.Percent();
-        Assert.AreEqual((Amount)22.3, addition);
+        addition.Should().Be((Amount)22.3);
     }
 
     [Test]
@@ -652,7 +652,7 @@ public class Can_be_subtracted_from
     public void _decimal()
     {
         var addition = 34.586m - 75.Percent();
-        Assert.AreEqual(8.6465m, addition);
+        addition.Should().Be(8.6465m);
     }
 
     [Test]
@@ -673,42 +673,42 @@ public class Can_be_subtracted_from
     public void _int()
     {
         var addition = 400 - 17.Percent();
-        Assert.AreEqual(332, addition);
+        addition.Should().Be(332);
     }
 
     [Test]
     public void _uint()
     {
         var addition = 400U - 17.Percent();
-        Assert.AreEqual(332U, addition);
+        addition.Should().Be(332U);
     }
 
     [Test]
     public void _long()
     {
         var addition = 400L - 17.Percent();
-        Assert.AreEqual(332L, addition);
+        addition.Should().Be(332L);
     }
 
     [Test]
     public void _ulong()
     {
         var addition = 400UL - 17.Percent();
-        Assert.AreEqual(332UL, addition);
+        addition.Should().Be(332UL);
     }
 
     [Test]
     public void _short()
     {
         var addition = ((short)400) - 17.Percent();
-        Assert.AreEqual((short)332, addition);
+        addition.Should().Be((short)332);
     }
 
     [Test]
     public void _ushort()
     {
         var addition = ((ushort)400) - 17.Percent();
-        Assert.AreEqual((ushort)332, addition);
+        addition.Should().Be((ushort)332);
     }
 }
 
@@ -718,14 +718,14 @@ public class Can_get_a_percentage_of
     public void _percentage()
     {
         var addition = 13.Percent() * 34.Percent();
-        Assert.AreEqual(4.42.Percent(), addition);
+        addition.Should().Be(4.42.Percent());
     }
 
     [Test]
     public void _amount()
     {
         var addition = (Amount)44.6 * 80.Percent();
-        Assert.AreEqual((Amount)35.68, addition);
+        addition.Should().Be((Amount)35.68);
     }
 
     [Test]
@@ -739,7 +739,7 @@ public class Can_get_a_percentage_of
     public void _decimal()
     {
         var addition = 34.586m * 75.Percent();
-        Assert.AreEqual(25.9395m, addition);
+        addition.Should().Be(25.9395m);
     }
 
     [Test]
@@ -760,42 +760,42 @@ public class Can_get_a_percentage_of
     public void _int()
     {
         var addition = 400 * 17.Percent();
-        Assert.AreEqual(68, addition);
+        addition.Should().Be(68);
     }
 
     [Test]
     public void _uint()
     {
         var addition = 400U * 17.Percent();
-        Assert.AreEqual(68U, addition);
+        addition.Should().Be(68U);
     }
 
     [Test]
     public void _long()
     {
         var addition = 400L * 17.Percent();
-        Assert.AreEqual(68L, addition);
+        addition.Should().Be(68L);
     }
 
     [Test]
     public void _ulong()
     {
         var addition = 400UL * 17.Percent();
-        Assert.AreEqual(68UL, addition);
+        addition.Should().Be(68UL);
     }
 
     [Test]
     public void _short()
     {
         var addition = ((short)400) * 17.Percent();
-        Assert.AreEqual((short)68, addition);
+        addition.Should().Be((short)68);
     }
 
     [Test]
     public void _ushort()
     {
         var addition = ((ushort)400) * 17.Percent();
-        Assert.AreEqual((ushort)68, addition);
+        addition.Should().Be((ushort)68);
     }
 }
 
@@ -805,14 +805,14 @@ public class Can_get_100_percent_based_on_percentage
     public void _percentage()
     {
         var addition = 13.Percent() / 25.Percent();
-        Assert.AreEqual(52.Percent(), addition);
+        addition.Should().Be(52.Percent());
     }
 
     [Test]
     public void _amount()
     {
         var addition = (Amount)44.6 / 80.Percent();
-        Assert.AreEqual((Amount)55.75, addition);
+        addition.Should().Be((Amount)55.75);
     }
 
     [Test]
@@ -847,42 +847,42 @@ public class Can_get_100_percent_based_on_percentage
     public void _int()
     {
         var addition = 400 / 17.Percent();
-        Assert.AreEqual(2352, addition);
+        addition.Should().Be(2352);
     }
 
     [Test]
     public void _uint()
     {
         var addition = 400U / 17.Percent();
-        Assert.AreEqual(2352U, addition);
+        addition.Should().Be(2352U);
     }
 
     [Test]
     public void _long()
     {
         var addition = 400L / 17.Percent();
-        Assert.AreEqual(2352L, addition);
+        addition.Should().Be(2352L);
     }
 
     [Test]
     public void _ulong()
     {
         var addition = 400UL / 17.Percent();
-        Assert.AreEqual(2352UL, addition);
+        addition.Should().Be(2352UL);
     }
 
     [Test]
     public void _short()
     {
         var addition = ((short)400) / 17.Percent();
-        Assert.AreEqual((short)2352, addition);
+        addition.Should().Be((short)2352);
     }
 
     [Test]
     public void _ushort()
     {
         var addition = ((ushort)400) / 17.Percent();
-        Assert.AreEqual((ushort)2352, addition);
+        addition.Should().Be((ushort)2352);
     }
 }
 
@@ -892,35 +892,35 @@ public class Can_be_rounded
     public void zero_decimals()
     {
         var actual = Svo.Percentage.Round();
-        Assert.AreEqual(18.Percent(), actual);
+        actual.Should().Be(18.Percent());
     }
 
     [Test]
     public void one_decimal()
     {
         var actual = Svo.Percentage.Round(1);
-        Assert.AreEqual(17.5.Percent(), actual);
+        actual.Should().Be(17.5.Percent());
     }
 
     [Test]
     public void away_from_zero()
     {
         var actual = 16.5.Percent().Round(0, DecimalRounding.AwayFromZero);
-        Assert.AreEqual(17.Percent(), actual);
+        actual.Should().Be(17.Percent());
     }
 
     [Test]
     public void to_even()
     {
         var actual = 16.5.Percent().Round(0, DecimalRounding.ToEven);
-        Assert.AreEqual(16.Percent(), actual);
+        actual.Should().Be(16.Percent());
     }
 
     [Test]
     public void to_multiple()
     {
         var actual = 16.4.Percent().RoundToMultiple(3.Percent());
-        Assert.AreEqual(15.Percent(), actual);
+        actual.Should().Be(15.Percent());
     }
 
     [Test]
@@ -940,7 +940,7 @@ public class Can_be_rounded
     public void using_system_midpoint_rounding()
     {
         var rounded = Svo.Percentage.Round(0, MidpointRounding.AwayFromZero);
-        Assert.AreEqual(18.Percent(), rounded);
+        rounded.Should().Be(18.Percent());
     }
 }
 
@@ -951,7 +951,7 @@ public class Can_be_increased
     {
         var increased = Svo.Percentage;
         increased++;
-        Assert.AreEqual(18.51.Percent(), increased);
+        increased.Should().Be(18.51.Percent());
     }
 }
 
@@ -962,7 +962,7 @@ public class Can_be_decreased
     {
         var decreased = Svo.Percentage;
         decreased--;
-        Assert.AreEqual(16.51.Percent(), decreased);
+        decreased.Should().Be(16.51.Percent());
     }
 }
 
@@ -995,7 +995,7 @@ public class Can_get
     public void Sign(int expected, Percentage percentage)
     {
         var actual = percentage.Sign();
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [TestCase("3%", "-3%")]
@@ -1004,7 +1004,7 @@ public class Can_get
     public void absolute_value(Percentage expected, Percentage percentage)
     {
         var actual = percentage.Abs();
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 }
 
@@ -1022,7 +1022,7 @@ public class Can_get_maximum_of
     public void multiple_values()
     {
         var max = Percentage.Max(15.Percent(), 66.Percent(), -117.Percent());
-        Assert.AreEqual(66.Percent(), max);
+        max.Should().Be(66.Percent());
     }
 }
 
@@ -1140,21 +1140,21 @@ public class Supports_XML_serialization
     public void using_XmlSerializer_to_serialize()
     {
         var xml = Serialize.Xml(Svo.Percentage);
-        Assert.AreEqual("17.51%", xml);
+        xml.Should().Be("17.51%");
     }
 
     [Test]
     public void using_XmlSerializer_to_deserialize()
     {
         var svo = Deserialize.Xml<Percentage>("17.51%");
-        Assert.AreEqual(Svo.Percentage, svo);
+        svo.Should().Be(Svo.Percentage);
     }
 
     [Test]
     public void using_DataContractSerializer()
     {
         var round_tripped = SerializeDeserialize.DataContract(Svo.Percentage);
-        Assert.AreEqual(Svo.Percentage, round_tripped);
+        round_tripped.Should().Be(Svo.Percentage);
     }
 
     [Test]
@@ -1162,7 +1162,7 @@ public class Supports_XML_serialization
     {
         var structure = XmlStructure.New(Svo.Percentage);
         var round_tripped = SerializeDeserialize.Xml(structure);
-        Assert.AreEqual(structure, round_tripped);
+        round_tripped.Should().Be(structure);
     }
 
     [Test]
@@ -1210,7 +1210,7 @@ public class Supports_binary_serialization
     public void storing_decimal_in_SerializationInfo()
     {
         var info = Serialize.GetInfo(Svo.Percentage);
-        Assert.AreEqual(0.1751m, info.GetDecimal("Value"));
+        info.GetDecimal("Value").Should().Be(0.1751m);
     }
 }
 #endif

--- a/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
+++ b/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
@@ -100,13 +100,13 @@ public class Can_be_parsed
     [Test]
     public void from_null_string_represents_Empty()
     {
-        Assert.AreEqual(CryptographicSeed.Empty, CryptographicSeed.Parse(null));
+        CryptographicSeed.Parse(null).Should().Be(CryptographicSeed.Empty);
     }
 
     [Test]
     public void from_empty_string_represents_Empty()
     {
-        Assert.AreEqual(CryptographicSeed.Empty, CryptographicSeed.Parse(string.Empty));
+        CryptographicSeed.Parse(string.Empty).Should().Be(CryptographicSeed.Empty);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
+++ b/specs/Qowaiv.Specs/Security/Cryptography/CryptographicSeed_specs.cs
@@ -87,12 +87,12 @@ public class ToByteArray
     [Test]
     public void from_empty_is_empty_array()
         => CryptographicSeed.Empty
-        .ToByteArray().Should().BeEquivalentTo(Array.Empty<byte>());
+        .ToByteArray().Should().BeEmpty();
 
     [Test]
     public void from_empty_array_stays_empty_array()
         => CryptographicSeed.Create([])
-        .ToByteArray().Should().BeEquivalentTo(Array.Empty<byte>());
+        .ToByteArray().Should().BeEmpty();
 }
 
 public class Can_be_parsed

--- a/specs/Qowaiv.Specs/Security/Secret_specs.cs
+++ b/specs/Qowaiv.Specs/Security/Secret_specs.cs
@@ -78,13 +78,13 @@ public class Can_be_parsed
     [Test]
     public void from_null_string_represents_Empty()
     {
-        Assert.AreEqual(Secret.Empty, Secret.Parse(null));
+        Secret.Parse(null).Should().Be(Secret.Empty);
     }
 
     [Test]
     public void from_empty_string_represents_Empty()
     {
-        Assert.AreEqual(Secret.Empty, Secret.Parse(string.Empty));
+        Secret.Parse(string.Empty).Should().Be(Secret.Empty);
     }
 }
 

--- a/specs/Qowaiv.Specs/Sex_specs.cs
+++ b/specs/Qowaiv.Specs/Sex_specs.cs
@@ -466,7 +466,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Sex);
-        Svo.Sex.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.Sex);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Sex_specs.cs
+++ b/specs/Qowaiv.Specs/Sex_specs.cs
@@ -34,7 +34,7 @@ public class With_domain_logic
     [TestCase(false, "")]
     public void IsUnknown_returns(bool result, Sex svo)
     {
-        Assert.AreEqual(result, svo.IsUnknown());
+        svo.IsUnknown().Should().Be(result);
     }
 
     [TestCase(true, "Male")]
@@ -43,7 +43,7 @@ public class With_domain_logic
     [TestCase(false, "")]
     public void IsMaleOrFemale_returns(bool result, Sex svo)
     {
-        Assert.AreEqual(result, svo.IsMaleOrFemale());
+        svo.IsMaleOrFemale().Should().Be(result);
     }
 }
 
@@ -54,14 +54,14 @@ public class Display_name
     {
         using (TestCultures.Nl_BE.Scoped())
         {
-            Assert.AreEqual("Vrouwelijk", Svo.Sex.DisplayName);
+            Svo.Sex.DisplayName.Should().Be("Vrouwelijk");
         }
     }
 
     [Test]
     public void for_custom_culture_if_specified()
     {
-        Assert.AreEqual("Mujer", Svo.Sex.GetDisplayName(TestCultures.Es_EC));
+        Svo.Sex.GetDisplayName(TestCultures.Es_EC).Should().Be("Mujer");
     }
 }
 
@@ -82,7 +82,7 @@ public class Has_constant
     [Test]
     public void Empty_represent_default_value()
     {
-        Assert.AreEqual(default(Sex), Sex.Empty);
+        Sex.Empty.Should().Be(default(Sex));
     }
 }
 
@@ -195,7 +195,7 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.Sex.ToString(), Svo.Sex.ToString(default(string)));
+            Svo.Sex.ToString(default(string)).Should().Be(Svo.Sex.ToString());
         }
     }
 
@@ -204,14 +204,14 @@ public class Has_custom_formatting
     {
         using (TestCultures.En_GB.Scoped())
         {
-            Assert.AreEqual(Svo.Sex.ToString(), Svo.Sex.ToString(string.Empty));
+            Svo.Sex.ToString(string.Empty).Should().Be(Svo.Sex.ToString());
         }
     }
 
     [Test]
     public void default_value_is_represented_as_string_empty()
     {
-        Assert.AreEqual(string.Empty, default(Sex).ToString());
+        default(Sex).ToString().Should().Be(string.Empty);
     }
 
     [Test]
@@ -231,7 +231,7 @@ public class Has_custom_formatting
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(expected);
         }
     }
 
@@ -240,7 +240,7 @@ public class Has_custom_formatting
     {
         using (new CultureInfoScope(culture: TestCultures.Nl_NL, cultureUI: TestCultures.En_GB))
         {
-            Assert.AreEqual("Vrouwelijk", Svo.Sex.ToString(provider: null));
+            Svo.Sex.ToString(provider: null).Should().Be("Vrouwelijk");
         }
     }
 }
@@ -277,7 +277,7 @@ public class Is_comparable
             };
         var list = new List<Sex> { sorted[3], sorted[4], sorted[2], sorted[0], sorted[1] };
         list.Sort();
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 }
 
@@ -287,21 +287,21 @@ public class Casts
     public void explicitly_to_byte()
     {
         var casted = (byte)Svo.Sex;
-        Assert.AreEqual((byte)2, casted);
+        casted.Should().Be((byte)2);
     }
 
     [Test]
     public void explicitly_to_int()
     {
         var casted = (int)Svo.Sex;
-        Assert.AreEqual(2, casted);
+        casted.Should().Be(2);
     }
 
     [TestCase(2, "Female")]
     [TestCase(null, "?")]
     public void explicitly_to_nullable_int(int casted, Sex sex)
     {
-        Assert.AreEqual(casted, (int?)sex);
+        ((int?)sex).Should().Be(casted);
     }
 
     [TestCase("Female", 2)]
@@ -309,7 +309,7 @@ public class Casts
     public void implicitly_from_nullable_int(Sex casted, int? value)
     {
         Sex sex = value;
-        Assert.AreEqual(casted, sex);
+        sex.Should().Be(casted);
     }
 
     [TestCase("Female", 2)]
@@ -317,7 +317,7 @@ public class Casts
     public void implicitly_from_int(Sex casted, int value)
     {
         Sex sex = value;
-        Assert.AreEqual(casted, sex);
+        sex.Should().Be(casted);
     }
 }
 

--- a/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
+++ b/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
@@ -543,7 +543,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.EnergyLabel);
-        Svo.EnergyLabel.Should().Be(round_tripped);
+        round_tripped.Should().Be(Svo.EnergyLabel);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/TestTools/Svo.cs
+++ b/specs/Qowaiv.Specs/TestTools/Svo.cs
@@ -43,6 +43,9 @@ public static class Svo
     /// <summary>info@qowaiv.org</summary>
     public static readonly EmailAddress EmailAddress = EmailAddress.Parse("info@qowaiv.org");
 
+    /// <summary>info@qowaiv.org,test@qowaiv.org"</summary>
+    public static EmailAddressCollection EmailAddressCollection => EmailAddressCollection.Parse("info@qowaiv.org,test@qowaiv.org");
+
     /// <summary>1732.4</summary>
     public static readonly Elo Elo = 1732.4;
 

--- a/specs/Qowaiv.Specs/Text/Base32_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base32_specs.cs
@@ -63,7 +63,7 @@ public class TryGetBytes_from
     public void Not_support_chars_returns_false_with_EmptyArray()
     {
         Base32.TryGetBytes("ABC}", out byte[] bytes).Should().BeFalse();
-        Assert.AreEqual(Array.Empty<byte>(), bytes);
+        bytes.Should().BeEquivalentTo(Array.Empty<byte>());
     }
 }
 public class GetBytes
@@ -86,7 +86,7 @@ public class GetBytes
         var str = "thequickbrownfoxjumbsoverthelazydog2345674";
         var lowercase = Base32.GetBytes(str);
         var uppercase = Base32.GetBytes(str.ToUpperInvariant());
-        Assert.AreEqual(uppercase, lowercase);
+        lowercase.Should().BeEquivalentTo(uppercase);
     }
 
     [Test]
@@ -98,7 +98,7 @@ public class GetBytes
             {
                 Base32.GetBytes("Q0waiv");
             });
-            Assert.AreEqual("Not a valid Base32 string", act.Message);
+            act.Message.Should().Be("Not a valid Base32 string");
         }
     }
 }

--- a/specs/Qowaiv.Specs/Text/Base32_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base32_specs.cs
@@ -56,14 +56,14 @@ public class TryGetBytes_from
     {
         var bytes = expected.Select(v => (byte)v).ToArray();
         Base32.TryGetBytes(str, out byte[] actualBytes).Should().BeTrue();
-        CollectionAssert.AreEqual(bytes, actualBytes);
+        actualBytes.Should().BeEquivalentTo(bytes);
     }
 
     [Test]
     public void Not_support_chars_returns_false_with_EmptyArray()
     {
         Base32.TryGetBytes("ABC}", out byte[] bytes).Should().BeFalse();
-        bytes.Should().BeEquivalentTo(Array.Empty<byte>());
+        bytes.Should().BeEmpty();
     }
 }
 public class GetBytes
@@ -71,13 +71,13 @@ public class GetBytes
     [Test]
     public void Null__returns_EmptyArray()
     {
-        CollectionAssert.AreEqual(Array.Empty<byte>(), Base32.GetBytes(null));
+        Base32.GetBytes(null).Should().BeEmpty();
     }
 
     [Test]
     public void StringEmpty_returns_EmptyArray()
     {
-        CollectionAssert.AreEqual(Array.Empty<byte>(), Base32.GetBytes(string.Empty));
+        Base32.GetBytes(string.Empty).Should().BeEmpty();
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Text/Base64_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base64_specs.cs
@@ -50,6 +50,6 @@ public class TryGetBytes_from
     public void Not_support_chars_returns_false_with_EmptyArray()
     {
         Base64.TryGetBytes("ABC}", out byte[] bytes).Should().BeFalse();
-        Assert.AreEqual(Array.Empty<byte>(), bytes);
+        bytes.Should().BeEquivalentTo(Array.Empty<byte>());
     }
 }

--- a/specs/Qowaiv.Specs/Text/Base64_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base64_specs.cs
@@ -26,14 +26,14 @@ public class TryGetBytes_from
     public void Null__returns_EmptyArray()
     {
         Base64.TryGetBytes(null, out var bytes).Should().BeTrue();
-        CollectionAssert.AreEqual(Array.Empty<byte>(), bytes);
+        bytes.Should().BeEmpty();
     }
 
     [Test]
     public void StringEmpty_returns_EmptyArray()
     {
         Base64.TryGetBytes(string.Empty, out var bytes).Should().BeTrue();
-        CollectionAssert.AreEqual(Array.Empty<byte>(), bytes);
+        bytes.Should().BeEmpty();
     }
 
     [TestCase("Aap=", 1, 170)]
@@ -43,13 +43,13 @@ public class TryGetBytes_from
     {
         var bytes = expected.Select(v => (byte)v).ToArray();
         Base64.TryGetBytes(str, out byte[] actualBytes).Should().BeTrue();
-        CollectionAssert.AreEqual(bytes, actualBytes);
+        actualBytes.Should().BeEquivalentTo(bytes);
     }
 
     [Test]
     public void Not_support_chars_returns_false_with_EmptyArray()
     {
         Base64.TryGetBytes("ABC}", out byte[] bytes).Should().BeFalse();
-        bytes.Should().BeEquivalentTo(Array.Empty<byte>());
+        bytes.Should().BeEmpty();
     }
 }

--- a/specs/Qowaiv.Specs/Text/CharBuffer_specs.cs
+++ b/specs/Qowaiv.Specs/Text/CharBuffer_specs.cs
@@ -8,21 +8,21 @@ public class Add
     public void A_char_can_be_added()
     {
         var buffer = WithCapacity().Add('c');
-        Assert.AreEqual("c", buffer);
+        buffer.Should().BeEquivalentTo("c");
     }
 
     [Test]
     public void A_char_can_be_added_as_lowercase()
     {
         var buffer = WithCapacity().AddLower('C');
-        Assert.AreEqual("c", buffer);
+        buffer.Should().BeEquivalentTo("c");
     }
 
     [Test]
     public void A_string_can_be_added()
     {
         var buffer = WithCapacity().Add("string");
-        Assert.AreEqual("string", buffer);
+        buffer.Should().BeEquivalentTo("string");
     }
 
     [Test]
@@ -30,7 +30,7 @@ public class Add
     {
         var other = " string ".Buffer().Trim();
         var buffer = WithCapacity().Add(other);
-        Assert.AreEqual("string", buffer);
+        buffer.Should().BeEquivalentTo("string");
     }
 }
 
@@ -40,21 +40,21 @@ public class Remove
     public void FromStart_removes_characters_from_the_start()
     {
         var buffer = " test ".Buffer().Trim().RemoveFromStart(2);
-        Assert.AreEqual("st", buffer);
+        buffer.Should().BeEquivalentTo("st");
     }
 
     [Test]
     public void FromEnd_removes_characters_from_the_end()
     {
         var buffer = " test ".Buffer().Trim().RemoveFromEnd(2);
-        Assert.AreEqual("te", buffer);
+        buffer.Should().BeEquivalentTo("te");
     }
 
     [Test]
     public void Range_removes_specified_range()
     {
         var buffer = " test ".Buffer().Trim().RemoveRange(1, 2);
-        Assert.AreEqual("tt", buffer);
+        buffer.Should().BeEquivalentTo("tt");
     }
 
     [TestCase('.')]
@@ -89,21 +89,21 @@ public class Trim
     public void Trims_left_and_right_spaces()
     {
         var buffer = "  content ".Buffer().Trim();
-        Assert.AreEqual("content", buffer);
+        buffer.Should().BeEquivalentTo("content");
     }
 
     [Test]
     public void Left_trims_left_spaces()
     {
         var buffer = "  content ".Buffer().TrimLeft();
-        Assert.AreEqual("content ", buffer);
+        buffer.Should().BeEquivalentTo("content ");
     }
 
     [Test]
     public void Right_trims_right_spaces()
     {
         var buffer = "  content ".Buffer().TrimRight();
-        Assert.AreEqual("  content", buffer);
+        buffer.Should().BeEquivalentTo("  content");
     }
 }
 
@@ -113,7 +113,7 @@ public class Uppercase
     public void Transforms_all_characters_to__uppercase_alternatives()
     {
         var buffer = "abcDeéf".Buffer().Uppercase();
-        Assert.AreEqual("ABCDEÉF", buffer);
+        buffer.Should().BeEquivalentTo("ABCDEÉF");
     }
 }
 
@@ -123,7 +123,7 @@ public class Count
     public void Returns_the_total_of_specified_char()
     {
         var buffer = " let us count this   ".Buffer().Trim();
-        Assert.AreEqual(3, buffer.Count(' '));
+        buffer.Count(' ').Should().Be(3);
     }
 }
 
@@ -133,7 +133,7 @@ public class IndexOf
     public void Last_returns_last_index_of_char()
     {
         var buffer = " 7123456789   ".Buffer().Trim();
-        Assert.AreEqual(7, buffer.LastIndexOf('7'));
+        buffer.LastIndexOf('7').Should().Be(7);
     }
 }
 
@@ -174,7 +174,7 @@ public class Substring
     public void With_start_index_returns_substring()
     {
         var buffer = " test ".Buffer().Trim();
-        Assert.AreEqual("st", buffer.Substring(2));
+        buffer.Substring(2).Should().Be("st");
     }
 }
 

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -171,10 +171,8 @@ public class Can_be_created
 {
     [Test]
     public void with_global_unique_value()
-    {
-        CollectionAssert.AllItemsAreUnique(Enumerable.Range(0, 10_000)
-             .Select(i => Uuid.NewUuid()));
-    }
+        => Enumerable.Range(0, 10_000).Select(i => Uuid.NewUuid()).ToHashSet()
+            .Should().HaveCount(10_000);
 
     [Test]
     public void with_MD5()
@@ -287,7 +285,8 @@ public class Can_be_created_sequential
                 ids.Add(Uuid.NewSequential(comparer));
             }
         }
-        CollectionAssert.IsOrdered(ids, comparer);
+
+        ids.Should().BeInAscendingOrder(comparer);
     }
 
     private static IEnumerable<DateTime> GetTimes()

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -10,7 +10,7 @@ public class With_domain_logic
     [TestCase(true, "")]
     public void IsEmpty_returns(bool result, Uuid svo)
     {
-        Assert.AreEqual(result, svo.IsEmpty());
+        svo.IsEmpty().Should().Be(result);
     }
 }
 
@@ -20,28 +20,28 @@ public class Has_version
     public void Random_for_new()
     {
         var id = Uuid.NewUuid();
-        Assert.AreEqual(UuidVersion.Random, id.Version);
+        id.Version.Should().Be(UuidVersion.Random);
     }
 
     [Test]
     public void Sequential_for_new_sequential()
     {
         var id = Uuid.NewSequential();
-        Assert.AreEqual(UuidVersion.Sequential, id.Version);
+        id.Version.Should().Be(UuidVersion.Sequential);
     }
 
     [Test]
     public void MD5_for_generated_with_MD5()
     {
         var id = Uuid.GenerateWithMD5(Encoding.UTF8.GetBytes("Qowaiv"));
-        Assert.AreEqual(UuidVersion.MD5, id.Version);
+        id.Version.Should().Be(UuidVersion.MD5);
     }
 
     [Test]
     public void SHA1_for_generated_with_SHA1()
     {
         var id = Uuid.GenerateWithSHA1(Encoding.UTF8.GetBytes("Qowaiv"));
-        Assert.AreEqual(UuidVersion.SHA1, id.Version);
+        id.Version.Should().Be(UuidVersion.SHA1);
     }
 }
 
@@ -50,7 +50,7 @@ public class Has_constant
     [Test]
     public void Empty_represent_default_value()
     {
-        Assert.AreEqual(default(Uuid), Uuid.Empty);
+        Uuid.Empty.Should().Be(default(Uuid));
     }
 }
 
@@ -120,13 +120,13 @@ public class Can_be_parsed
     [Test]
     public void from_null_string_represents_Empty()
     {
-        Assert.AreEqual(Uuid.Empty, Uuid.Parse(null));
+        Uuid.Parse(null).Should().Be(Uuid.Empty);
     }
 
     [Test]
     public void from_empty_string_represents_Empty()
     {
-        Assert.AreEqual(Uuid.Empty, Uuid.Parse(string.Empty));
+        Uuid.Parse(string.Empty).Should().Be(Uuid.Empty);
     }
 
     [TestCase("en", "Qowaiv_SVOLibrary_GUIA")]
@@ -136,7 +136,7 @@ public class Can_be_parsed
         using (culture.Scoped())
         {
             var parsed = Uuid.Parse(input);
-            Assert.AreEqual(Svo.Uuid, parsed);
+            parsed.Should().Be(Svo.Uuid);
         }
     }
 
@@ -146,7 +146,7 @@ public class Can_be_parsed
         using (TestCultures.En_GB.Scoped())
         {
             var exception = Assert.Throws<FormatException>(() => Uuid.Parse("invalid input"));
-            Assert.AreEqual("Not a valid GUID", exception.Message);
+            exception.Message.Should().Be("Not a valid GUID");
         }
     }
 
@@ -163,7 +163,7 @@ public class Can_be_parsed
     [Test]
     public void with_TryParse_returns_SVO()
     {
-        Assert.AreEqual(Svo.Uuid, Uuid.TryParse("Qowaiv_SVOLibrary_GUIA"));
+        Uuid.TryParse("Qowaiv_SVOLibrary_GUIA").Should().Be(Svo.Uuid);
     }
 }
 
@@ -180,7 +180,7 @@ public class Can_be_created
     public void with_MD5()
     {
         var hashed = Uuid.GenerateWithMD5(Encoding.UTF8.GetBytes("Qowaiv"));
-        Assert.AreEqual(Uuid.Parse("lmZO_haEOTCwGsCcbIZFFg"), hashed);
+        hashed.Should().Be(Uuid.Parse("lmZO_haEOTCwGsCcbIZFFg"));
     }
 
     [Test]
@@ -309,7 +309,7 @@ public class Has_custom_formatting
     [Test]
     public void default_value_is_represented_as_string_empty()
     {
-        Assert.AreEqual(string.Empty, default(Uuid).ToString());
+        default(Uuid).ToString().Should().Be(string.Empty);
     }
 
     [Test]
@@ -338,7 +338,7 @@ public class Has_custom_formatting
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(expected);
         }
     }
 
@@ -347,7 +347,7 @@ public class Has_custom_formatting
     {
         using (new CultureInfoScope(culture: TestCultures.Nl_NL, cultureUI: TestCultures.En_GB))
         {
-            Assert.AreEqual("Qowaiv_SVOLibrary_GUIA", Svo.Uuid.ToString(provider: null));
+            Svo.Uuid.ToString(provider: null).Should().Be("Qowaiv_SVOLibrary_GUIA");
         }
     }
 }
@@ -357,14 +357,14 @@ public class Is_comparable
     [Test]
     public void to_null_is_1()
     {
-        Assert.AreEqual(1, Svo.Uuid.CompareTo(null));
+        Svo.Uuid.CompareTo(null).Should().Be(1);
     }
 
     [Test]
     public void to_Uuid_as_object()
     {
         object obj = Svo.Uuid;
-        Assert.AreEqual(0, Svo.Uuid.CompareTo(obj));
+        Svo.Uuid.CompareTo(obj).Should().Be(0);
     }
 
     [Test]
@@ -387,7 +387,7 @@ public class Is_comparable
             };
         var list = new List<Uuid> { sorted[3], sorted[4], sorted[5], sorted[2], sorted[0], sorted[1] };
         list.Sort();
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 }
 
@@ -397,14 +397,14 @@ public class Casts
     public void explicitly_from_Guid()
     {
         var casted = (Uuid)Svo.Guid;
-        Assert.AreEqual(Svo.Uuid, casted);
+        casted.Should().Be(Svo.Uuid);
     }
 
     [Test]
     public void explicitly_to_Guid()
     {
         var casted = (Guid)Svo.Uuid;
-        Assert.AreEqual(Svo.Guid, casted);
+        casted.Should().Be(Svo.Guid);
     }
 }
 
@@ -495,21 +495,21 @@ public class Supports_XML_serialization
     public void using_XmlSerializer_to_serialize()
     {
         var xml = Serialize.Xml(Svo.Uuid);
-        Assert.AreEqual("Qowaiv_SVOLibrary_GUIA", xml);
+        xml.Should().Be("Qowaiv_SVOLibrary_GUIA");
     }
 
     [Test]
     public void using_XmlSerializer_to_deserialize()
     {
         var svo = Deserialize.Xml<Uuid>("Qowaiv_SVOLibrary_GUIA");
-        Assert.AreEqual(Svo.Uuid, svo);
+        svo.Should().Be(Svo.Uuid);
     }
 
     [Test]
     public void using_DataContractSerializer()
     {
         var round_tripped = SerializeDeserialize.DataContract(Svo.Uuid);
-        Assert.AreEqual(Svo.Uuid, round_tripped);
+        round_tripped.Should().Be(Svo.Uuid);
     }
 
     [Test]
@@ -517,7 +517,7 @@ public class Supports_XML_serialization
     {
         var structure = XmlStructure.New(Svo.Uuid);
         var round_tripped = SerializeDeserialize.Xml(structure);
-        Assert.AreEqual(structure, round_tripped);
+        round_tripped.Should().Be(structure);
     }
 
     [Test]
@@ -551,7 +551,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Uuid);
-        Assert.AreEqual(Svo.Uuid, round_tripped);
+        round_tripped.Should().Be(Svo.Uuid);
     }
 
     [Test]
@@ -565,7 +565,7 @@ public class Supports_binary_serialization
     public void export_to_byte_array_equal_to_GUID_equivalent()
     {
         var bytes = Svo.Uuid.ToByteArray();
-        Assert.AreEqual(((Guid)Svo.Uuid).ToByteArray(), bytes);
+        bytes.Should().BeEquivalentTo(((Guid)Svo.Uuid).ToByteArray());
     }
 }
 #endif

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
@@ -14,21 +14,21 @@ public class DateSpanTest
     [Test]
     public void Zero_None_EqualsDefault()
     {
-        Assert.AreEqual(default(DateSpan), DateSpan.Zero);
+        DateSpan.Zero.Should().Be(default(DateSpan));
     }
 
     [Test]
     public void MaxValue_EqualsDateMaxDateMin()
     {
         var max = DateSpan.Subtract(Date.MaxValue, Date.MinValue);
-        Assert.AreEqual(DateSpan.MaxValue, max);
+        max.Should().Be(DateSpan.MaxValue);
     }
 
     [Test]
     public void MinValue_EqualsDateMinDateMax()
     {
         var min = DateSpan.Subtract(Date.MinValue, Date.MaxValue);
-        Assert.AreEqual(DateSpan.MinValue, min);
+        min.Should().Be(DateSpan.MinValue);
     }
 
     #endregion
@@ -66,7 +66,7 @@ public class DateSpanTest
             var exp = TestStruct;
             var act = DateSpan.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -84,7 +84,7 @@ public class DateSpanTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void XmlSerializeDeserialize_TestStruct_AreEqual()
@@ -92,7 +92,7 @@ public class DateSpanTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
 #if NET8_0_OR_GREATER
@@ -223,7 +223,7 @@ public class DateSpanTest
     {
         var act = DateSpan.Zero.ToString();
         var exp = "0Y+0M+0D";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -232,7 +232,7 @@ public class DateSpanTest
         var act = TestStruct.ToString("Unit Test Format", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '10Y+3M-5D', format: 'Unit Test Format'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [TestCase("0Y+0M+0D", 0, 0)]
@@ -251,7 +251,7 @@ public class DateSpanTest
         using (CultureInfoScope.NewInvariant())
         {
             var span = new DateSpan(months, days);
-            Assert.AreEqual(expected, span.ToString());
+            span.ToString().Should().Be(expected);
         }
     }
 
@@ -263,7 +263,7 @@ public class DateSpanTest
     [Test]
     public void GetHash_Zero_Hash()
     {
-        Assert.AreEqual(0, DateSpan.Zero.GetHashCode());
+        DateSpan.Zero.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
@@ -394,7 +394,7 @@ public class DateSpanTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -455,7 +455,7 @@ public class DateSpanTest
     public void Days(int years, int months, int days)
     {
         var span = new DateSpan(years, months, days);
-        Assert.AreEqual(days, span.Days);
+        span.Days.Should().Be(days);
     }
 
     [TestCase(1, 2, +3)]
@@ -466,7 +466,7 @@ public class DateSpanTest
     public void Months(int years, int months, int days)
     {
         var span = new DateSpan(years, months, days);
-        Assert.AreEqual(months, span.Months);
+        span.Months.Should().Be(months);
     }
 
     [TestCase(1, 2, +3)]
@@ -477,7 +477,7 @@ public class DateSpanTest
     public void Years(int years, int months, int days)
     {
         var span = new DateSpan(years, months, days);
-        Assert.AreEqual(years, span.Years);
+        span.Years.Should().Be(years);
     }
 
     [TestCase(014, 1, 2, +3)]
@@ -488,7 +488,7 @@ public class DateSpanTest
     public void TotalMonths(int total, int years, int months, int days)
     {
         var span = new DateSpan(years, months, days);
-        Assert.AreEqual(total, span.TotalMonths);
+        span.TotalMonths.Should().Be(total);
     }
 
     #endregion
@@ -499,7 +499,7 @@ public class DateSpanTest
     public void Mutate_Overflows()
     {
         var x = Assert.Catch<OverflowException>(() => DateSpan.MaxValue.AddDays(1));
-        Assert.AreEqual("DateSpan overflowed because the resulting duration is too long.", x.Message);
+        x.Message.Should().Be("DateSpan overflowed because the resulting duration is too long.");
     }
 
     #endregion
@@ -517,7 +517,7 @@ public class DateSpanTest
         var span = DateSpan.FromDays(4);
         var exp = new DateSpan(0, 4);
 
-        Assert.AreEqual(exp, span);
+        span.Should().Be(exp);
     }
 
     [Test]
@@ -526,7 +526,7 @@ public class DateSpanTest
         var span = DateSpan.FromMonths(17);
         var exp = new DateSpan(17, 0);
 
-        Assert.AreEqual(exp, span);
+        span.Should().Be(exp);
     }
 
     [Test]
@@ -535,7 +535,7 @@ public class DateSpanTest
         var span = DateSpan.FromYears(17);
         var exp = new DateSpan(17, 0, 0);
 
-        Assert.AreEqual(exp, span);
+        span.Should().Be(exp);
     }
 }
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
@@ -78,29 +78,6 @@ public class DateSpanTest
 
     #region (XML) (De)serialization tests
 
-#if NET8_0_OR_GREATER
-#else
-    [Test]
-    public void GetObjectData_SerializationInfo_AreEqual()
-    {
-        ISerializable obj = TestStruct;
-        var info = new SerializationInfo(typeof(DateSpan), new FormatterConverter());
-        obj.GetObjectData(info, default);
-
-        Assert.AreEqual(532575944699UL, info.GetUInt64("Value"));
-    }
-
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void SerializeDeserialize_TestStruct_AreEqual()
-    {
-        var input = TestStruct;
-        var exp = TestStruct;
-        var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
-    }
-#endif
-
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
@@ -366,7 +366,7 @@ public class DateSpanTest
         var exp = new List<DateSpan> { item0, DateSpan.Zero, DateSpan.Zero, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of date spans descending.</summary>
@@ -382,7 +382,7 @@ public class DateSpanTest
         var exp = new List<DateSpan> { item3, item2, item1, DateSpan.Zero, DateSpan.Zero, item0 };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateSpanTest.cs
@@ -270,7 +270,7 @@ public class DateSpanTest
     [Test]
     public void GetHash_TestStruct_Hash()
     {
-        Assert.AreNotEqual(0, TestStruct.GetHashCode());
+        TestStruct.GetHashCode().Should().NotBe(0);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
@@ -328,7 +328,7 @@ public class DateTest
         var exp = new List<Date> { Date.MinValue, Date.MinValue, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of Dates descending.</summary>
@@ -344,7 +344,7 @@ public class DateTest
         var exp = new List<Date> { item3, item2, item1, item0, Date.MinValue, Date.MinValue };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DateTest.cs
@@ -13,7 +13,7 @@ public class DateTest
     [Test]
     public void MinValue_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Date), Date.MinValue);
+        Date.MinValue.Should().Be(default(Date));
     }
 
     #endregion
@@ -26,7 +26,7 @@ public class DateTest
         var act = new Date(621393984000000017L);
         var exp = TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -78,7 +78,7 @@ public class DateTest
             var exp = TestStruct;
             var act = Date.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -109,7 +109,7 @@ public class DateTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -119,7 +119,7 @@ public class DateTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
 
@@ -127,14 +127,14 @@ public class DateTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "1970-02-14";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Date>("1970-02-14");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -266,7 +266,7 @@ public class DateTest
         var act = TestStruct.ToString("d_M_yy", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '14_2_70', format: 'd_M_yy'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStruct_ComplexPattern()
@@ -275,7 +275,7 @@ public class DateTest
         {
             var act = TestStruct.ToString(string.Empty);
             var exp = "14/02/1970";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -286,7 +286,7 @@ public class DateTest
         {
             var act = new Date(1988, 08, 08).ToString("yy-M-d");
             var exp = "88-8-8";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -295,7 +295,7 @@ public class DateTest
     {
         var act = new Date(1988, 08, 08).ToString("d", new CultureInfo("es-EC"));
         var exp = "8/8/1988";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -356,7 +356,7 @@ public class DateTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -427,7 +427,7 @@ public class DateTest
         Date exp = new WeekDate(1970, 07, 6);
         Date act = TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Implicit_DateToWeekDate_AreEqual()
@@ -435,7 +435,7 @@ public class DateTest
         WeekDate exp = TestStruct;
         WeekDate act = new(1970, 07, 6);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -444,7 +444,7 @@ public class DateTest
         Date exp = (Date)new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local);
         Date act = TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Implicit_DateToDateTime_AreEqual()
@@ -452,7 +452,7 @@ public class DateTest
         DateTime exp = TestStruct;
         DateTime act = new(1970, 02, 14, 00, 00, 000, DateTimeKind.Local);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -464,35 +464,35 @@ public class DateTest
     {
         var act = TestStruct.Year;
         var exp = 1970;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Month_TestStruct_AreEqual()
     {
         var act = TestStruct.Month;
         var exp = 2;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Day_TestStruct_AreEqual()
     {
         var act = TestStruct.Day;
         var exp = 14;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void DayOfWeek_TestStruct_AreEqual()
     {
         var act = TestStruct.DayOfWeek;
         var exp = DayOfWeek.Saturday;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void DayOfYear_TestStruct_AreEqual()
     {
         var act = TestStruct.DayOfYear;
         var exp = 45;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -505,7 +505,7 @@ public class DateTest
         var act = TestStruct;
         act++;
         var exp = new Date(1970, 02, 15);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Decrement_None_AreEqual()
@@ -513,7 +513,7 @@ public class DateTest
         var act = TestStruct;
         act--;
         var exp = new Date(1970, 02, 13);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -521,14 +521,14 @@ public class DateTest
     {
         var act = TestStruct + new TimeSpan(25, 30, 15);
         var exp = new Date(1970, 02, 15);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Min_TimeSpan_AreEqual()
     {
         var act = TestStruct - new TimeSpan(25, 30, 15);
         var exp = new Date(1970, 02, 12);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -536,7 +536,7 @@ public class DateTest
     {
         var act = TestStruct - new Date(1970, 02, 12);
         var exp = TimeSpan.FromDays(2);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -545,7 +545,7 @@ public class DateTest
         var act = TestStruct.AddTicks(4000000000017L);
         var exp = new Date(1970, 02, 18);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -554,7 +554,7 @@ public class DateTest
         var act = TestStruct.AddMilliseconds(3 * 24 * 60 * 60 * 1003);
         var exp = new Date(1970, 02, 17);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void AddSeconds_around3Days_AreEqual()
@@ -562,7 +562,7 @@ public class DateTest
         var act = TestStruct.AddSeconds(3 * 24 * 60 * 64);
         var exp = new Date(1970, 02, 17);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void AddMinutes_2280_AreEqual()
@@ -570,7 +570,7 @@ public class DateTest
         var act = TestStruct.AddMinutes(2 * 24 * 60);
         var exp = new Date(1970, 02, 16);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -579,7 +579,7 @@ public class DateTest
         var act = TestStruct.AddHours(41);
         var exp = new Date(1970, 02, 15);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -588,7 +588,7 @@ public class DateTest
         var act = TestStruct.AddMonths(12);
         var exp = new Date(1971, 02, 14);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -611,7 +611,7 @@ public class DateTest
         var act = TestStruct.AddYears(-12);
         var exp = new Date(1958, 02, 14);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/DecimalRoundTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/DecimalRoundTest.cs
@@ -8,14 +8,14 @@ public class DecimalRoundTest
         // initializes a decimal with scale of 4, instead of 0.
         var value = decimal.Parse("1000.0000", CultureInfo.InvariantCulture);
         var rounded = value.Round(-2);
-        Assert.AreEqual(1000m, rounded);
+        rounded.Should().Be(1000m);
     }
 
     [Test]
     public void Round_Positive_ShouldRoundToEven()
     {
         var rounded = 24.5m.Round();
-        Assert.AreEqual(24m, rounded);
+        rounded.Should().Be(24m);
     }
     [Test]
     public void Round_Negative_ShouldRoundToEven()
@@ -31,7 +31,7 @@ public class DecimalRoundTest
         var rounded = value.Round(-9);
         var expected = 10_000_000_000m;
 
-        Assert.AreEqual(expected, rounded);
+        rounded.Should().Be(expected);
     }
 
 
@@ -39,7 +39,7 @@ public class DecimalRoundTest
     public void RoundToMultiple_PositiveWithMultipleOf_ShouldRoundToEven()
     {
         var rounded = 24.5m.RoundToMultiple(1m);
-        Assert.AreEqual(24m, rounded);
+        rounded.Should().Be(24m);
     }
     [Test]
     public void RoundToMultiple_NegativeWithMultipleOf_ShouldRoundToEven()
@@ -56,7 +56,7 @@ public class DecimalRoundTest
     public void Round_MultipleOf(decimal exp, decimal value, decimal factor, DecimalRounding mode)
     {
         var act = value.RoundToMultiple(factor, mode);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <remarks>Use strings as doubles lack precision.</remarks>
@@ -83,7 +83,7 @@ public class DecimalRoundTest
     public void Round_Digits(decimal exp, int digits)
     {
         var act = 123456789.123456789m.Round(digits, DecimalRounding.AwayFromZero);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     // Halfway/nearest rounding
@@ -113,7 +113,7 @@ public class DecimalRoundTest
     public void Round_NearestAndDirect(decimal exp, decimal value, DecimalRounding mode)
     {
         var act = value.Round(0, mode);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
@@ -8,29 +8,6 @@ public class EmailAddressCollectionTest
 
     #region (XML) (De)serialization tests
 
-#if NET8_0_OR_GREATER
-#else
-    [Test]
-    public void GetObjectData_SerializationInfo_AreEqual()
-    {
-        ISerializable obj = GetTestInstance();
-        var info = new SerializationInfo(typeof(EmailAddressCollection), new FormatterConverter());
-        obj.GetObjectData(info, default);
-
-        Assert.AreEqual("info@qowaiv.org,test@qowaiv.org", info.GetString("Value"));
-    }
-
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void SerializeDeserialize_TestStruct_AreEqual()
-    {
-        var input = GetTestInstance();
-        var exp = GetTestInstance();
-        var act = SerializeDeserialize.Binary(input);
-        act.Should().BeEquivalentTo(exp);
-    }
-#endif
-
     [Test]
     public void DataContractSerializeDeserialize_TestStruct_AreEqual()
     {
@@ -55,51 +32,6 @@ public class EmailAddressCollectionTest
         act.Should().BeEquivalentTo(GetTestInstance());
     }
 
-#if NET8_0_OR_GREATER
-#else
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void SerializeDeserialize_EmailAddressSerializeObject_AreEqual()
-    {
-        var input = new EmailAddressCollectionSerializeObject
-        {
-            Id = 17,
-            Obj = GetTestInstance(),
-            Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
-        };
-        var exp = new EmailAddressCollectionSerializeObject
-        {
-            Id = 17,
-            Obj = GetTestInstance(),
-            Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
-        };
-        var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
-    }
-#endif
-
-    [Test]
-    public void XmlSerializeDeserialize_EmailAddressSerializeObject_AreEqual()
-    {
-        var input = new EmailAddressCollectionSerializeObject
-        {
-            Id = 17,
-            Obj = GetTestInstance(),
-            Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
-        };
-        var exp = new EmailAddressCollectionSerializeObject
-        {
-            Id = 17,
-            Obj = GetTestInstance(),
-            Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
-        };
-        var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
-    }
     [Test]
     public void DataContractSerializeDeserialize_EmailAddressSerializeObject_AreEqual()
     {
@@ -120,31 +52,6 @@ public class EmailAddressCollectionTest
         CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
         Assert.AreEqual(exp.Date, act.Date, "Date");
     }
-
-#if NET8_0_OR_GREATER
-#else
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void SerializeDeserialize_Empty_AreEqual()
-    {
-        var input = new EmailAddressCollectionSerializeObject
-        {
-            Id = 17,
-            Obj = [],
-            Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
-        };
-        var exp = new EmailAddressCollectionSerializeObject
-        {
-            Id = 17,
-            Obj = [],
-            Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
-        };
-        var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        CollectionAssert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
-    }
-#endif
 
     [Test]
     public void XmlSerializeDeserialize_Empty_AreEqual()

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
@@ -45,14 +45,14 @@ public class EmailAddressCollectionTest
     {
         var act = Serialize.Xml(GetTestInstance());
         var exp = "info@qowaiv.org,test@qowaiv.org";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<EmailAddressCollection>("info@qowaiv.org,test@qowaiv.org");
-        Assert.AreEqual(GetTestInstance(), act);
+        act.Should().BeEquivalentTo(GetTestInstance());
     }
 
 #if NET8_0_OR_GREATER
@@ -186,7 +186,7 @@ public class EmailAddressCollectionTest
         var exp = string.Empty;
         var act = collection.ToString();
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -197,7 +197,7 @@ public class EmailAddressCollectionTest
         var exp = "info@qowaiv.org";
         var act = collection.ToString();
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -208,7 +208,7 @@ public class EmailAddressCollectionTest
         var exp = "info@qowaiv.org,test@qowaiv.org";
         var act = collection.ToString();
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -217,7 +217,7 @@ public class EmailAddressCollectionTest
         var act = GetTestInstance().ToString("U", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: 'INFO@QOWAIV.ORG,TEST@QOWAIV.ORG', format: 'U'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -225,7 +225,7 @@ public class EmailAddressCollectionTest
     {
         var act = GetTestInstance().ToString(@"mai\lto:f");
         var exp = "mailto:info@qowaiv.org,mailto:test@qowaiv.org";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/EmailAddressCollectionTest.cs
@@ -27,7 +27,7 @@ public class EmailAddressCollectionTest
         var input = GetTestInstance();
         var exp = GetTestInstance();
         var act = SerializeDeserialize.Binary(input);
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 #endif
 
@@ -37,7 +37,7 @@ public class EmailAddressCollectionTest
         var input = GetTestInstance();
         var exp = GetTestInstance();
         var act = SerializeDeserialize.DataContract(input);
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]
@@ -241,7 +241,7 @@ public class EmailAddressCollectionTest
             EmailAddress.Empty
         };
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]
@@ -253,7 +253,7 @@ public class EmailAddressCollectionTest
             EmailAddress.Unknown
         };
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]
@@ -263,7 +263,7 @@ public class EmailAddressCollectionTest
         var act = GetTestInstance();
         act.Add(EmailAddress.Empty);
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]
@@ -273,7 +273,7 @@ public class EmailAddressCollectionTest
         var act = GetTestInstance();
         act.Add(EmailAddress.Unknown);
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     #endregion
@@ -286,7 +286,7 @@ public class EmailAddressCollectionTest
         var act = EmailAddressCollection.Parse("info@qowaiv.org,test@qowaiv.org,?");
         var exp = GetTestInstance();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]
@@ -294,7 +294,7 @@ public class EmailAddressCollectionTest
     {
         EmailAddressCollection exp = [];
         EmailAddressCollection.TryParse(null, out EmailAddressCollection act).Should().BeTrue();
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]
@@ -302,7 +302,7 @@ public class EmailAddressCollectionTest
     {
         EmailAddressCollection exp = [];
         EmailAddressCollection.TryParse(string.Empty, out EmailAddressCollection act).Should().BeTrue();
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]
@@ -311,7 +311,7 @@ public class EmailAddressCollectionTest
         var act = EmailAddressCollection.TryParse("invalid");
         var exp = new EmailAddressCollection();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]
@@ -320,7 +320,7 @@ public class EmailAddressCollectionTest
         var act = EmailAddressCollection.TryParse("svo@qowaiv.org");
         var exp = new EmailAddressCollection { EmailAddress.Parse("svo@qowaiv.org") };
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     #endregion
@@ -336,7 +336,7 @@ public class EmailAddressCollectionTest
         var exp = EmailAddressCollection.Parse("mail@qowaiv.org,info@qowaiv.org,test@qowaiv.org");
 
         Assert.AreEqual(typeof(EmailAddressCollection), act.GetType(), "The outcome of to collection should be an email address collection.");
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
@@ -22,7 +22,7 @@ public class AmountTest
     [Test]
     public void Zero_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Amount), Amount.Zero);
+        Amount.Zero.Should().Be(default(Amount));
     }
 
     #endregion
@@ -71,7 +71,7 @@ public class AmountTest
             var exp = TestStruct;
             var act = Amount.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -85,7 +85,7 @@ public class AmountTest
         Amount act = Amount.Parse("5#123*34", GetCustomNumberFormatInfo());
         Amount exp = (Amount)5123.34;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -101,7 +101,7 @@ public class AmountTest
         var info = new SerializationInfo(typeof(Amount), new FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual(42.17m, info.GetDecimal("Value"));
+        info.GetDecimal("Value").Should().Be(42.17m);
     }
 
     [Test]
@@ -111,7 +111,7 @@ public class AmountTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -121,7 +121,7 @@ public class AmountTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -129,14 +129,14 @@ public class AmountTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "42.17";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Amount>("42.17");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -268,14 +268,14 @@ public class AmountTest
         var act = TestStruct.ToString("#.0", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '42.2', format: '#.0'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStruct_ComplexPattern()
     {
         var act = TestStruct.ToString(string.Empty, CultureInfo.InvariantCulture);
         var exp = "42.17";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -285,7 +285,7 @@ public class AmountTest
         {
             var act = Amount.Parse("1600,1").ToString();
             var exp = "1600,1";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -296,7 +296,7 @@ public class AmountTest
         {
             var act = Amount.Parse("1600.1").ToString();
             var exp = "1600.1";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -307,7 +307,7 @@ public class AmountTest
         {
             var act = Amount.Parse("800").ToString("0000");
             var exp = "0800";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -318,7 +318,7 @@ public class AmountTest
         {
             var act = Amount.Parse("800").ToString("0000");
             var exp = "0800";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -327,7 +327,7 @@ public class AmountTest
     {
         var act = Amount.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
         var exp = "01700,0";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -336,7 +336,7 @@ public class AmountTest
         Amount amount = (Amount)170.42;
         var act = amount.ToString("C", new CultureInfo("fr-FR"));
         var exp = "170,42 €";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
 
@@ -346,7 +346,7 @@ public class AmountTest
         Amount amount = (Amount)12345678.235m;
         var act = amount.ToString("#,##0.0000", GetCustomNumberFormatInfo());
         var exp = "12#345#678*2350";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -357,7 +357,7 @@ public class AmountTest
     [Test]
     public void GetHash_Zero_Hash()
     {
-        Assert.AreEqual(0, Amount.Zero.GetHashCode());
+        Amount.Zero.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
@@ -366,7 +366,7 @@ public class AmountTest
     {
         var hash0 = ((Amount)451).GetHashCode();
         var hash1 = ((Amount)451).GetHashCode();
-        Assert.AreEqual(hash1, hash0);
+        hash0.Should().Be(hash1);
     }
 
     [Test]
@@ -484,7 +484,7 @@ public class AmountTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -553,7 +553,7 @@ public class AmountTest
     public void Sign(int expected, Amount value)
     {
         var actual = value.Sign();
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [TestCase(1234.01, -1234.01)]
@@ -561,7 +561,7 @@ public class AmountTest
     public void Abs(Amount expected, Amount value)
     {
         var abs = value.Abs();
-        Assert.AreEqual(expected, abs);
+        abs.Should().Be(expected);
     }
 
     [TestCase(-1234.01)]
@@ -569,7 +569,7 @@ public class AmountTest
     public void Plus(Amount expected)
     {
         var plus = +expected;
-        Assert.AreEqual(expected, plus);
+        plus.Should().Be(expected);
     }
 
     [TestCase(+1234.01, -1234.01)]
@@ -577,7 +577,7 @@ public class AmountTest
     public void Negate(Amount expected, Amount value)
     {
         var negated = -value;
-        Assert.AreEqual(expected, negated);
+        negated.Should().Be(expected);
     }
 
     [Test]
@@ -585,7 +585,7 @@ public class AmountTest
     {
         Amount amount = (Amount)43.17;
         amount--;
-        Assert.AreEqual(TestStruct, amount);
+        amount.Should().Be(TestStruct);
     }
 
     [Test]
@@ -593,7 +593,7 @@ public class AmountTest
     {
         Amount amount = (Amount)41.17;
         amount++;
-        Assert.AreEqual(TestStruct, amount);
+        amount.Should().Be(TestStruct);
     }
 
     [Test]
@@ -813,7 +813,7 @@ public class AmountTest
     {
         var amount = (Amount)123.4567m;
         var rounded = amount.Round();
-        Assert.AreEqual((Amount)123m, rounded);
+        rounded.Should().Be((Amount)123m);
     }
 
     [Test]
@@ -821,7 +821,7 @@ public class AmountTest
     {
         var amount = (Amount)123.4567m;
         var rounded = amount.Round(1);
-        Assert.AreEqual((Amount)123.5m, rounded);
+        rounded.Should().Be((Amount)123.5m);
     }
 
     [Test]
@@ -829,7 +829,7 @@ public class AmountTest
     {
         var amount = (Amount)123.6567m;
         var rounded = amount.RoundToMultiple(0.25m);
-        Assert.AreEqual((Amount)123.75m, rounded);
+        rounded.Should().Be((Amount)123.75m);
     }
 }
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/AmountTest.cs
@@ -456,7 +456,7 @@ public class AmountTest
         var exp = new List<Amount> { Amount.Zero, Amount.Zero, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of Amounts descending.</summary>
@@ -472,7 +472,7 @@ public class AmountTest
         var exp = new List<Amount> { item3, item2, item1, item0, Amount.Zero, Amount.Zero };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
@@ -473,7 +473,7 @@ public class BusinessIdentifierCodeTest
         var exp = new List<BusinessIdentifierCode> { BusinessIdentifierCode.Empty, BusinessIdentifierCode.Empty, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of BICs descending.</summary>
@@ -489,7 +489,7 @@ public class BusinessIdentifierCodeTest
         var exp = new List<BusinessIdentifierCode> { item3, item2, item1, item0, BusinessIdentifierCode.Empty, BusinessIdentifierCode.Empty };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/BusinessIdentifierCodeTest.cs
@@ -12,7 +12,7 @@ public class BusinessIdentifierCodeTest
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(BusinessIdentifierCode), BusinessIdentifierCode.Empty);
+        BusinessIdentifierCode.Empty.Should().Be(default(BusinessIdentifierCode));
     }
 
     #endregion
@@ -131,7 +131,7 @@ public class BusinessIdentifierCodeTest
         {
             var act = BusinessIdentifierCode.Parse("?");
             var exp = BusinessIdentifierCode.Unknown;
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -157,7 +157,7 @@ public class BusinessIdentifierCodeTest
             var exp = TestStruct;
             var act = BusinessIdentifierCode.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -178,7 +178,7 @@ public class BusinessIdentifierCodeTest
         var info = new SerializationInfo(typeof(BusinessIdentifierCode), new FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual(TestStruct.ToString(), info.GetString("Value"));
+        info.GetString("Value").Should().Be(TestStruct.ToString());
     }
 
     [Test]
@@ -188,7 +188,7 @@ public class BusinessIdentifierCodeTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -198,7 +198,7 @@ public class BusinessIdentifierCodeTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -206,14 +206,14 @@ public class BusinessIdentifierCodeTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "AEGONL2UXXX";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<BusinessIdentifierCode>("AEGONL2UXXX");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -344,7 +344,7 @@ public class BusinessIdentifierCodeTest
     {
         var act = BusinessIdentifierCode.Empty.ToString();
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -352,7 +352,7 @@ public class BusinessIdentifierCodeTest
     {
         var act = BusinessIdentifierCode.Unknown.ToString();
         var exp = "?";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -361,14 +361,14 @@ public class BusinessIdentifierCodeTest
         var act = TestStruct.ToString("Unit Test Format", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: 'AEGONL2UXXX', format: 'Unit Test Format'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStruct_ComplexPattern()
     {
         var act = TestStruct.ToString(string.Empty);
         var exp = "AEGONL2UXXX";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -379,7 +379,7 @@ public class BusinessIdentifierCodeTest
     [Test]
     public void GetHash_Empty_Hash()
     {
-        Assert.AreEqual(0, BusinessIdentifierCode.Empty.GetHashCode());
+        BusinessIdentifierCode.Empty.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
@@ -501,7 +501,7 @@ public class BusinessIdentifierCodeTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -521,21 +521,21 @@ public class BusinessIdentifierCodeTest
     {
         var exp = 0;
         var act = BusinessIdentifierCode.Empty.Length;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Length_Unknown_0()
     {
         var exp = 0;
         var act = BusinessIdentifierCode.Unknown.Length;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Length_TestStruct_IntValue()
     {
         var exp = 11;
         var act = TestStruct.Length;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -543,14 +543,14 @@ public class BusinessIdentifierCodeTest
     {
         var exp = "";
         var act = BusinessIdentifierCode.Empty.Business;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void BusinessCode_Unknown_StringEmpty()
     {
         var exp = "";
         var act = BusinessIdentifierCode.Unknown.Business;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void BusinessCode_has_length_of_four()
@@ -561,21 +561,21 @@ public class BusinessIdentifierCodeTest
     {
         var exp = Country.Empty;
         var act = BusinessIdentifierCode.Empty.Country;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Country_Unknown_CountryUnknown()
     {
         var exp = Country.Unknown;
         var act = BusinessIdentifierCode.Unknown.Country;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Country_TestStruct_NL()
     {
         var exp = Country.NL;
         var act = TestStruct.Country;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -583,21 +583,21 @@ public class BusinessIdentifierCodeTest
     {
         var exp = "";
         var act = BusinessIdentifierCode.Empty.Location;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void LocationCode_Unknown_StringEmpty()
     {
         var exp = "";
         var act = BusinessIdentifierCode.Unknown.Location;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void LocationCode_TestStruct_NL()
     {
         var exp = "2U";
         var act = TestStruct.Location;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -605,28 +605,28 @@ public class BusinessIdentifierCodeTest
     {
         var exp = "";
         var act = BusinessIdentifierCode.Empty.Branch;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void BranchCode_Unknown_StringEmpty()
     {
         var exp = "";
         var act = BusinessIdentifierCode.Unknown.Branch;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void BranchCode_TestStruct_NL()
     {
         var exp = "XXX";
         var act = TestStruct.Branch;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void BranchCode_empty_for_BIC_without_one()
     {
         var exp = "";
         var act = BusinessIdentifierCode.Parse("AEGONL2U").Branch;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
@@ -629,7 +629,7 @@ public class CurrencyTest
         var exp = new List<Currency> { Currency.Empty, Currency.Empty, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of currencys descending.</summary>
@@ -645,7 +645,7 @@ public class CurrencyTest
         var exp = new List<Currency> { item3, item2, item1, item0, Currency.Empty, Currency.Empty };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/CurrencyTest.cs
@@ -12,7 +12,7 @@ public class CurrencyTest
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Currency), Currency.Empty);
+        Currency.Empty.Should().Be(default(Currency));
     }
 
     #endregion
@@ -27,7 +27,7 @@ public class CurrencyTest
             var act = Currency.Current;
             var exp = Currency.EUR;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -39,7 +39,7 @@ public class CurrencyTest
             var act = Currency.Current;
             var exp = Currency.USD;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -51,7 +51,7 @@ public class CurrencyTest
             var act = Currency.Current;
             var exp = Currency.Empty;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -180,7 +180,7 @@ public class CurrencyTest
         {
             var act = Currency.Parse("?");
             var exp = Currency.Unknown;
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -206,7 +206,7 @@ public class CurrencyTest
             var exp = TestStruct;
             var act = Currency.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -219,7 +219,7 @@ public class CurrencyTest
     {
         var act = Currency.Parse("€");
         var exp = Currency.EUR;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -235,7 +235,7 @@ public class CurrencyTest
         var info = new SerializationInfo(typeof(Currency), new System.Runtime.Serialization.FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual("EUR", info.GetString("Value"));
+        info.GetString("Value").Should().Be("EUR");
     }
 
     [Test]
@@ -245,7 +245,7 @@ public class CurrencyTest
         var input = CurrencyTest.TestStruct;
         var exp = CurrencyTest.TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -255,7 +255,7 @@ public class CurrencyTest
         var input = CurrencyTest.TestStruct;
         var exp = CurrencyTest.TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -263,14 +263,14 @@ public class CurrencyTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "EUR";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Currency>("EUR");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -401,7 +401,7 @@ public class CurrencyTest
     {
         var act = Currency.Empty.ToString();
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -409,7 +409,7 @@ public class CurrencyTest
     {
         var act = Currency.Unknown.ToString();
         var exp = "?";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -418,14 +418,14 @@ public class CurrencyTest
         var act = TestStruct.ToString("$: e", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '€: Euro', format: '$: e'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStruct_ComplexPattern()
     {
         var act = TestStruct.ToString(string.Empty);
         var exp = "EUR";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -435,7 +435,7 @@ public class CurrencyTest
         {
             var act = Currency.Parse("Amerikaanse dollar").ToString();
             var exp = "USD";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -446,7 +446,7 @@ public class CurrencyTest
         {
             var act = Currency.Parse("pound sterling").ToString("f");
             var exp = "Pound sterling";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
     #endregion
@@ -461,7 +461,7 @@ public class CurrencyTest
             Amount number = (Amount)1200.34m;
             var act = number.ToString("C", Currency.BYR);
             var exp = "BYR1,200";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -473,7 +473,7 @@ public class CurrencyTest
             Amount number = (Amount)12.34m;
             var act = number.ToString("C", Currency.ANG);
             var exp = "NAf.12.34";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -485,7 +485,7 @@ public class CurrencyTest
             var number = 12.34m;
             var act = number.ToString("C", Currency.ANG);
             var exp = "NAf.12.34";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -497,7 +497,7 @@ public class CurrencyTest
             var number = 12.34m;
             var act = number.ToString("C", Currency.TND);
             var exp = "TND12.340";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -510,7 +510,7 @@ public class CurrencyTest
             var act = number.ToString("C", Currency.EUR);
             var exp = "€12.34";
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -523,7 +523,7 @@ public class CurrencyTest
             var act = number.ToString("C", Currency.EUR);
             var exp = "€12.34";
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -535,7 +535,7 @@ public class CurrencyTest
     [Test]
     public void GetHash_Empty_0()
     {
-        Assert.AreEqual(0, Currency.Empty.GetHashCode());
+        Currency.Empty.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
@@ -657,7 +657,7 @@ public class CurrencyTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -676,7 +676,7 @@ public class CurrencyTest
     {
         var act = Currency.AZN.Symbol;
         var exp = "₼";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
@@ -11,7 +11,7 @@ public class InternationalBankAccountNumberTest
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(InternationalBankAccountNumber), InternationalBankAccountNumber.Empty);
+        InternationalBankAccountNumber.Empty.Should().Be(default(InternationalBankAccountNumber));
     }
 
     #endregion
@@ -103,7 +103,7 @@ public class InternationalBankAccountNumberTest
             var exp = TestStruct;
             var act = InternationalBankAccountNumber.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -124,7 +124,7 @@ public class InternationalBankAccountNumberTest
         var input = InternationalBankAccountNumberTest.TestStruct;
         var exp = InternationalBankAccountNumberTest.TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -134,7 +134,7 @@ public class InternationalBankAccountNumberTest
         var input = InternationalBankAccountNumberTest.TestStruct;
         var exp = InternationalBankAccountNumberTest.TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -142,14 +142,14 @@ public class InternationalBankAccountNumberTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "NL20INGB0001234567";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<InternationalBankAccountNumber>("NL20INGB0001234567");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -280,7 +280,7 @@ public class InternationalBankAccountNumberTest
     {
         var act = InternationalBankAccountNumber.Empty.ToString();
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -289,7 +289,7 @@ public class InternationalBankAccountNumberTest
         var act = TestStruct.ToString("[f]", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '[nl20 ingb 0001 2345 67]', format: '[f]'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -297,7 +297,7 @@ public class InternationalBankAccountNumberTest
     {
         var act = InternationalBankAccountNumber.Unknown.ToString(string.Empty, null);
         var exp = "?";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -305,7 +305,7 @@ public class InternationalBankAccountNumberTest
     {
         var act = TestStruct.ToString();
         var exp = "NL20INGB0001234567";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -313,42 +313,42 @@ public class InternationalBankAccountNumberTest
     {
         var act = TestStruct.ToString("u");
         var exp = "nl20ingb0001234567";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStructFormatUUpper_AreEqual()
     {
         var act = TestStruct.ToString("U");
         var exp = "NL20INGB0001234567";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStructFormatFLower_AreEqual()
     {
         var act = TestStruct.ToString("f");
         var exp = "nl20 ingb 0001 2345 67";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStructFormatFUpper_AreEqual()
     {
         var act = TestStruct.ToString("F");
         var exp = "NL20 INGB 0001 2345 67";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_EmptyFormatF_AreEqual()
     {
         var act = InternationalBankAccountNumber.Empty.ToString("F");
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_UnknownFormatF_AreEqual()
     {
         var act = InternationalBankAccountNumber.Unknown.ToString("F");
         var exp = "?";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -359,7 +359,7 @@ public class InternationalBankAccountNumberTest
     [Test]
     public void GetHash_Empty_Hash()
     {
-        Assert.AreEqual(0, InternationalBankAccountNumber.Empty.GetHashCode());
+        InternationalBankAccountNumber.Empty.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
@@ -481,7 +481,7 @@ public class InternationalBankAccountNumberTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -500,21 +500,21 @@ public class InternationalBankAccountNumberTest
     {
         var exp = 0;
         var act = InternationalBankAccountNumber.Empty.Length;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Length_Unknown_0()
     {
         var exp = 0;
         var act = InternationalBankAccountNumber.Unknown.Length;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Length_TestStruct_IntValue()
     {
         var exp = 18;
         var act = TestStruct.Length;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
 
@@ -523,21 +523,21 @@ public class InternationalBankAccountNumberTest
     {
         var exp = Country.Empty;
         var act = InternationalBankAccountNumber.Empty.Country;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Country_Unknown_Null()
     {
         var exp = Country.Unknown;
         var act = InternationalBankAccountNumber.Unknown.Country;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Country_TestStruct_Null()
     {
         var exp = Country.NL;
         var act = TestStruct.Country;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/InternationalBankAccountNumberTest.cs
@@ -453,7 +453,7 @@ public class InternationalBankAccountNumberTest
         var exp = new List<InternationalBankAccountNumber> { InternationalBankAccountNumber.Empty, InternationalBankAccountNumber.Empty, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of IBANs descending.</summary>
@@ -469,7 +469,7 @@ public class InternationalBankAccountNumberTest
         var exp = new List<InternationalBankAccountNumber> { item3, item2, item1, item0, InternationalBankAccountNumber.Empty, InternationalBankAccountNumber.Empty };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
@@ -13,7 +13,7 @@ public class MoneyTest
     [Test]
     public void Zero_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Money), Money.Zero);
+        Money.Zero.Should().Be(default(Money));
     }
 
     #endregion
@@ -63,7 +63,7 @@ public class MoneyTest
             var exp = TestStruct;
             var act = Money.TryParse("€42.17");
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -78,7 +78,7 @@ public class MoneyTest
         {
             var exp = 12 + Currency.EUR;
             var act = Money.Parse("€ 12");
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -89,7 +89,7 @@ public class MoneyTest
         {
             var exp = -12.765 + Currency.EUR;
             var act = Money.Parse("-12,765 €");
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -106,8 +106,8 @@ public class MoneyTest
         var info = new SerializationInfo(typeof(Money), new FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual(42.17m, info.GetDecimal("Value"));
-        Assert.AreEqual("EUR", info.GetString("Currency"));
+        info.GetDecimal("Value").Should().Be(42.17m);
+        info.GetString("Currency").Should().Be("EUR");
     }
 
     [Test]
@@ -117,7 +117,7 @@ public class MoneyTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -127,7 +127,7 @@ public class MoneyTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -135,14 +135,14 @@ public class MoneyTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "EUR42.17";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Money>("EUR42.17");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -275,7 +275,7 @@ public class MoneyTest
         {
             var act = Money.Zero.ToString();
             var exp = "0";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -285,7 +285,7 @@ public class MoneyTest
         var act = TestStruct.ToString("0.0", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '42.2', format: '0.0'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -295,7 +295,7 @@ public class MoneyTest
         {
             var act = TestStruct.ToString("0.00");
             var exp = "42,17";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -308,7 +308,7 @@ public class MoneyTest
             CultureInfo.CurrentCulture.NumberFormat.CurrencyPositivePattern = 3;
             var act = Money.Parse("ALL 1600,1").ToString();
             var exp = "1.600,10 Lekë";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -319,7 +319,7 @@ public class MoneyTest
         {
             var act = Money.Parse("EUR 1600.1").ToString();
             var exp = "€1,600.10";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -330,7 +330,7 @@ public class MoneyTest
         {
             var act = Money.Parse("AED 1600.1").ToString();
             var exp = "AED1,600.10";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -341,7 +341,7 @@ public class MoneyTest
         {
             var act = Money.Parse("800").ToString("0000");
             var exp = "0800";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -352,7 +352,7 @@ public class MoneyTest
         {
             var act = Money.Parse("800").ToString("0000");
             var exp = "0800";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -361,7 +361,7 @@ public class MoneyTest
     {
         var act = Money.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
         var exp = "01700,0";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -372,7 +372,7 @@ public class MoneyTest
     [Test]
     public void GetHash_Empty_Hash()
     {
-        Assert.AreEqual(0, Money.Zero.GetHashCode());
+        Money.Zero.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
@@ -494,7 +494,7 @@ public class MoneyTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -563,14 +563,14 @@ public class MoneyTest
     public void Currency_Set()
     {
         var money = 42 + Currency.EUR;
-        Assert.AreEqual(Currency.EUR, money.Currency);
+        money.Currency.Should().Be(Currency.EUR);
     }
 
     [Test]
     public void Amount_Set()
     {
         var money = 42 + Currency.EUR;
-        Assert.AreEqual((Amount)42, money.Amount);
+        money.Amount.Should().Be((Amount)42);
     }
 
     #endregion
@@ -583,7 +583,7 @@ public class MoneyTest
     public void Sign(int expected, Money value)
     {
         var actual = value.Sign();
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [TestCase(23.1234, -23.1234)]
@@ -599,7 +599,7 @@ public class MoneyTest
     public void Plus_TestStruct_SameValue()
     {
         var act = +TestStruct;
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
     [Test]
@@ -607,7 +607,7 @@ public class MoneyTest
     {
         var act = -TestStruct;
         var exp = -42.17 + Currency.EUR;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -616,7 +616,7 @@ public class MoneyTest
         var act = TestStruct;
         act++;
         var exp = 43.17 + Currency.EUR;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -625,7 +625,7 @@ public class MoneyTest
         var act = TestStruct;
         act--;
         var exp = 41.17 + Currency.EUR;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -655,7 +655,7 @@ public class MoneyTest
         var r = 666 + Currency.USD;
 
         var x = Assert.Catch<CurrencyMismatchException>(() => l.Add(r));
-        Assert.AreEqual("The addition operation could not be applied. There is a mismatch between EUR and USD.", x.Message);
+        x.Message.Should().Be("The addition operation could not be applied. There is a mismatch between EUR and USD.");
     }
 
     [Test]
@@ -686,7 +686,7 @@ public class MoneyTest
 
         var x = Assert.Catch<CurrencyMismatchException>(() => l.Subtract(r));
 
-        Assert.AreEqual("The subtraction operation could not be applied. There is a mismatch between EUR and USD.", x.Message);
+        x.Message.Should().Be("The subtraction operation could not be applied. There is a mismatch between EUR and USD.");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Financial/MoneyTest.cs
@@ -466,7 +466,7 @@ public class MoneyTest
         var exp = new List<Money> { Money.Zero, Money.Zero, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of Moneys descending.</summary>
@@ -482,7 +482,7 @@ public class MoneyTest
         var exp = new List<Money> { item3, item2, item1, item0, Money.Zero, Money.Zero };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsCollectionTest.cs
@@ -69,7 +69,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Format("Begin {1000000} End", args);
         var exp = "Begin Test End";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Format_InvalidFormat_ThrowsFormatException()
@@ -120,7 +120,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Format("Value: '{0}'", args);
         var exp = "Value: ''";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Format_AlignLeft_String()
@@ -130,7 +130,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Format("{0,-4}", "a");
         var exp = "a   ";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Format_AlignRight_String()
@@ -140,7 +140,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Format("{0,3}", "a");
         var exp = "  a";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Format_EscapeLeft_String()
@@ -150,7 +150,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Format("{{");
         var exp = "{";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Format_EscapeRight_String()
@@ -160,7 +160,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Format("}}");
         var exp = "}";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Format_ComplexPattern_AreEqual()
@@ -176,7 +176,7 @@ public class FormattingArgumentsCollectionTest
             var act = collection.Format("{0:000.00} - {1} * {1:dd-MM-yyyy} - {2} - {3} - {4}", 3, new Date(2014, 10, 8), 666, 0.8m, 0.9);
             var exp = "003,00 - 2014-10-08 00:00 * 08-10-2014 - 666 - 0,800 - 0,9";
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
     [Test]
@@ -193,7 +193,7 @@ public class FormattingArgumentsCollectionTest
             var act = collection.Format("{0:yyyy-MM-dd} * {0}", new Date(2014, 10, 8));
             var exp = "Unit Test Formatter, value: '2014-10-08', format: 'yyyy-MM-dd' * Unit Test Formatter, value: '10/08/2014', format: ''";
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -218,7 +218,7 @@ public class FormattingArgumentsCollectionTest
         string act = collection.ToString((object)typeof(int));
         string exp = "System.Int32";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_7_007()
@@ -327,7 +327,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Remove(typeof(int));
         var exp = false;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Remove_AddedInt32_Successful()
@@ -339,7 +339,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Remove(typeof(int));
         var exp = true;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -399,7 +399,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Count;
         var exp = 0;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -411,7 +411,7 @@ public class FormattingArgumentsCollectionTest
         };
         var act = collection.Contains(typeof(int));
         var exp = true;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Contains_EmptyCollectionInt32_IsFalse()
@@ -419,7 +419,7 @@ public class FormattingArgumentsCollectionTest
         var collection = new FormattingArgumentsCollection();
         var act = collection.Contains(typeof(int));
         var exp = false;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsCollectionTest.cs
@@ -369,7 +369,7 @@ public class FormattingArgumentsCollectionTest
         var ienumerable = collection as IEnumerable<KeyValuePair<Type, FormattingArguments>>;
 
         var act = ienumerable.GetEnumerator();
-        Assert.IsNotNull(act);
+        act.Should().NotBeNull();
     }
     [Test]
     public void GetEnumerator_IEnumerable_IsNotNull()
@@ -383,7 +383,7 @@ public class FormattingArgumentsCollectionTest
         var ienumerable = collection as IEnumerable;
 
         var act = ienumerable.GetEnumerator();
-        Assert.IsNotNull(act);
+        act.Should().NotBeNull();
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsCollectionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsCollectionTest.cs
@@ -354,7 +354,7 @@ public class FormattingArgumentsCollectionTest
         var act = collection.Types;
         var exp = new [] { typeof(int), typeof(Date) };
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/FormattingArgumentsTest.cs
@@ -12,7 +12,7 @@ public class FormattingArgumentsTest
     [Test]
     public void None_None_EqualsDefault()
     {
-        Assert.AreEqual(default(FormattingArguments), FormattingArguments.None);
+        FormattingArguments.None.Should().Be(default(FormattingArguments));
     }
 
     #endregion
@@ -28,7 +28,7 @@ public class FormattingArgumentsTest
         var info = new SerializationInfo(typeof(FormattingArguments), new System.Runtime.Serialization.FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual("0.000", info.GetString("Format"));
+        info.GetString("Format").Should().Be("0.000");
         Assert.AreEqual(new CultureInfo("fr-BE"), info.GetValue("FormatProvider", typeof(IFormatProvider)));
     }
 
@@ -84,7 +84,7 @@ public class FormattingArgumentsTest
     [Test]
     public void GetHash_Empty_0()
     {
-        Assert.AreEqual(0, FormattingArguments.None.GetHashCode());
+        FormattingArguments.None.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
@@ -162,14 +162,14 @@ public class FormattingArgumentsTest
     {
         var exp = Nil.String;
         var act = FormattingArguments.None.Format;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Format_TestStruct_FormatString()
     {
         var exp = "0.000";
         var act = TestStruct.Format;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     #endregion
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/StringFormatterTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Formatting/StringFormatterTest.cs
@@ -21,7 +21,7 @@ public class StringFormatterTest
         var exp = Nil.String;
         var act = StringFormatter.ToNonDiacritic(str);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -32,7 +32,7 @@ public class StringFormatterTest
         var exp = string.Empty;
         var act = StringFormatter.ToNonDiacritic(str);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -43,7 +43,7 @@ public class StringFormatterTest
         var exp = "Cafe & Strasze";
         var act = StringFormatter.ToNonDiacritic(str);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -54,6 +54,6 @@ public class StringFormatterTest
         var exp = "Café & Strasze";
         var act = StringFormatter.ToNonDiacritic(str, "é");
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -9,7 +9,7 @@ public class CountryTest
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Country), Country.Empty);
+        Country.Empty.Should().Be(default(Country));
     }
 
     #region Current
@@ -22,7 +22,7 @@ public class CountryTest
             var act = Country.Current;
             var exp = Country.DE;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -34,7 +34,7 @@ public class CountryTest
             var act = Country.Current;
             var exp = Country.EC;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -46,7 +46,7 @@ public class CountryTest
             var act = Country.Current;
             var exp = Country.Empty;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -147,7 +147,7 @@ public class CountryTest
             var exp = TestStruct;
             var act = Country.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -164,7 +164,7 @@ public class CountryTest
     {
         var exp = Country.Empty;
         var act = Country.Create((RegionInfo?)null);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -172,7 +172,7 @@ public class CountryTest
     {
         var exp = Country.Empty;
         var act = Country.Create((CultureInfo?)null);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -180,7 +180,7 @@ public class CountryTest
     {
         var exp = Country.NL;
         var act = Country.Create(new RegionInfo("NL"));
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -188,7 +188,7 @@ public class CountryTest
     {
         var exp = Country.Empty;
         var act = Country.Create(CultureInfo.InvariantCulture);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -196,7 +196,7 @@ public class CountryTest
     {
         var exp = Country.Empty;
         var act = Country.Create(new CultureInfo("es"));
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -204,7 +204,7 @@ public class CountryTest
     {
         var exp = Country.EC;
         var act = Country.Create(new CultureInfo("es-EC"));
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -212,7 +212,7 @@ public class CountryTest
     {
         var cs = new RegionInfo("CS");
         var country = Country.Create(cs);
-        Assert.AreEqual(Country.CSXX, country);
+        country.Should().Be(Country.CSXX);
     }
 
     [TestCaseSource(typeof(Country), nameof(Country.All))]
@@ -233,7 +233,7 @@ public class CountryTest
         var input = CountryTest.TestStruct;
         var exp = CountryTest.TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -241,14 +241,14 @@ public class CountryTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "VA";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Country>("VA");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -380,7 +380,7 @@ public class CountryTest
         var act = TestStruct.ToString("e (3)", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: 'Holy See (VAT)', format: 'e (3)'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -388,7 +388,7 @@ public class CountryTest
     {
         var act = Country.Empty.ToString();
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -396,7 +396,7 @@ public class CountryTest
     {
         var act = Country.Unknown.ToString();
         var exp = "?";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -404,21 +404,21 @@ public class CountryTest
     {
         var exp = "MZ";
         var act = Country.MZ.ToString("2");
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString3_MZ_AreEqual()
     {
         var exp = "MOZ";
         var act = Country.MZ.ToString("3", new CultureInfo("ja-JP"));
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString0_MZ_AreEqual()
     {
         var exp = "508";
         var act = Country.MZ.ToString("0", new CultureInfo("ja-JP"));
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -426,7 +426,7 @@ public class CountryTest
     {
         var exp = "CSHH";
         var act = Country.CSHH.ToString("n", new CultureInfo("ja-JP"));
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -434,7 +434,7 @@ public class CountryTest
     {
         var exp = "Mozambique";
         var act = Country.MZ.ToString("e", new CultureInfo("ja-JP"));
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -442,7 +442,7 @@ public class CountryTest
     {
         var exp = "モザンビーク";
         var act = Country.MZ.ToString("f", new CultureInfo("ja-JP"));
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -453,7 +453,7 @@ public class CountryTest
     [Test]
     public void GetHash_Empty_Hash()
     {
-        Assert.AreEqual(0, Country.Empty.GetHashCode());
+        Country.Empty.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
@@ -578,7 +578,7 @@ public class CountryTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -598,7 +598,7 @@ public class CountryTest
         Country exp = Country.NL;
         Country act = new RegionInfo("NL");
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_CountryToRegionInfo_AreEqual()
@@ -606,7 +606,7 @@ public class CountryTest
         var exp = new RegionInfo("NL");
         var act = (RegionInfo)Country.NL;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -618,21 +618,21 @@ public class CountryTest
     {
         var exp = "";
         var act = Country.Empty.CallingCode;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void CallingCode_Unknown_AreEqual()
     {
         var exp = "";
         var act = Country.Unknown.CallingCode;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void CallingCode_TestStruct_AreEqual()
     {
         var exp = "+379";
         var act = TestStruct.CallingCode;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -642,7 +642,7 @@ public class CountryTest
         {
             var exp = "";
             var act = Country.Empty.Name;
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
     [Test]
@@ -652,7 +652,7 @@ public class CountryTest
         {
             var exp = "?";
             var act = Country.Unknown.Name;
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
     [Test]
@@ -662,7 +662,7 @@ public class CountryTest
         {
             var exp = "VA";
             var act = TestStruct.Name;
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -671,21 +671,21 @@ public class CountryTest
     {
         var exp = 0;
         var act = Country.Empty.IsoNumericCode;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void IsoNumericCode_Unknown_AreEqual()
     {
         var exp = 999;
         var act = Country.Unknown.IsoNumericCode;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void IsoNumericCode_TestStruct_AreEqual()
     {
         var exp = 336;
         var act = TestStruct.IsoNumericCode;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -717,7 +717,7 @@ public class CountryTest
     public void GetCurrency_BF1980_Empty()
     {
         var currency = Country.BF.GetCurrency(new Date(1980, 01, 01));
-        Assert.AreEqual(Currency.Empty, currency);
+        currency.Should().Be(Currency.Empty);
     }
 
     [Test]
@@ -726,7 +726,7 @@ public class CountryTest
         var act = Country.NL.GetCurrency(new Date(2001, 12, 31));
         var exp = Currency.NLG;
 
-        Assert.AreEqual(act, exp);
+        exp.Should().Be(act);
     }
 
     [Test]
@@ -735,7 +735,7 @@ public class CountryTest
         var act = Country.NL.GetCurrency(Clock.Today());
         var exp = Currency.EUR;
 
-        Assert.AreEqual(act, exp);
+        exp.Should().Be(act);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CountryTest.cs
@@ -550,7 +550,7 @@ public class CountryTest
         var exp = new List<Country> { Country.Empty, Country.Empty, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of Countrys descending.</summary>
@@ -566,7 +566,7 @@ public class CountryTest
         var exp = new List<Country> { item3, item2, item1, item0, Country.Empty, Country.Empty };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CultureInfoScopeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Globalization/CultureInfoScopeTest.cs
@@ -14,8 +14,8 @@ public class CultureInfoScopeTest
             Assert.AreEqual("fr-FR", CultureInfo.CurrentUICulture.Name);
         }
 
-        Assert.AreEqual(current, CultureInfo.CurrentCulture);
-        Assert.AreEqual(currentUI, CultureInfo.CurrentUICulture);
+        CultureInfo.CurrentCulture.Should().Be(current);
+        CultureInfo.CurrentUICulture.Should().Be(currentUI);
     }
 
     [Test]
@@ -30,7 +30,7 @@ public class CultureInfoScopeTest
             Assert.AreEqual("es-ES", CultureInfo.CurrentUICulture.Name);
         }
 
-        Assert.AreEqual(current, CultureInfo.CurrentCulture);
-        Assert.AreEqual(currentUI, CultureInfo.CurrentUICulture);
+        CultureInfo.CurrentCulture.Should().Be(current);
+        CultureInfo.CurrentUICulture.Should().Be(currentUI);
     }
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
@@ -467,7 +467,7 @@ public class HouseNumberTest
         var exp = new List<HouseNumber> { HouseNumber.Empty, HouseNumber.Empty, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of house numbers descending.</summary>
@@ -483,7 +483,7 @@ public class HouseNumberTest
         var exp = new List<HouseNumber> { item3, item2, item1, item0, HouseNumber.Empty, HouseNumber.Empty };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/HouseNumberTest.cs
@@ -13,19 +13,19 @@ public class HouseNumberTest
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(HouseNumber), HouseNumber.Empty);
+        HouseNumber.Empty.Should().Be(default(HouseNumber));
     }
 
     [Test]
     public void MinValue_None_1()
     {
-        Assert.AreEqual(HouseNumber.Create(1), HouseNumber.MinValue);
+        HouseNumber.MinValue.Should().Be(HouseNumber.Create(1));
     }
 
     [Test]
     public void MaxValue_None_999999999()
     {
-        Assert.AreEqual(HouseNumber.Create(999999999), HouseNumber.MaxValue);
+        HouseNumber.MaxValue.Should().Be(HouseNumber.Create(999999999));
     }
 
     #endregion
@@ -148,7 +148,7 @@ public class HouseNumberTest
         {
             var act = HouseNumber.Parse("?");
             var exp = HouseNumber.Unknown;
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -174,7 +174,7 @@ public class HouseNumberTest
             var exp = TestStruct;
             var act = HouseNumber.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -191,14 +191,14 @@ public class HouseNumberTest
     {
         HouseNumber exp = HouseNumber.Empty;
         HouseNumber.TryCreate(null, out HouseNumber act).Should().BeTrue();
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void TryCreate_Int32MinValue_IsEmpty()
     {
         HouseNumber exp = HouseNumber.Empty;
         HouseNumber.TryCreate(int.MinValue, out HouseNumber act).Should().BeFalse();
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -206,14 +206,14 @@ public class HouseNumberTest
     {
         var exp = HouseNumber.Empty;
         var act = HouseNumber.TryCreate(int.MinValue);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void TryCreate_Value_AreEqual()
     {
         var exp = TestStruct;
         var act = HouseNumber.TryCreate(123456789);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -229,7 +229,7 @@ public class HouseNumberTest
         var info = new SerializationInfo(typeof(HouseNumber), new System.Runtime.Serialization.FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual(123456789, info.GetInt32("Value"));
+        info.GetInt32("Value").Should().Be(123456789);
     }
 
     [Test]
@@ -239,7 +239,7 @@ public class HouseNumberTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -249,7 +249,7 @@ public class HouseNumberTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -257,14 +257,14 @@ public class HouseNumberTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "123456789";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<HouseNumber>("123456789");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -395,14 +395,14 @@ public class HouseNumberTest
     {
         var act = HouseNumber.Empty.ToString();
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_Unknown_QuestionMark()
     {
         var act = HouseNumber.Unknown.ToString();
         var exp = "?";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_CustomFormatter_SupportsCustomFormatting()
@@ -410,14 +410,14 @@ public class HouseNumberTest
         var act = TestStruct.ToString("#,##0", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '123,456,789', format: '#,##0'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStruct_ComplexPattern()
     {
         var act = TestStruct.ToString(string.Empty);
         var exp = "123456789";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -427,7 +427,7 @@ public class HouseNumberTest
         {
             var act = HouseNumber.Parse("800").ToString("0000");
             var exp = "0800";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -438,7 +438,7 @@ public class HouseNumberTest
         {
             var act = HouseNumber.Parse("800").ToString("0000");
             var exp = "0800";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -447,7 +447,7 @@ public class HouseNumberTest
     {
         var act = HouseNumber.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
         var exp = "01700,0";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -495,7 +495,7 @@ public class HouseNumberTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -566,7 +566,7 @@ public class HouseNumberTest
         var exp = TestStruct;
         var act = (HouseNumber)123456789;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_HouseNumberToInt32_AreEqual()
@@ -574,7 +574,7 @@ public class HouseNumberTest
         var exp = 123456789;
         var act = (int)TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     #endregion
 
@@ -628,7 +628,7 @@ public class HouseNumberTest
     {
         var act = HouseNumber.Empty.Length;
         var exp = 0;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -636,7 +636,7 @@ public class HouseNumberTest
     {
         var act = HouseNumber.Unknown.Length;
         var exp = 0;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -644,7 +644,7 @@ public class HouseNumberTest
     {
         var act = TestStruct.Length;
         var exp = 9;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -652,7 +652,7 @@ public class HouseNumberTest
     {
         var act = HouseNumber.Create(1234).Length;
         var exp = 4;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     #endregion
 }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
@@ -536,7 +536,7 @@ public class StreamSizeTest
         var exp = new List<StreamSize> { StreamSize.Zero, StreamSize.Zero, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of stream sizes descending.</summary>
@@ -552,7 +552,7 @@ public class StreamSizeTest
         var exp = new List<StreamSize> { item3, item2, item1, item0, StreamSize.Zero, StreamSize.Zero };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/IO/StreamSizeTest.cs
@@ -12,7 +12,7 @@ public class StreamSizeTest
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(StreamSize), StreamSize.Zero);
+        StreamSize.Zero.Should().Be(default(StreamSize));
     }
 
     #endregion
@@ -25,7 +25,7 @@ public class StreamSizeTest
         var size = StreamSize.FromKilobytes(2);
         var act = (long)size;
         var exp = 2000L;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void FromMegabytes_3Dot5_3500000()
@@ -33,7 +33,7 @@ public class StreamSizeTest
         var size = StreamSize.FromMegabytes(3.5);
         var act = (long)size;
         var exp = 3500000L;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void FromGigabytes_0Dot8_800000000()
@@ -41,7 +41,7 @@ public class StreamSizeTest
         var size = StreamSize.FromGigabytes(0.8);
         var act = (long)size;
         var exp = 800000000L;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void FromTerabytes_10_10000000000000()
@@ -49,7 +49,7 @@ public class StreamSizeTest
         var size = StreamSize.FromTerabytes(10);
         var act = (long)size;
         var exp = 10000000000000L;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -58,7 +58,7 @@ public class StreamSizeTest
         var size = StreamSize.FromKibibytes(2);
         var act = (long)size;
         var exp = 2048L;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void FromMebibytes_3Dot5_3670016()
@@ -66,7 +66,7 @@ public class StreamSizeTest
         var size = StreamSize.FromMebibytes(3.5);
         var act = (long)size;
         var exp = 3670016L;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void FromGibibytes_0Dot8_858993459()
@@ -74,7 +74,7 @@ public class StreamSizeTest
         var size = StreamSize.FromGibibytes(0.8);
         var act = (long)size;
         var exp = 858993459L;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void FromTebibytes_10_10995116277760()
@@ -82,7 +82,7 @@ public class StreamSizeTest
         var size = StreamSize.FromTebibytes(10);
         var act = (long)size;
         var exp = 10995116277760L;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -98,7 +98,7 @@ public class StreamSizeTest
         var info = new SerializationInfo(typeof(StreamSize), new System.Runtime.Serialization.FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual((long)123456789, info.GetInt64("Value"));
+        info.GetInt64("Value").Should().Be((long)123456789);
     }
 
     [Test]
@@ -108,7 +108,7 @@ public class StreamSizeTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -118,7 +118,7 @@ public class StreamSizeTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -126,14 +126,14 @@ public class StreamSizeTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "123456789 byte";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<StreamSize>("123456789 byte");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -264,7 +264,7 @@ public class StreamSizeTest
     {
         var act = StreamSize.Zero.ToString();
         var exp = "0 byte";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -273,7 +273,7 @@ public class StreamSizeTest
         var act = TestStruct.ToString("0.0 F", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '123.5 Megabyte', format: '0.0 F'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -281,7 +281,7 @@ public class StreamSizeTest
     {
         var act = TestStruct.ToString(Nil.String);
         var exp = "123456789";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -289,7 +289,7 @@ public class StreamSizeTest
     {
         var act = TestStruct.ToString(string.Empty);
         var exp = "123456789";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -299,7 +299,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("#,##0b");
             var exp = "123.456.789b";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -310,7 +310,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("#,##0.00 kB");
             var exp = "123.456,79 kB";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -321,7 +321,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("0.0 MegaByte");
             var exp = "123,5 MegaByte";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -332,7 +332,7 @@ public class StreamSizeTest
         {
             var act = (-TestStruct).ToString("0.0 F");
             var exp = "-123,5 Megabyte";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -343,7 +343,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("0.00GB");
             var exp = "0,12GB";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -354,7 +354,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("0.0000 GiB");
             var exp = "0,1150 GiB";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -365,7 +365,7 @@ public class StreamSizeTest
         {
             var act = StreamSize.PB.ToString("tb");
             var exp = "1000tb";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -376,7 +376,7 @@ public class StreamSizeTest
         {
             var act = StreamSize.TB.ToString(" petabyte");
             var exp = "0,001 petabyte";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -387,7 +387,7 @@ public class StreamSizeTest
         {
             var act = StreamSize.MaxValue.ToString("#,##0.## Exabyte");
             var exp = "9,22 Exabyte";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -398,7 +398,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("#,##0.## F");
             var exp = "123,46 Megabyte";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
     [Test]
@@ -408,7 +408,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("0 f");
             var exp = "123 megabyte";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -419,7 +419,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("0000 S");
             var exp = "0123 MB";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
     [Test]
@@ -429,7 +429,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("0 s");
             var exp = "123 mb";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
     [Test]
@@ -439,7 +439,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("0s");
             var exp = "123mb";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -450,7 +450,7 @@ public class StreamSizeTest
         {
             var act = TestStruct.ToString("0.0 si");
             var exp = "117,7 mib";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -461,7 +461,7 @@ public class StreamSizeTest
         {
             var act = StreamSize.Parse("1600,1").ToString();
             var exp = "1600 byte";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -472,7 +472,7 @@ public class StreamSizeTest
         {
             var act = StreamSize.Parse("1600.1").ToString();
             var exp = "1600 byte";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -483,7 +483,7 @@ public class StreamSizeTest
         {
             var act = StreamSize.Parse("800").ToString("0000 byte");
             var exp = "0800 byte";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -494,7 +494,7 @@ public class StreamSizeTest
         {
             var act = StreamSize.Parse("800").ToString("0000");
             var exp = "0800";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -503,7 +503,7 @@ public class StreamSizeTest
     {
         var act = StreamSize.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
         var exp = "01700,0";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -564,7 +564,7 @@ public class StreamSizeTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -635,7 +635,7 @@ public class StreamSizeTest
         StreamSize exp = TestStruct;
         StreamSize act = 123456789;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_StreamSizeToInt32_AreEqual()
@@ -643,7 +643,7 @@ public class StreamSizeTest
         var exp = 123456789;
         var act = (int)TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -652,7 +652,7 @@ public class StreamSizeTest
         var exp = TestStruct;
         StreamSize act = 123456789L;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_StreamSizeToInt64_AreEqual()
@@ -660,7 +660,7 @@ public class StreamSizeTest
         var exp = 123456789L;
         var act = (long)TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -669,7 +669,7 @@ public class StreamSizeTest
         var exp = TestStruct;
         var act = (StreamSize)123456789d;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_StreamSizeToDouble_AreEqual()
@@ -677,7 +677,7 @@ public class StreamSizeTest
         var exp = 123456789d;
         var act = (double)TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -686,7 +686,7 @@ public class StreamSizeTest
         var exp = TestStruct;
         var act = (StreamSize)123456789m;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_StreamSizeToDecimal_AreEqual()
@@ -694,7 +694,7 @@ public class StreamSizeTest
         var exp = 123456789m;
         var act = (decimal)TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
 
@@ -706,7 +706,7 @@ public class StreamSizeTest
     public void Sign(int expected, StreamSize size)
     {
         var actual = size.Sign();
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [TestCase(1234, -1234)]
@@ -714,7 +714,7 @@ public class StreamSizeTest
     public void Abs(StreamSize expected, StreamSize value)
     {
         var abs = value.Abs();
-        Assert.AreEqual(expected, abs);
+        abs.Should().Be(expected);
     }
 
     [Test]
@@ -724,7 +724,7 @@ public class StreamSizeTest
         StreamSize exp = 22;
         act++;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Decrement_21_20()
@@ -733,7 +733,7 @@ public class StreamSizeTest
         StreamSize exp = 20;
         act--;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -742,7 +742,7 @@ public class StreamSizeTest
         StreamSize act = +((StreamSize)21);
         StreamSize exp = 21;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Negate_21_Minus21()
@@ -750,7 +750,7 @@ public class StreamSizeTest
         StreamSize act = -((StreamSize)21);
         StreamSize exp = -21;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -760,7 +760,7 @@ public class StreamSizeTest
         StreamSize exp = 18;
         act += Percentage.Create(0.1);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Addition_17And5_24()
@@ -769,7 +769,7 @@ public class StreamSizeTest
         StreamSize exp = 24;
         act += (StreamSize)7;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -779,7 +779,7 @@ public class StreamSizeTest
         StreamSize exp = 16;
         act -= Percentage.Create(0.1);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Subtraction_17And5_12()
@@ -788,7 +788,7 @@ public class StreamSizeTest
         StreamSize exp = 12;
         act -= (StreamSize)5;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -798,7 +798,7 @@ public class StreamSizeTest
         StreamSize exp = 40;
         act /= (short)2;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Division_81And2Int32_40()
@@ -807,7 +807,7 @@ public class StreamSizeTest
         StreamSize exp = 40;
         act /= 2;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -817,7 +817,7 @@ public class StreamSizeTest
         StreamSize exp = 40;
         act /= (long)2;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Division_81And2UInt16_40()
@@ -826,7 +826,7 @@ public class StreamSizeTest
         StreamSize exp = 40;
         act /= (ushort)2;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Division_81And2UInt32_40()
@@ -835,7 +835,7 @@ public class StreamSizeTest
         StreamSize exp = 40;
         act /= (uint)2;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Division_81And2UInt64_40()
@@ -844,7 +844,7 @@ public class StreamSizeTest
         StreamSize exp = 40;
         act /= (ulong)2;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Division_81And150Percentage_54()
@@ -853,7 +853,7 @@ public class StreamSizeTest
         StreamSize exp = 54;
         act /= (Percentage)1.50;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Division_81And1Point5Single_54()
@@ -862,7 +862,7 @@ public class StreamSizeTest
         StreamSize exp = 54;
         act /= (float)1.5;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Division_81And1Point5Double_54()
@@ -871,7 +871,7 @@ public class StreamSizeTest
         StreamSize exp = 54;
         act /= 1.5;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Division_81And1Point5Decimal_54()
@@ -880,7 +880,7 @@ public class StreamSizeTest
         StreamSize exp = 54;
         act /= 1.5d;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -890,7 +890,7 @@ public class StreamSizeTest
         StreamSize exp = 126;
         act *= (short)3;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Multiply_42And3Int32_126()
@@ -899,7 +899,7 @@ public class StreamSizeTest
         StreamSize exp = 126;
         act *= 3;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Multiply_42And3Int64_126()
@@ -908,7 +908,7 @@ public class StreamSizeTest
         StreamSize exp = 126;
         act *= (long)3;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Multiply_42And3UInt16_126()
@@ -917,7 +917,7 @@ public class StreamSizeTest
         StreamSize exp = 126;
         act *= (ushort)3;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Multiply_42And3UInt32_126()
@@ -926,7 +926,7 @@ public class StreamSizeTest
         StreamSize exp = 126;
         act *= (uint)3;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Multiply_42And3UInt64_126()
@@ -935,7 +935,7 @@ public class StreamSizeTest
         StreamSize exp = 126;
         act *= (ulong)3;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Multiply_42And50Percentage_21()
@@ -944,7 +944,7 @@ public class StreamSizeTest
         StreamSize exp = 21;
         act *= 50.Percent();
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Multiply_42AndHalfSingle_21()
@@ -953,7 +953,7 @@ public class StreamSizeTest
         StreamSize exp = 21;
         act *= (float)0.5;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Multiply_42AndHalfDouble_21()
@@ -962,7 +962,7 @@ public class StreamSizeTest
         StreamSize exp = 21;
         act *= 0.5;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Multiply_42AndHalfDecimal_21()
@@ -971,7 +971,7 @@ public class StreamSizeTest
         StreamSize exp = 21;
         act *= 0.5d;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #region Extension tests
@@ -984,7 +984,7 @@ public class StreamSizeTest
         StreamSize act = stream.GetStreamSize();
         StreamSize exp = 17;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -1001,7 +1001,7 @@ public class StreamSizeTest
         StreamSize act = file.GetStreamSize();
         StreamSize exp = 9;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -1012,7 +1012,7 @@ public class StreamSizeTest
         StreamSize act = arr.Average();
         StreamSize exp = 5;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Sum_ArrayOfStreamSizes_45Byte()
@@ -1022,7 +1022,7 @@ public class StreamSizeTest
         StreamSize act = arr.Sum();
         StreamSize exp = 45;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdCastTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdCastTest.cs
@@ -27,21 +27,21 @@ public class IdCastTest
     public void Create_StringForInt64_Throws()
     {
         var x = Assert.Catch<InvalidCastException>(() => Id<ForInt64>.Create("NaN"));
-        Assert.AreEqual("Cast from string to Qowaiv.Identifiers.Id<Qowaiv.UnitTests.Identifiers.ForInt64> is not valid.", x.Message);
+        x.Message.Should().Be("Cast from string to Qowaiv.Identifiers.Id<Qowaiv.UnitTests.Identifiers.ForInt64> is not valid.");
     }
 
     [Test]
     public void Create_Int64ForGuid_Throws()
     {
         var x = Assert.Catch<InvalidCastException>(() => Id<ForGuid>.Create(13245L));
-        Assert.AreEqual("Cast from long to Qowaiv.Identifiers.Id<Qowaiv.UnitTests.Identifiers.ForGuid> is not valid.", x.Message);
+        x.Message.Should().Be("Cast from long to Qowaiv.Identifiers.Id<Qowaiv.UnitTests.Identifiers.ForGuid> is not valid.");
     }
 
     [Test]
     public void FromJson_NegativeValue_Throws()
     {
         var x = Assert.Catch<InvalidCastException>(() => Id<ForInt64>.FromJson(-1));
-        Assert.AreEqual("Cast from long to Qowaiv.Identifiers.Id<Qowaiv.UnitTests.Identifiers.ForInt64> is not valid.", x.Message);
+        x.Message.Should().Be("Cast from long to Qowaiv.Identifiers.Id<Qowaiv.UnitTests.Identifiers.ForInt64> is not valid.");
     }
 
     [Test]
@@ -50,7 +50,7 @@ public class IdCastTest
         var guid = Guid.Parse("AD38ECD4-020F-475C-9318-DFF2067DA1D4");
         var casted = (Id<ForGuid>)guid;
         var expected = Id<ForGuid>.Parse("AD38ECD4-020F-475C-9318-DFF2067DA1D4");
-        Assert.AreEqual(expected, casted);
+        casted.Should().Be(expected);
     }
 
     [Test]
@@ -59,7 +59,7 @@ public class IdCastTest
         var guid = Guid.Parse("AD38ECD4-020F-475C-9318-DFF2067DA1D4");
         var casted = (Id<ForString>)guid;
         var expected = Id<ForString>.Parse("ad38ecd4-020f-475c-9318-dff2067da1d4");
-        Assert.AreEqual(expected, casted);
+        casted.Should().Be(expected);
     }
 
     [Test]
@@ -68,7 +68,7 @@ public class IdCastTest
         var number = 12345L;
         var casted = (Id<ForInt64>)number;
         var expected = Id<ForInt64>.Create(12345L);
-        Assert.AreEqual(expected, casted);
+        casted.Should().Be(expected);
     }
 
     [Test]
@@ -77,7 +77,7 @@ public class IdCastTest
         var number = "12345";
         var casted = (Id<ForInt64>)number;
         var expected = Id<ForInt64>.Create(12345L);
-        Assert.AreEqual(expected, casted);
+        casted.Should().Be(expected);
     }
 
     [Test]
@@ -86,7 +86,7 @@ public class IdCastTest
         var number = 12345L;
         var casted = (Id<ForString>)number;
         var expected = Id<ForString>.Parse("12345");
-        Assert.AreEqual(expected, casted);
+        casted.Should().Be(expected);
     }
 
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
@@ -48,7 +48,7 @@ public class IdForGuidTest
     public void ToByteArray_Empty_EmptyArray()
     {
         var bytes = Id<ForGuid>.Empty.ToByteArray();
-        bytes.Should().BeEquivalentTo(Array.Empty<byte>());
+        bytes.Should().BeEmpty();
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
@@ -421,10 +421,8 @@ public class IdForGuidTest
 
     [Test]
     public void Next_100Items_AllUnique()
-    {
-        var nexts = Enumerable.Range(0, 100).Select(i => Id<ForGuid>.Next()).ToArray();
-        CollectionAssert.AllItemsAreUnique(nexts);
-    }
+        => Enumerable.Range(0, 100).Select(i => Id<ForGuid>.Next())
+        .ToHashSet().Should().HaveCount(100);
 
     [TestCase(null)]
     [TestCase("")]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
@@ -13,7 +13,7 @@ public class IdForGuidTest
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Id<ForGuid>), Id<ForGuid>.Empty);
+        Id<ForGuid>.Empty.Should().Be(default(Id<ForGuid>));
     }
 
     /// <summary>Id<ForGuid>.IsEmpty() should be true for the default of identifier.</summary>
@@ -34,21 +34,21 @@ public class IdForGuidTest
     public void FromBytes_Null_IsEmpty()
     {
         var fromBytes = Id<ForGuid>.FromBytes(null);
-        Assert.AreEqual(Id<ForGuid>.Empty, fromBytes);
+        fromBytes.Should().Be(Id<ForGuid>.Empty);
     }
 
     [Test]
     public void FromBytes_Bytes_IsTestStruct()
     {
         var fromBytes = Id<ForGuid>.FromBytes([171, 181, 90, 15, 203, 18, 41, 70, 135, 141, 177, 139, 136, 185, 165, 4]);
-        Assert.AreEqual(TestStruct, fromBytes);
+        fromBytes.Should().Be(TestStruct);
     }
 
     [Test]
     public void ToByteArray_Empty_EmptyArray()
     {
         var bytes = Id<ForGuid>.Empty.ToByteArray();
-        Assert.AreEqual(Array.Empty<byte>(), bytes);
+        bytes.Should().BeEquivalentTo(Array.Empty<byte>());
     }
 
     [Test]
@@ -56,7 +56,7 @@ public class IdForGuidTest
     {
         var bytes = TestStruct.ToByteArray();
         var exepected = new byte[] { 171, 181, 90, 15, 203, 18, 41, 70, 135, 141, 177, 139, 136, 185, 165, 4 };
-        Assert.AreEqual(exepected, bytes);
+        bytes.Should().BeEquivalentTo(exepected);
     }
 
     /// <summary>TryParse null should be valid.</summary>
@@ -64,7 +64,7 @@ public class IdForGuidTest
     public void TryParse_Null_IsValid()
     {
         Id<ForGuid>.TryParse(null, out var val).Should().BeTrue();
-        Assert.AreEqual(default(Id<ForGuid>), val);
+        val.Should().Be(default(Id<ForGuid>));
     }
 
     /// <summary>TryParse string.Empty should be valid.</summary>
@@ -72,7 +72,7 @@ public class IdForGuidTest
     public void TryParse_StringEmpty_IsValid()
     {
         Id<ForGuid>.TryParse(string.Empty, out var val).Should().BeTrue();
-        Assert.AreEqual(default(Id<ForGuid>), val);
+        val.Should().Be(default(Id<ForGuid>));
     }
 
     /// <summary>TryParse with specified string value should be valid.</summary>
@@ -81,7 +81,7 @@ public class IdForGuidTest
     {
         string str = "0f5ab5ab-12cb-4629-878d-b18b88b9a504";
         Id<ForGuid>.TryParse(str, out var val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString());
+        val.ToString().Should().Be(str);
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -90,7 +90,7 @@ public class IdForGuidTest
     {
         string str = "0F5AB5AB-12CB-4629-878D";
         Id<ForGuid>.TryParse(str, out var val).Should().BeFalse();
-        Assert.AreEqual(default(Id<ForGuid>), val);
+        val.Should().Be(default(Id<ForGuid>));
     }
 
     [Test]
@@ -114,7 +114,7 @@ public class IdForGuidTest
         {
             var exp = TestStruct;
             var act = Id<ForGuid>.TryParse(exp.ToString());
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -125,7 +125,7 @@ public class IdForGuidTest
         {
             var exp = default(Id<ForGuid>);
             var act = Id<ForGuid>.TryParse("InvalidInput");
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -148,7 +148,7 @@ public class IdForGuidTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -156,14 +156,14 @@ public class IdForGuidTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "0f5ab5ab-12cb-4629-878d-b18b88b9a504";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Id<ForGuid>>("0F5AB5AB-12CB-4629-878D-B18B88B9A504");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -313,7 +313,7 @@ public class IdForGuidTest
     public void FromJson(Id<ForGuid> expected, object json)
     {
         var actual = JsonTester.Read<Id<ForGuid>>(json);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -328,7 +328,7 @@ public class IdForGuidTest
     {
         var act = Id<ForGuid>.Empty.ToString();
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -336,14 +336,14 @@ public class IdForGuidTest
     {
         var act = TestStruct.ToString("S", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: 'q7VaD8sSKUaHjbGLiLmlBA', format: 'S'";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>GetHash should not fail for Id<ForGuid>.Empty.</summary>
     [Test]
     public void GetHash_Empty_Hash()
     {
-        Assert.AreEqual(0, Id<ForGuid>.Empty.GetHashCode());
+        Id<ForGuid>.Empty.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForGuidTest.cs
@@ -350,7 +350,7 @@ public class IdForGuidTest
     [Test]
     public void GetHash_TestStruct_Hash()
     {
-        Assert.AreNotEqual(0, TestStruct.GetHashCode());
+        TestStruct.GetHashCode().Should().NotBe(0);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
@@ -13,7 +13,7 @@ public class IdForInt32Test
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Id<ForInt32>), Id<ForInt32>.Empty);
+        Id<ForInt32>.Empty.Should().Be(default(Id<ForInt32>));
     }
 
     /// <summary>Id<ForInt32>.IsEmpty() should be true for the default of identifier.</summary>
@@ -34,21 +34,21 @@ public class IdForInt32Test
     public void FromBytes_Null_IsEmpty()
     {
         var fromBytes = Id<ForInt32>.FromBytes(null);
-        Assert.AreEqual(Id<ForInt32>.Empty, fromBytes);
+        fromBytes.Should().Be(Id<ForInt32>.Empty);
     }
 
     [Test]
     public void FromBytes_Bytes_IsTestStruct()
     {
         var fromBytes = Id<ForInt32>.FromBytes([21, 205, 91, 7]);
-        Assert.AreEqual(TestStruct, fromBytes);
+        fromBytes.Should().Be(TestStruct);
     }
 
     [Test]
     public void ToByteArray_Empty_EmptyArray()
     {
         var bytes = Id<ForInt32>.Empty.ToByteArray();
-        Assert.AreEqual(Array.Empty<byte>(), bytes);
+        bytes.Should().BeEmpty();
     }
 
     [Test]
@@ -56,7 +56,7 @@ public class IdForInt32Test
     {
         var bytes = TestStruct.ToByteArray();
         var exepected = new byte[] { 21, 205, 91, 7 };
-        Assert.AreEqual(exepected, bytes);
+        bytes.Should().BeEquivalentTo(exepected);
     }
 
     /// <summary>TryParse null should be valid.</summary>
@@ -64,7 +64,7 @@ public class IdForInt32Test
     public void TryParse_Null_IsValid()
     {
         Id<ForInt32>.TryParse(null, out var val).Should().BeTrue();
-        Assert.AreEqual(default(Id<ForInt32>), val);
+        val.Should().Be(default(Id<ForInt32>));
     }
 
     /// <summary>TryParse string.Empty should be valid.</summary>
@@ -72,7 +72,7 @@ public class IdForInt32Test
     public void TryParse_StringEmpty_IsValid()
     {
         Id<ForInt32>.TryParse(string.Empty, out var val).Should().BeTrue();
-        Assert.AreEqual(default(Id<ForInt32>), val);
+        val.Should().Be(default(Id<ForInt32>));
     }
 
     /// <summary>TryParse with specified string value should be valid.</summary>
@@ -81,7 +81,7 @@ public class IdForInt32Test
     {
         string str = "123456789";
         Id<ForInt32>.TryParse(str, out var val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString());
+        val.ToString().Should().Be(str);
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -90,7 +90,7 @@ public class IdForInt32Test
     {
         string str = "ABC";
         Id<ForInt32>.TryParse(str, out var val).Should().BeFalse();
-        Assert.AreEqual(default(Id<ForInt32>), val);
+        val.Should().Be(default(Id<ForInt32>));
     }
 
     [Test]
@@ -114,7 +114,7 @@ public class IdForInt32Test
         {
             var exp = TestStruct;
             var act = Id<ForInt32>.TryParse(exp.ToString());
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -125,7 +125,7 @@ public class IdForInt32Test
         {
             var exp = default(Id<ForInt32>);
             var act = Id<ForInt32>.TryParse("InvalidInput");
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -133,7 +133,7 @@ public class IdForInt32Test
     public void TryCreate_Int_Successful()
     {
         Id<ForInt32>.TryCreate(13, out var id).Should().BeTrue();
-        Assert.AreEqual(Id<ForInt32>.Parse("13"), id);
+        id.Should().Be(Id<ForInt32>.Parse("13"));
     }
 
     [Test]
@@ -142,7 +142,7 @@ public class IdForInt32Test
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -150,14 +150,14 @@ public class IdForInt32Test
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "123456789";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Id<ForInt32>>("123456789");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -305,7 +305,7 @@ public class IdForInt32Test
     {
         var act = Id<ForInt32>.Empty.ToString(CultureInfo.InvariantCulture);
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -313,14 +313,14 @@ public class IdForInt32Test
     {
         var act = TestStruct.ToString("#,##0.0", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '123,456,789.0', format: '#,##0.0'";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>GetHash should not fail for Id<ForInt32>.Empty.</summary>
     [Test]
     public void GetHash_Empty_Hash()
     {
-        Assert.AreEqual(0, Id<ForInt32>.Empty.GetHashCode());
+        Id<ForInt32>.Empty.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt32Test.cs
@@ -327,7 +327,7 @@ public class IdForInt32Test
     [Test]
     public void GetHash_TestStruct_Hash()
     {
-        Assert.AreNotEqual(0, TestStruct.GetHashCode());
+        TestStruct.GetHashCode().Should().NotBe(0);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
@@ -333,7 +333,7 @@ public class IdForInt64Test
     [Test]
     public void GetHash_TestStruct_Hash()
     {
-        Assert.AreNotEqual(0, TestStruct.GetHashCode());
+        TestStruct.GetHashCode().Should().NotBe(0);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForInt64Test.cs
@@ -13,7 +13,7 @@ public class IdForInt64Test
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Id<ForInt64>), Id<ForInt64>.Empty);
+        Id<ForInt64>.Empty.Should().Be(default(Id<ForInt64>));
     }
 
     /// <summary>Id<ForInt64>.IsEmpty() should be true for the default of identifier.</summary>
@@ -34,21 +34,21 @@ public class IdForInt64Test
     public void FromBytes_Null_IsEmpty()
     {
         var fromBytes = Id<ForInt64>.FromBytes(null);
-        Assert.AreEqual(Id<ForInt64>.Empty, fromBytes);
+        fromBytes.Should().Be(Id<ForInt64>.Empty);
     }
 
     [Test]
     public void FromBytes_Bytes_IsTestStruct()
     {
         var fromBytes = Id<ForInt64>.FromBytes([21, 205, 91, 7, 0, 0, 0, 0]);
-        Assert.AreEqual(TestStruct, fromBytes);
+        fromBytes.Should().Be(TestStruct);
     }
 
     [Test]
     public void ToByteArray_Empty_EmptyArray()
     {
         var bytes = Id<ForInt64>.Empty.ToByteArray();
-        Assert.AreEqual(Array.Empty<byte>(), bytes);
+        bytes.Should().BeEmpty();
     }
 
     [Test]
@@ -56,7 +56,7 @@ public class IdForInt64Test
     {
         var bytes = TestStruct.ToByteArray();
         var exepected = new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
-        Assert.AreEqual(exepected, bytes);
+        bytes.Should().BeEquivalentTo(exepected);
     }
 
     /// <summary>TryParse null should be valid.</summary>
@@ -64,7 +64,7 @@ public class IdForInt64Test
     public void TryParse_Null_IsValid()
     {
         Id<ForInt64>.TryParse(null, out var val).Should().BeTrue();
-        Assert.AreEqual(default(Id<ForInt64>), val);
+        val.Should().Be(default(Id<ForInt64>));
     }
 
     /// <summary>TryParse string.Empty should be valid.</summary>
@@ -72,7 +72,7 @@ public class IdForInt64Test
     public void TryParse_StringEmpty_IsValid()
     {
         Id<ForInt64>.TryParse(string.Empty, out var val).Should().BeTrue();
-        Assert.AreEqual(default(Id<ForInt64>), val);
+        val.Should().Be(default(Id<ForInt64>));
     }
 
     /// <summary>TryParse with specified string value should be valid.</summary>
@@ -81,7 +81,7 @@ public class IdForInt64Test
     {
         string str = "123456789";
         Id<ForInt64>.TryParse(str, out var val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString());
+        val.ToString().Should().Be(str);
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -90,14 +90,14 @@ public class IdForInt64Test
     {
         string str = "ABC";
         Id<ForInt64>.TryParse(str, out var val).Should().BeFalse();
-        Assert.AreEqual(default(Id<ForInt64>), val);
+        val.Should().Be(default(Id<ForInt64>));
     }
 
     [Test]
     public void TryCreate_Int_Successful()
     {
         Id<ForInt64>.TryCreate(13L, out var id).Should().BeTrue();
-        Assert.AreEqual(Id<ForInt64>.Parse("13"), id);
+        id.Should().Be(Id<ForInt64>.Parse("13"));
     }
 
     [Test]
@@ -121,7 +121,7 @@ public class IdForInt64Test
         {
             var exp = TestStruct;
             var act = Id<ForInt64>.TryParse(exp.ToString());
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -132,7 +132,7 @@ public class IdForInt64Test
         {
             var exp = default(Id<ForInt64>);
             var act = Id<ForInt64>.TryParse("InvalidInput");
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -142,7 +142,7 @@ public class IdForInt64Test
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -150,14 +150,14 @@ public class IdForInt64Test
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "123456789";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Id<ForInt64>>("123456789");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -311,7 +311,7 @@ public class IdForInt64Test
     {
         var act = Id<ForInt64>.Empty.ToString(CultureInfo.InvariantCulture);
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -319,14 +319,14 @@ public class IdForInt64Test
     {
         var act = TestStruct.ToString("#,##0.0", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '123,456,789.0', format: '#,##0.0'";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>GetHash should not fail for Id<ForInt64>.Empty.</summary>
     [Test]
     public void GetHash_Empty_Hash()
     {
-        Assert.AreEqual(0, Id<ForInt64>.Empty.GetHashCode());
+        Id<ForInt64>.Empty.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
@@ -294,7 +294,7 @@ public class IdForStringTest
     [Test]
     public void GetHash_TestStruct_Hash()
     {
-        Assert.AreNotEqual(0, TestStruct.GetHashCode());
+        TestStruct.GetHashCode().Should().NotBe(0);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Identifiers/IdForStringTest.cs
@@ -13,7 +13,7 @@ public class IdForStringTest
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Id<ForString>), Id<ForString>.Empty);
+        Id<ForString>.Empty.Should().Be(default(Id<ForString>));
     }
 
     /// <summary>Id<ForString>.IsEmpty() should be true for the default of identifier.</summary>
@@ -34,21 +34,21 @@ public class IdForStringTest
     public void FromBytes_Null_IsEmpty()
     {
         var fromBytes = Id<ForString>.FromBytes(null);
-        Assert.AreEqual(Id<ForString>.Empty, fromBytes);
+        fromBytes.Should().Be(Id<ForString>.Empty);
     }
 
     [Test]
     public void FromBytes_Bytes_IsTestStruct()
     {
         var fromBytes = Id<ForString>.FromBytes([81, 111, 119, 97, 105, 118, 45, 73, 68]);
-        Assert.AreEqual(TestStruct, fromBytes);
+        fromBytes.Should().Be(TestStruct);
     }
 
     [Test]
     public void ToByteArray_Empty_EmptyArray()
     {
         var bytes = Id<ForString>.Empty.ToByteArray();
-        Assert.AreEqual(Array.Empty<byte>(), bytes);
+        bytes.Should().BeEmpty();
     }
 
     [Test]
@@ -56,7 +56,7 @@ public class IdForStringTest
     {
         var bytes = TestStruct.ToByteArray();
         var exepected = "Qowaiv-ID"u8.ToArray();
-        Assert.AreEqual(exepected, bytes);
+        bytes.Should().BeEquivalentTo(exepected);
     }
 
     /// <summary>TryParse null should be valid.</summary>
@@ -64,7 +64,7 @@ public class IdForStringTest
     public void TryParse_Null_IsValid()
     {
         Id<ForString>.TryParse(null, out var val).Should().BeTrue();
-        Assert.AreEqual(default(Id<ForString>), val);
+        val.Should().Be(default(Id<ForString>));
     }
 
     /// <summary>TryParse string.Empty should be valid.</summary>
@@ -72,7 +72,7 @@ public class IdForStringTest
     public void TryParse_StringEmpty_IsValid()
     {
         Id<ForString>.TryParse(string.Empty, out var val).Should().BeTrue();
-        Assert.AreEqual(default(Id<ForString>), val);
+        val.Should().Be(default(Id<ForString>));
     }
 
     /// <summary>TryParse with specified string value should be valid.</summary>
@@ -81,7 +81,7 @@ public class IdForStringTest
     {
         string str = "0f5ab5ab-12cb-4629-878d-b18b88b9a504";
         Id<ForString>.TryParse(str, out var val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString());
+        val.ToString().Should().Be(str);
     }
 
     [Test]
@@ -91,7 +91,7 @@ public class IdForStringTest
         {
             var exp = TestStruct;
             var act = Id<ForString>.TryParse(exp.ToString());
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -101,7 +101,7 @@ public class IdForStringTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -109,14 +109,14 @@ public class IdForStringTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "Qowaiv-ID";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Id<ForString>>("Qowaiv-ID");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -264,7 +264,7 @@ public class IdForStringTest
     public void FromJson(Id<ForString> expected, object json)
     {
         var actual = JsonTester.Read<Id<ForString>>(json);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -272,7 +272,7 @@ public class IdForStringTest
     {
         var act = Id<ForString>.Empty.ToString();
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -280,14 +280,14 @@ public class IdForStringTest
     {
         var act = TestStruct.ToString("S", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: 'Qowaiv-ID', format: 'S'";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>GetHash should not fail for Id<ForString>.Empty.</summary>
     [Test]
     public void GetHash_Empty_Hash()
     {
-        Assert.AreEqual(0, Id<ForString>.Empty.GetHashCode());
+        Id<ForString>.Empty.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
@@ -15,7 +15,7 @@ public class LocalDateTimeTest
     [Test]
     public void MinValue_None_EqualsDefault()
     {
-        Assert.AreEqual(default(LocalDateTime), LocalDateTime.MinValue);
+        LocalDateTime.MinValue.Should().Be(default(LocalDateTime));
     }
 
     #endregion
@@ -56,7 +56,7 @@ public class LocalDateTimeTest
             var exp = TestStructNoMilliseconds;
             var act = LocalDateTime.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -88,7 +88,7 @@ public class LocalDateTimeTest
         var input = LocalDateTimeTest.TestStructNoMilliseconds;
         var exp = LocalDateTimeTest.TestStructNoMilliseconds;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -98,7 +98,7 @@ public class LocalDateTimeTest
         var input = LocalDateTimeTest.TestStructNoMilliseconds;
         var exp = LocalDateTimeTest.TestStructNoMilliseconds;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -106,14 +106,14 @@ public class LocalDateTimeTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "1988-06-13 22:10:05.001";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<LocalDateTime>("1988-06-13 22:10:05.001");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -220,7 +220,7 @@ public class LocalDateTimeTest
         var act = TestStruct.ToString("M:d & h:m", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '6:13 & 10:10', format: 'M:d & h:m'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -228,7 +228,7 @@ public class LocalDateTimeTest
     {
         var act = TestStruct.ToString(@"yyyy-MM-dd\THH:mm:ss.FFFFFFF");
         var exp = "1988-06-13T22:10:05.001";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -292,7 +292,7 @@ public class LocalDateTimeTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -313,7 +313,7 @@ public class LocalDateTimeTest
         var act = TestStruct;
         act++;
         var exp = new LocalDateTime(1988, 06, 14, 22, 10, 05, 001);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Decrement_None_AreEqual()
@@ -321,7 +321,7 @@ public class LocalDateTimeTest
         var act = TestStruct;
         act--;
         var exp = new LocalDateTime(1988, 06, 12, 22, 10, 05, 001);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -329,14 +329,14 @@ public class LocalDateTimeTest
     {
         var act = TestStruct + new TimeSpan(25, 30, 15);
         var exp = new LocalDateTime(1988, 06, 14, 23, 40, 20, 001);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Min_TimeSpan_AreEqual()
     {
         var act = TestStruct - new TimeSpan(25, 30, 15);
         var exp = new LocalDateTime(1988, 06, 12, 20, 39, 50, 001);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -344,7 +344,7 @@ public class LocalDateTimeTest
     {
         var act = TestStruct - new LocalDateTime(1988, 06, 11, 20, 10, 05);
         var exp = new TimeSpan(2, 02, 00, 00, 001);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -353,7 +353,7 @@ public class LocalDateTimeTest
         var act = TestStruct.AddTicks(4000001700000L);
         var exp = new LocalDateTime(1988, 06, 18, 13, 16, 45, 171);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -362,7 +362,7 @@ public class LocalDateTimeTest
         var act = TestStruct.AddMilliseconds(3 * 24 * 60 * 60 * 1003);
         var exp = new LocalDateTime(1988, 06, 16, 22, 23, 02, 601);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void AddSeconds_around3Days_AreEqual()
@@ -370,7 +370,7 @@ public class LocalDateTimeTest
         var act = TestStruct.AddSeconds(3 * 24 * 60 * 64);
         var exp = new LocalDateTime(1988, 06, 17, 02, 58, 05, 001);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void AddMinutes_2280_AreEqual()
@@ -378,7 +378,7 @@ public class LocalDateTimeTest
         var act = TestStruct.AddMinutes(2 * 24 * 60);
         var exp = new LocalDateTime(1988, 06, 15, 22, 10, 05, 001);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -387,7 +387,7 @@ public class LocalDateTimeTest
         var act = TestStruct.AddHours(41);
         var exp = new LocalDateTime(1988, 06, 15, 15, 10, 05, 001);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -396,7 +396,7 @@ public class LocalDateTimeTest
         var act = TestStruct.AddMonths(12);
         var exp = new LocalDateTime(1989, 06, 13, 22, 10, 05, 001);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -405,7 +405,7 @@ public class LocalDateTimeTest
         var act = TestStruct + MonthSpan.FromYears(1);
         var exp = new LocalDateTime(1989, 06, 13, 22, 10, 05, 001);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -414,7 +414,7 @@ public class LocalDateTimeTest
         var act = TestStruct - MonthSpan.FromMonths(1);
         var exp = new LocalDateTime(1988, 05, 13, 22, 10, 05, 001);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -423,7 +423,7 @@ public class LocalDateTimeTest
         var act = TestStruct.AddYears(-12);
         var exp = new LocalDateTime(1976, 06, 13, 22, 10, 05, 001);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/LocalDateTimeTest.cs
@@ -264,7 +264,7 @@ public class LocalDateTimeTest
         var exp = new List<LocalDateTime> { LocalDateTime.MinValue, LocalDateTime.MinValue, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of local date times descending.</summary>
@@ -280,7 +280,7 @@ public class LocalDateTimeTest
         var exp = new List<LocalDateTime> { item3, item2, item1, item0, LocalDateTime.MinValue, LocalDateTime.MinValue };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionOperationsTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionOperationsTest.cs
@@ -38,7 +38,7 @@ public class FractionOperationsTest
     [TestCase("-2/3", "-3/2")]
     public void Inverse(Fraction faction, Fraction expected)
     {
-        Assert.AreEqual(expected, faction.Inverse());
+        faction.Inverse().Should().Be(expected);
     }
 
     [Test]
@@ -54,7 +54,7 @@ public class FractionOperationsTest
         var fraction = 19.DividedBy(72);
         var actual = fraction * 48L;
         var expected = 38.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -63,7 +63,7 @@ public class FractionOperationsTest
         var fraction = 19.DividedBy(72);
         var actual = fraction * 48;
         var expected = 38.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [TestCase("1/3", "1/4", "1/12")]
@@ -90,7 +90,7 @@ public class FractionOperationsTest
         var fraction = 19.DividedBy(72);
         var actual = fraction / 48L;
         var expected = 19.DividedBy(3456);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -99,7 +99,7 @@ public class FractionOperationsTest
         var fraction = 19.DividedBy(72);
         var actual = fraction / 48;
         var expected = 19.DividedBy(3456);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [TestCase("1/3", "1/4", "4/3")]
@@ -130,7 +130,7 @@ public class FractionOperationsTest
         var actual = l + r;
         var expected = 3.DividedBy(8_000_000_000L);
 
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -139,7 +139,7 @@ public class FractionOperationsTest
         var fraction = 1.DividedBy(3);
         var actual = fraction + 2L;
         var expected = 7.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -148,7 +148,7 @@ public class FractionOperationsTest
         var fraction = 1.DividedBy(3);
         var actual = 2L + fraction;
         var expected = 7.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -157,7 +157,7 @@ public class FractionOperationsTest
         var fraction = 1.DividedBy(3);
         var actual = fraction + 2;
         var expected = 7.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -166,7 +166,7 @@ public class FractionOperationsTest
         var fraction = 1.DividedBy(3);
         var actual = 2 + fraction;
         var expected = 7.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [TestCase("1/4", "0", "1/4")]
@@ -195,7 +195,7 @@ public class FractionOperationsTest
         var fraction = 1.DividedBy(3);
         var actual = fraction - 2L;
         var expected = -5.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -204,7 +204,7 @@ public class FractionOperationsTest
         var fraction = 1.DividedBy(3);
         var actual = 2L - fraction;
         var expected = 5.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -213,7 +213,7 @@ public class FractionOperationsTest
         var fraction = 1.DividedBy(3);
         var actual = fraction - 2;
         var expected = -5.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -222,7 +222,7 @@ public class FractionOperationsTest
         var fraction = 1.DividedBy(3);
         var actual = 2 - fraction;
         var expected = 5.DividedBy(3);
-        Assert.AreEqual(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [TestCase("1/4", "0", "1/4")]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Mathematics/FractionTest.cs
@@ -10,7 +10,7 @@ public class FractionTest
     [Test]
     public void Zero_None_EqualsDefault()
     {
-        Assert.AreEqual(default(Fraction), Fraction.Zero);
+        Fraction.Zero.Should().Be(default(Fraction));
     }
 
     /// <summary>Fraction.IsZero() should be true for the default of fraction.</summary>
@@ -47,7 +47,7 @@ public class FractionTest
         {
             var exp = TestStruct;
             var act = Fraction.TryParse(exp.ToString());
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -78,7 +78,7 @@ public class FractionTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -88,7 +88,7 @@ public class FractionTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -96,14 +96,14 @@ public class FractionTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "-69/17";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Fraction>("-69/17");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -181,7 +181,7 @@ public class FractionTest
     {
         var act = Fraction.Zero.ToString();
         var exp = "0/1";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -189,7 +189,7 @@ public class FractionTest
     {
         var act = TestStruct.ToString("[0] 0/000", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '-4 1/017', format: '[0] 0/000'";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [TestCase("-2:7", "-2/7", "0:0")]
@@ -210,21 +210,21 @@ public class FractionTest
     public void ToString_WithFormat(string expected, Fraction fraction, string format)
     {
         var formatted = fraction.ToString(format, CultureInfo.InvariantCulture);
-        Assert.AreEqual(expected, formatted);
+        formatted.Should().Be(expected);
     }
 
     /// <summary>GetHash should not fail for Fraction.Zero.</summary>
     [Test]
     public void GetHash_Zero_Hash()
     {
-        Assert.AreEqual(0, Fraction.Zero.GetHashCode());
+        Fraction.Zero.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
     [Test]
     public void GetHash_TestStruct_Hash()
     {
-        Assert.AreEqual(132548, TestStruct.GetHashCode());
+        TestStruct.GetHashCode().Should().Be(132548);
     }
 
     [Test]
@@ -298,7 +298,7 @@ public class FractionTest
     {
         var exp = 123456789.DividedBy(1);
         var act = (Fraction)123456789;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -10,7 +10,7 @@ public class MonthSpanTest
     [Test]
     public void Zero_EqualsDefault()
     {
-        Assert.AreEqual(default(MonthSpan), MonthSpan.Zero);
+        MonthSpan.Zero.Should().Be(default(MonthSpan));
     }
 
     /// <summary>TryParse null should be valid.</summary>
@@ -18,7 +18,7 @@ public class MonthSpanTest
     public void TryParse_Null_IsValid()
     {
         MonthSpan.TryParse(null, out var val).Should().BeTrue();
-        Assert.AreEqual(default(MonthSpan), val);
+        val.Should().Be(default(MonthSpan));
     }
 
     /// <summary>TryParse string.Empty should be valid.</summary>
@@ -26,7 +26,7 @@ public class MonthSpanTest
     public void TryParse_StringEmpty_IsValid()
     {
         MonthSpan.TryParse(string.Empty, out var val).Should().BeTrue();
-        Assert.AreEqual(default(MonthSpan), val);
+        val.Should().Be(default(MonthSpan));
     }
 
     /// <summary>TryParse with specified string value should be valid.</summary>
@@ -35,7 +35,7 @@ public class MonthSpanTest
     {
         string str = "0Y+0M";
         MonthSpan.TryParse(str, out var val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString());
+        val.ToString().Should().Be(str);
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -44,7 +44,7 @@ public class MonthSpanTest
     {
         string str = "5Y#9M";
         MonthSpan.TryParse(str, out var val).Should().BeFalse();
-        Assert.AreEqual(default(MonthSpan), val);
+        val.Should().Be(default(MonthSpan));
     }
 
     [Test]
@@ -67,7 +67,7 @@ public class MonthSpanTest
         {
             var exp = TestStruct;
             var act = MonthSpan.TryParse(exp.ToString());
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -97,7 +97,7 @@ public class MonthSpanTest
     public void Constructor_5Years9Months_69Months()
     {
         var ctor = new MonthSpan(years: 5, months: 9);
-        Assert.AreEqual(MonthSpan.FromMonths(69), ctor);
+        ctor.Should().Be(MonthSpan.FromMonths(69));
     }
 
 #if NET8_0_OR_GREATER
@@ -125,7 +125,7 @@ public class MonthSpanTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -135,7 +135,7 @@ public class MonthSpanTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -143,14 +143,14 @@ public class MonthSpanTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "5Y+9M";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<MonthSpan>("69");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -227,7 +227,7 @@ public class MonthSpanTest
     public void From_years_3_36M()
     {
         var span = MonthSpan.FromYears(3);
-        Assert.AreEqual(MonthSpan.FromMonths(36), span);
+        span.Should().Be(MonthSpan.FromMonths(36));
     }
 
     [Test]
@@ -235,7 +235,7 @@ public class MonthSpanTest
     {
         var act = MonthSpan.Zero.ToString();
         var exp = "0Y+0M";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -243,7 +243,7 @@ public class MonthSpanTest
     {
         var act = TestStruct.ToString("0.00", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '69.00', format: '0.00'";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -251,7 +251,7 @@ public class MonthSpanTest
     {
         var act = MonthSpan.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
         var exp = "01700,0";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -266,7 +266,7 @@ public class MonthSpanTest
     public void Plus_TestStruct_Unchanged()
     {
         var plus = +TestStruct;
-        Assert.AreEqual(TestStruct, plus);
+        plus.Should().Be(TestStruct);
     }
 
     [Test]
@@ -280,7 +280,7 @@ public class MonthSpanTest
     public void Add_1Year7Months_19Months()
     {
         var added = MonthSpan.FromYears(1) + MonthSpan.FromMonths(7);
-        Assert.AreEqual(MonthSpan.FromMonths(19), added);
+        added.Should().Be(MonthSpan.FromMonths(19));
     }
 
     [Test]
@@ -294,7 +294,7 @@ public class MonthSpanTest
     public void Subtract_19Months6Months_13Months()
     {
         var subtracted = MonthSpan.FromMonths(19) - MonthSpan.FromMonths(6);
-        Assert.AreEqual(MonthSpan.FromMonths(13), subtracted);
+        subtracted.Should().Be(MonthSpan.FromMonths(13));
     }
 
     [Test]
@@ -337,7 +337,7 @@ public class MonthSpanTest
     {
         var exp = TestStruct;
         var act = (MonthSpan)69;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -345,7 +345,7 @@ public class MonthSpanTest
     {
         var exp = 69;
         var act = (int)TestStruct;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 }
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/MonthSpanTest.cs
@@ -315,7 +315,7 @@ public class MonthSpanTest
         var inp = new List<MonthSpan> { MonthSpan.Zero, item3, item2, item0, item1, MonthSpan.Zero };
         var exp = new List<MonthSpan> { MonthSpan.Zero, MonthSpan.Zero, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of month spans descending.</summary>
@@ -329,7 +329,7 @@ public class MonthSpanTest
         var inp = new List<MonthSpan> { MonthSpan.Zero, item3, item2, item0, item1, MonthSpan.Zero };
         var exp = new List<MonthSpan> { item3, item2, item1, item0, MonthSpan.Zero, MonthSpan.Zero };
         var act = inp.OrderByDescending(item => item).ToList();
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/NumericSvoTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/NumericSvoTest.cs
@@ -163,8 +163,8 @@ public class NumericSvoTest
             .Select(pars => pars[1])
             .ToArray();
 
-        CollectionAssert.AreEquivalent(expected, methods, nameof(methods));
-        CollectionAssert.AreEquivalent(expected, operators, nameof(operators));
+        methods.Should().BeEquivalentTo(expected);
+        operators.Should().BeEquivalentTo(expected);
     }
 
     [TestCase(typeof(Amount), typeof(Amount), typeof(Percentage))]
@@ -193,8 +193,8 @@ public class NumericSvoTest
             .Select(pars => pars[1])
             .ToArray();
 
-        CollectionAssert.AreEquivalent(expected, methods, nameof(methods));
-        CollectionAssert.AreEquivalent(expected, operators, nameof(operators));
+        methods.Should().BeEquivalentTo(expected);
+        operators.Should().BeEquivalentTo(expected);
     }
 
     [TestCase(typeof(Amount), typeof(short), typeof(int), typeof(long), typeof(ushort), typeof(uint), typeof(ulong), typeof(float), typeof(double), typeof(decimal), typeof(Percentage))]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
@@ -58,7 +58,7 @@ public class TimestampTest
             var exp = TestStruct;
             var act = Timestamp.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -79,7 +79,7 @@ public class TimestampTest
         var info = new SerializationInfo(typeof(Timestamp), new FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual((long)123456789, info.GetInt64("Value"));
+        info.GetInt64("Value").Should().Be((long)123456789);
     }
 
     [Test]
@@ -97,14 +97,14 @@ public class TimestampTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "0x00000000075BCD15";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<Timestamp>("0x00000000075BCD15");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -235,7 +235,7 @@ public class TimestampTest
     {
         var act = Timestamp.MinValue.ToString();
         var exp = "0x0000000000000000";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -243,7 +243,7 @@ public class TimestampTest
     {
         var act = Timestamp.MaxValue.ToString();
         var exp = "0xFFFFFFFFFFFFFFFF";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -252,14 +252,14 @@ public class TimestampTest
         var act = TestStruct.ToString("#,##0", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '123,456,789', format: '#,##0'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStruct_ComplexPattern()
     {
         var act = TestStruct.ToString(string.Empty);
         var exp = "0x00000000075BCD15";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -269,7 +269,7 @@ public class TimestampTest
         {
             var act = Timestamp.Parse("1600").ToString();
             var exp = "0x0000000000000640";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -280,7 +280,7 @@ public class TimestampTest
         {
             var act = Timestamp.Parse("800").ToString("0000");
             var exp = "0800";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -291,7 +291,7 @@ public class TimestampTest
         {
             var act = Timestamp.Parse("800").ToString("0000");
             var exp = "0800";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -300,7 +300,7 @@ public class TimestampTest
     {
         var act = Timestamp.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
         var exp = "01700,0";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -361,7 +361,7 @@ public class TimestampTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -445,7 +445,7 @@ public class TimestampTest
         var exp = TestStruct;
         var act = (Timestamp)new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_TimestampToByteArray_AreEqual()
@@ -453,7 +453,7 @@ public class TimestampTest
         var exp = new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
         var act = (byte[])TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     [Test]
@@ -462,7 +462,7 @@ public class TimestampTest
         var exp = TestStruct;
         var act = (Timestamp)123456789L;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_TimestampToInt64_AreEqual()
@@ -470,7 +470,7 @@ public class TimestampTest
         var exp = 123456789L;
         var act = (long)TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -479,7 +479,7 @@ public class TimestampTest
         var exp = TestStruct;
         var act = (Timestamp)123456789UL;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_TimestampToUInt64_AreEqual()
@@ -487,7 +487,7 @@ public class TimestampTest
         var exp = 123456789UL;
         var act = (ulong)TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Sql/TimestampTest.cs
@@ -333,7 +333,7 @@ public class TimestampTest
         var exp = new List<Timestamp> { Timestamp.MinValue, Timestamp.MinValue, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of timestamps descending.</summary>
@@ -349,7 +349,7 @@ public class TimestampTest
         var exp = new List<Timestamp> { item3, item2, item1, item0, Timestamp.MinValue, Timestamp.MinValue };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>
@@ -432,7 +432,7 @@ public class TimestampTest
         var act = TestStruct.ToByteArray();
         var exp = new byte[] { 21, 205, 91, 7, 0, 0, 0, 0 };
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
@@ -331,7 +331,7 @@
             var exp = new List<Elo> { Elo.Zero, Elo.Zero, item0, item1, item2, item3 };
             var act = inp.OrderBy(item => item).ToList();
 
-            CollectionAssert.AreEqual(exp, act);
+            act.Should().BeEquivalentTo(exp);
         }
 
         /// <summary>Orders a list of Elos descending.</summary>
@@ -347,7 +347,7 @@
             var exp = new List<Elo> { item3, item2, item1, item0, Elo.Zero, Elo.Zero };
             var act = inp.OrderByDescending(item => item).ToList();
 
-            CollectionAssert.AreEqual(exp, act);
+            act.Should().BeEquivalentTo(exp);
         }
 
         /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Statistics/EloTest.cs
@@ -12,17 +12,17 @@
         [Test]
         public void Zero_None_EqualsDefault()
         {
-            Assert.AreEqual(default(Elo), Elo.Zero);
+            Elo.Zero.Should().Be(default(Elo));
         }
         [Test]
         public void MinValue_None_DoubleMinValue()
         {
-            Assert.AreEqual((Elo)double.MinValue, Elo.MinValue);
+            Elo.MinValue.Should().Be((Elo)double.MinValue);
         }
         [Test]
         public void MaxValue_None_DoubleMaxValue()
         {
-            Assert.AreEqual((Elo)double.MaxValue, Elo.MaxValue);
+            Elo.MaxValue.Should().Be((Elo)double.MaxValue);
         }
 
         #endregion
@@ -73,7 +73,7 @@
                 var exp = TestStruct;
                 var act = Elo.TryParse(exp.ToString());
 
-                Assert.AreEqual(exp, act);
+                act.Should().Be(exp);
             }
         }
 
@@ -90,7 +90,7 @@
             var info = new SerializationInfo(typeof(Elo), new System.Runtime.Serialization.FormatterConverter());
             obj.GetObjectData(info, default);
 
-            Assert.AreEqual(1732.4000000000001, info.GetDouble("Value"));
+            info.GetDouble("Value").Should().Be(1732.4000000000001);
         }
 
         [Test]
@@ -100,7 +100,7 @@
             var input = EloTest.TestStruct;
             var exp = EloTest.TestStruct;
             var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 #endif
 
@@ -110,7 +110,7 @@
             var input = EloTest.TestStruct;
             var exp = EloTest.TestStruct;
             var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
@@ -118,14 +118,14 @@
         {
             var act = Serialize.Xml(TestStruct);
             var exp = "1732.4";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
         public void XmlDeserialize_XmlString_AreEqual()
         {
             var act = Deserialize.Xml<Elo>("1732.4");
-            Assert.AreEqual(TestStruct, act);
+            act.Should().Be(TestStruct);
         }
 
 #if NET8_0_OR_GREATER
@@ -236,7 +236,7 @@
             var act = TestStruct.ToString("00000", FormatProvider.CustomFormatter);
             var exp = "Unit Test Formatter, value: '01732', format: '00000'";
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
         [Test]
         public void ToString_TestStruct_ComplexPattern()
@@ -245,7 +245,7 @@
             {
                 var act = TestStruct.ToString(string.Empty);
                 var exp = "1732.4";
-                Assert.AreEqual(exp, act);
+                act.Should().Be(exp);
             }
         }
 
@@ -256,7 +256,7 @@
             {
                 var act = Elo.Parse("1600,1").ToString();
                 var exp = "1600,1";
-                Assert.AreEqual(exp, act);
+                act.Should().Be(exp);
             }
         }
 
@@ -267,7 +267,7 @@
             {
                 var act = Elo.Parse("1600.1").ToString();
                 var exp = "1600.1";
-                Assert.AreEqual(exp, act);
+                act.Should().Be(exp);
             }
         }
 
@@ -278,7 +278,7 @@
             {
                 var act = Elo.Parse("800").ToString("0000");
                 var exp = "0800";
-                Assert.AreEqual(exp, act);
+                act.Should().Be(exp);
             }
         }
 
@@ -289,7 +289,7 @@
             {
                 var act = Elo.Parse("800").ToString("0000");
                 var exp = "0800";
-                Assert.AreEqual(exp, act);
+                act.Should().Be(exp);
             }
         }
 
@@ -298,7 +298,7 @@
         {
             var act = Elo.Parse("1700").ToString("00000.0", new CultureInfo("es-EC"));
             var exp = "01700,0";
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         #endregion
@@ -359,7 +359,7 @@
             var exp = 0;
             var act = TestStruct.CompareTo(other);
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         /// <summary>Compare with a random object should throw an exception.</summary>
@@ -430,7 +430,7 @@
             Elo exp = Elo.Create(1600.1);
             Elo act = 1600.1;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
         [Test]
         public void Explicit_EloToDouble_AreEqual()
@@ -438,7 +438,7 @@
             var exp = 1600.1;
             var act = (double)Elo.Create(1600.1);
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
@@ -447,7 +447,7 @@
             Elo exp = Elo.Create(1600.1);
             Elo act = 1600.1m;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
         [Test]
         public void Explicit_EloToDecimal_AreEqual()
@@ -455,7 +455,7 @@
             var exp = 1600.1m;
             var act = (decimal)Elo.Create(1600.1);
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
 
@@ -465,7 +465,7 @@
             Elo exp = Elo.Create(1600);
             Elo act = 1600;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
         [Test]
         public void Explicit_EloToInt32_AreEqual()
@@ -473,7 +473,7 @@
             var exp = 1600;
             var act = (int)Elo.Create(1600);
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         #endregion
@@ -492,7 +492,7 @@
             Elo act = l + r;
             Elo exp = 1700;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
@@ -504,7 +504,7 @@
             Elo act = l - r;
             Elo exp = 1500;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
@@ -516,7 +516,7 @@
 
             Elo exp = 800;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
@@ -528,7 +528,7 @@
 
             Elo exp = 3200;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
@@ -539,7 +539,7 @@
 
             Elo exp = 1601;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
@@ -550,7 +550,7 @@
 
             Elo exp = 1599;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
@@ -562,7 +562,7 @@
 
             Elo exp = 1600;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
 
         [Test]
@@ -574,7 +574,7 @@
 
             Elo exp = 1600;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
         #endregion
     }

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Text/WildcardPatternTest.cs
@@ -90,8 +90,8 @@ public class WildcardPatternTest
         obj.GetObjectData(info, default);
 
         Assert.AreEqual("t?st*", info.GetString("Pattern"));
-        Assert.AreEqual((int)WildcardPatternOptions.SingleOrTrailing, info.GetInt32("Options"));
-        Assert.AreEqual((int)StringComparison.Ordinal, info.GetInt32("ComparisonType"));
+        info.GetInt32("Options").Should().Be((int)WildcardPatternOptions.SingleOrTrailing);
+        info.GetInt32("ComparisonType").Should().Be((int)StringComparison.Ordinal);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Threading/ThreadDomainTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Threading/ThreadDomainTest.cs
@@ -16,14 +16,14 @@ public class ThreadDomainTest
     public void Get_NullableDecimal_ThrowsNotSupportedException()
     {
         var x = Assert.Catch<NotSupportedException>(() => ThreadDomain.Current.Get<decimal?>());
-        Assert.AreEqual("Type must be a none generic type.", x.Message);
+        x.Message.Should().Be("Type must be a none generic type.");
     }
 
     [Test]
     public void Get_Object_ThrowsNotSupportedException()
     {
         var x = Assert.Catch<NotSupportedException>(() => ThreadDomain.Current.Get<object>());
-        Assert.AreEqual("Converter can not convert from System.String.", x.Message);
+        x.Message.Should().Be("Converter can not convert from System.String.");
     }
 
     [Test]
@@ -34,7 +34,7 @@ public class ThreadDomainTest
             var act = ThreadDomain.Current.Get<Country>();
             var exp = Country.PT;
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -44,7 +44,7 @@ public class ThreadDomainTest
         var act = ThreadDomain.Current.Get<InternationalBankAccountNumber>();
         var exp = InternationalBankAccountNumber.Empty;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -55,7 +55,7 @@ public class ThreadDomainTest
         var act = ThreadDomain.Current.Get<Currency>();
         var exp = Currency.ALL;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/UuidComparerTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/UuidComparerTest.cs
@@ -50,8 +50,7 @@ public class UuidComparerTest
             uuids.Add(Uuid.NewUuid());
         }
         uuids.Sort(UuidComparer.Default);
-
-        CollectionAssert.IsOrdered(uuids, Comparer<Guid>.Default);
+        uuids.Should().BeInAscendingOrder();
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
@@ -484,7 +484,7 @@ public class InternetMediaTypeTest
         var exp = new List<InternetMediaType> { InternetMediaType.Empty, InternetMediaType.Empty, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of internet media types descending.</summary>
@@ -500,7 +500,7 @@ public class InternetMediaTypeTest
         var exp = new List<InternetMediaType> { item3, item2, item1, item0, InternetMediaType.Empty, InternetMediaType.Empty };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/Web/InternetMediaTypeTest.cs
@@ -18,7 +18,7 @@ public class InternetMediaTypeTest
     [Test]
     public void Empty_None_EqualsDefault()
     {
-        Assert.AreEqual(default(InternetMediaType), InternetMediaType.Empty);
+        InternetMediaType.Empty.Should().Be(default(InternetMediaType));
     }
 
     #endregion
@@ -142,7 +142,7 @@ public class InternetMediaTypeTest
         {
             var act = InternetMediaType.Parse("?");
             var exp = InternetMediaType.Unknown;
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -168,7 +168,7 @@ public class InternetMediaTypeTest
             var exp = TestStruct;
             var act = InternetMediaType.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -199,7 +199,7 @@ public class InternetMediaTypeTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -209,7 +209,7 @@ public class InternetMediaTypeTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -217,14 +217,14 @@ public class InternetMediaTypeTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "application/x-chess-pgn";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<InternetMediaType>("application/x-chess-pgn");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -355,7 +355,7 @@ public class InternetMediaTypeTest
     {
         var act = InternetMediaType.Empty.ToString();
         var exp = "";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -363,7 +363,7 @@ public class InternetMediaTypeTest
     {
         var act = InternetMediaType.Unknown.ToString();
         var exp = "application/octet-stream";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -372,14 +372,14 @@ public class InternetMediaTypeTest
         var act = TestStruct.ToString("Unit Test Format", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: 'application/x-chess-pgn', format: 'Unit Test Format'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void ToString_TestStruct_ComplexPattern()
     {
         var act = TestStruct.ToString(string.Empty);
         var exp = "application/x-chess-pgn";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -390,7 +390,7 @@ public class InternetMediaTypeTest
     [Test]
     public void GetHash_Empty_0()
     {
-        Assert.AreEqual(0, InternetMediaType.Empty.GetHashCode());
+        InternetMediaType.Empty.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
@@ -512,7 +512,7 @@ public class InternetMediaTypeTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -531,14 +531,14 @@ public class InternetMediaTypeTest
     {
         var exp = 0;
         var act = InternetMediaType.Empty.Length;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Length_TestStruct_23()
     {
         var exp = 23;
         var act = TestStruct.Length;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -546,28 +546,28 @@ public class InternetMediaTypeTest
     {
         var exp = string.Empty;
         var act = InternetMediaType.Empty.TopLevel;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void TopLevel_TextHtml_Text()
     {
         var exp = "text";
         var act = TextHtml.TopLevel;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void TopLevel_XConferenceXCooltalk_XConference()
     {
         var exp = "x-conference";
         var act = XConferenceXCooltalk.TopLevel;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void TopLevel_TestStruct_Application()
     {
         var exp = "application";
         var act = TestStruct.TopLevel;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -575,28 +575,28 @@ public class InternetMediaTypeTest
     {
         var exp = InternetMediaTopLevelType.None;
         var act = InternetMediaType.Empty.TopLevelType;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void TopLevelType_TextHtml_Text()
     {
         var exp = InternetMediaTopLevelType.Text;
         var act = TextHtml.TopLevelType;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void TopLevelType_XConferenceXCooltalk_Unregistered()
     {
         var exp = InternetMediaTopLevelType.Unregistered;
         var act = XConferenceXCooltalk.TopLevelType;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void TopLevelType_TestStruct_Application()
     {
         var exp = InternetMediaTopLevelType.Application;
         var act = TestStruct.TopLevelType;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -604,28 +604,28 @@ public class InternetMediaTypeTest
     {
         var exp = string.Empty;
         var act = InternetMediaType.Empty.Subtype;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Subtype_TextHtml_Html()
     {
         var exp = "html";
         var act = TextHtml.Subtype;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Subtype_XConferenceXCooltalk_XCooltalk()
     {
         var exp = "x-cooltalk";
         var act = XConferenceXCooltalk.Subtype;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Subtype_TestStruct_XChessPgn()
     {
         var exp = "x-chess-pgn";
         var act = TestStruct.Subtype;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -633,28 +633,28 @@ public class InternetMediaTypeTest
     {
         var exp = false;
         var act = InternetMediaType.Empty.IsRegistered;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void IsRegistered_TextHtml_IsTrue()
     {
         var exp = true;
         var act = TextHtml.IsRegistered;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void IsRegistered_XConferenceXCooltalk_IsFalse()
     {
         var exp = false;
         var act = XConferenceXCooltalk.IsRegistered;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void IsRegistered_TestStruct_IsFalse()
     {
         var exp = false;
         var act = TestStruct.IsRegistered;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void IsRegistered_VideoSlashXDotTest_IsFalse()
@@ -662,7 +662,7 @@ public class InternetMediaTypeTest
         var mime = InternetMediaType.Parse("video/x.test");
         var exp = false;
         var act = mime.IsRegistered;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
 
@@ -671,7 +671,7 @@ public class InternetMediaTypeTest
     {
         var exp = InternetMediaSuffixType.None;
         var act = InternetMediaType.Empty.Suffix;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -679,7 +679,7 @@ public class InternetMediaTypeTest
     {
         var exp = InternetMediaSuffixType.None;
         var act = TestStruct.Suffix;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Suffix_ApplicationAtomXml_Xml()
@@ -688,7 +688,7 @@ public class InternetMediaTypeTest
 
         var exp = InternetMediaSuffixType.xml;
         var act = mime.Suffix;
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
@@ -12,7 +12,7 @@ public class WeekDateTest
     [Test]
     public void MinValue_None_EqualsDefault()
     {
-        Assert.AreEqual(default(WeekDate), WeekDate.MinValue);
+        WeekDate.MinValue.Should().Be(default(WeekDate));
     }
 
     #endregion
@@ -50,7 +50,7 @@ public class WeekDateTest
             var exp = TestStruct;
             var act = WeekDate.TryParse(exp.ToString());
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -59,7 +59,7 @@ public class WeekDateTest
     {
         WeekDate exp = default;
         WeekDate.TryParse("0000-W21-7", out WeekDate act).Should().BeFalse();
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -67,7 +67,7 @@ public class WeekDateTest
     {
         WeekDate exp = default;
         WeekDate.TryParse("2000-W53-7", out WeekDate act).Should().BeFalse();
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -83,7 +83,7 @@ public class WeekDateTest
         var info = new SerializationInfo(typeof(WeekDate), new System.Runtime.Serialization.FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual((DateTime)TestStruct, info.GetDateTime("Value"));
+        info.GetDateTime("Value").Should().Be((DateTime)TestStruct);
     }
 
     [Test]
@@ -93,7 +93,7 @@ public class WeekDateTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 #endif
 
@@ -103,7 +103,7 @@ public class WeekDateTest
         var input = TestStruct;
         var exp = TestStruct;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -111,14 +111,14 @@ public class WeekDateTest
     {
         var act = Serialize.Xml(TestStruct);
         var exp = "1997-W14-6";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
     public void XmlDeserialize_XmlString_AreEqual()
     {
         var act = Deserialize.Xml<WeekDate>("1997-W14-6");
-        Assert.AreEqual(TestStruct, act);
+        act.Should().Be(TestStruct);
     }
 
 #if NET8_0_OR_GREATER
@@ -250,7 +250,7 @@ public class WeekDateTest
         var act = TestStruct.ToString("y#W", FormatProvider.CustomFormatter);
         var exp = "Unit Test Formatter, value: '1997#14', format: 'y#W'";
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -261,7 +261,7 @@ public class WeekDateTest
             var act = TestStruct.ToString(@"y-\WW-d", null);
             var exp = "1997-W14-6";
 
-            Assert.AreEqual(exp, act);
+            act.Should().Be(exp);
         }
     }
 
@@ -270,7 +270,7 @@ public class WeekDateTest
     {
         var act = TestStruct.ToString(string.Empty);
         var exp = "1997-W14-6";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -278,7 +278,7 @@ public class WeekDateTest
     {
         var act = new WeekDate(1979, 3, 5).ToString(@"y-\WW-d");
         var exp = "1979-W3-5";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -286,7 +286,7 @@ public class WeekDateTest
     {
         var act = new WeekDate(1979, 3, 5).ToString(@"y-\Ww-d");
         var exp = "1979-W03-5";
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     #endregion
@@ -297,14 +297,14 @@ public class WeekDateTest
     [Test]
     public void GetHash_Empty_Hash()
     {
-        Assert.AreEqual(0, WeekDate.MinValue.GetHashCode());
+        WeekDate.MinValue.GetHashCode().Should().Be(0);
     }
 
     /// <summary>GetHash should not fail for the test struct.</summary>
     [Test]
     public void GetHash_TestStruct_Hash()
     {
-        Assert.AreEqual(2027589483, TestStruct.GetHashCode());
+        TestStruct.GetHashCode().Should().Be(2027589483);
     }
 
     [Test]
@@ -413,7 +413,7 @@ public class WeekDateTest
         var exp = 0;
         var act = TestStruct.CompareTo(other);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     /// <summary>Compare with a random object should throw an exception.</summary>
@@ -484,7 +484,7 @@ public class WeekDateTest
         var exp = TestStruct;
         var act = (WeekDate)new DateTime(1997, 04, 05, 00, 00, 000, DateTimeKind.Local);
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     [Test]
     public void Explicit_WeekDateToInt32_AreEqual()
@@ -492,7 +492,7 @@ public class WeekDateTest
         DateTime exp = new(1997, 04, 05, 00, 00, 000, DateTimeKind.Local);
         DateTime act = TestStruct;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
     #endregion
 
@@ -504,7 +504,7 @@ public class WeekDateTest
         var exp = new Date(1997, 04, 05);
         var act = TestStruct.Date;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -513,7 +513,7 @@ public class WeekDateTest
         var exp = WeekDate.MinValue.Year;
         var act = 1;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -522,7 +522,7 @@ public class WeekDateTest
         var exp = WeekDate.MaxValue.Year;
         var act = 9999;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -532,7 +532,7 @@ public class WeekDateTest
         var exp = 2010;
         var act = date.Year;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -542,7 +542,7 @@ public class WeekDateTest
         var exp = 2020;
         var act = date.Year;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
 
@@ -554,7 +554,7 @@ public class WeekDateTest
         var exp = 6;
         var act = TestStruct.Day;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -564,7 +564,7 @@ public class WeekDateTest
         var exp = 7;
         var act = date.Day;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
     [Test]
@@ -573,7 +573,7 @@ public class WeekDateTest
         var exp = 96;
         var act = TestStruct.DayOfYear;
 
-        Assert.AreEqual(exp, act);
+        act.Should().Be(exp);
     }
 
 

--- a/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
+++ b/specs/Qowaiv.Specs/UnitTests.OldStyle/WeekDateTest.cs
@@ -385,7 +385,7 @@ public class WeekDateTest
         var exp = new List<WeekDate> { WeekDate.MinValue, WeekDate.MinValue, item0, item1, item2, item3 };
         var act = inp.OrderBy(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Orders a list of week dates descending.</summary>
@@ -401,7 +401,7 @@ public class WeekDateTest
         var exp = new List<WeekDate> { item3, item2, item1, item0, WeekDate.MinValue, WeekDate.MinValue };
         var act = inp.OrderByDescending(item => item).ToList();
 
-        CollectionAssert.AreEqual(exp, act);
+        act.Should().BeEquivalentTo(exp);
     }
 
     /// <summary>Compare with a to object casted instance should be fine.</summary>

--- a/specs/Qowaiv.Specs/Unknown_specs.cs
+++ b/specs/Qowaiv.Specs/Unknown_specs.cs
@@ -47,12 +47,12 @@ public class Can_be_resolved_for
     [Test]
     public void value_type_with_unknown_value()
     {
-        Assert.AreEqual(PostalCode.Unknown, Unknown.Value(typeof(PostalCode)));
+        Unknown.Value(typeof(PostalCode)).Should().Be(PostalCode.Unknown);
     }
     [Test]
     public void reference_type_with_unknown_value()
     {
-        Assert.AreEqual(ClassWithUnknownValue.Unknown, Unknown.Value(typeof(ClassWithUnknownValue)));
+        Unknown.Value(typeof(ClassWithUnknownValue)).Should().Be(ClassWithUnknownValue.Unknown);
     }
 
     private class ClassWithUnknownValue

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -530,7 +530,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.Year);
-        Assert.AreEqual(Svo.Year, round_tripped);
+        round_tripped.Should().Be(Svo.Year);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -17,7 +17,7 @@ public class With_domain_logic
     [TestCase(true, "")]
     public void IsEmpty_returns(bool result, Year svo)
     {
-        Assert.AreEqual(result, svo.IsEmpty());
+        svo.IsEmpty().Should().Be(result);
     }
 
     [TestCase(false, 1979)]
@@ -25,7 +25,7 @@ public class With_domain_logic
     [TestCase(true, "")]
     public void IsEmptyOrUnknown_returns(bool result, Year svo)
     {
-        Assert.AreEqual(result, svo.IsEmptyOrUnknown());
+        svo.IsEmptyOrUnknown().Should().Be(result);
     }
 
     [TestCase(false, 1979)]
@@ -33,7 +33,7 @@ public class With_domain_logic
     [TestCase(false, "")]
     public void IsUnknown_returns(bool result, Year svo)
     {
-        Assert.AreEqual(result, svo.IsUnknown());
+        svo.IsUnknown().Should().Be(result);
     }
 }
 
@@ -83,21 +83,21 @@ public class Has_constant
     [Test]
     public void Empty_represent_default_value()
     {
-        Assert.AreEqual(default(Year), Year.Empty);
+        Year.Empty.Should().Be(default(Year));
     }
 
     [Test]
     public void MinValue_represents_1()
     {
         Year min = 1.CE();
-        Assert.AreEqual(min, Year.MinValue);
+        Year.MinValue.Should().Be(min);
     }
 
     [Test]
     public void MaxValue_represents_9999()
     {
         Year max = 9999.CE();
-        Assert.AreEqual(max, Year.MaxValue);
+        Year.MaxValue.Should().Be(max);
     }
 }
 
@@ -168,26 +168,26 @@ public class Can_be_parsed
     [Test]
     public void from_null_string_represents_Empty()
     {
-        Assert.AreEqual(Year.Empty, Year.Parse(null));
+        Year.Parse(null).Should().Be(Year.Empty);
     }
 
     [Test]
     public void from_empty_string_represents_Empty()
     {
-        Assert.AreEqual(Year.Empty, Year.Parse(string.Empty));
+        Year.Parse(string.Empty).Should().Be(Year.Empty);
     }
 
     [Test]
     public void from_question_mark_represents_Unknown()
     {
-        Assert.AreEqual(Year.Unknown, Year.Parse("?"));
+        Year.Parse("?").Should().Be(Year.Unknown);
     }
 
     [Test]
     public void from_string()
     {
         var parsed = Year.Parse("1979");
-        Assert.AreEqual(Svo.Year, parsed);
+        parsed.Should().Be(Svo.Year);
     }
 
     [Test]
@@ -196,7 +196,7 @@ public class Can_be_parsed
         using (TestCultures.En_GB.Scoped())
         {
             var exception = Assert.Throws<FormatException>(() => Year.Parse("invalid input"));
-            Assert.AreEqual("Not a valid year", exception.Message);
+            exception.Message.Should().Be("Not a valid year");
         }
     }
 
@@ -213,7 +213,7 @@ public class Can_be_parsed
     [Test]
     public void with_TryParse_returns_SVO()
     {
-        Assert.AreEqual(Svo.Year, Year.TryParse("1979"));
+        Year.TryParse("1979").Should().Be(Svo.Year);
     }
 }
 
@@ -222,7 +222,7 @@ public class Can_be_created_from_int
     [Test]
     public void empty_for_not_set_int()
     {
-        Assert.AreEqual(Year.Empty, Year.TryCreate(default));
+        Year.TryCreate(default).Should().Be(Year.Empty);
     }
 
     [Test]
@@ -234,7 +234,7 @@ public class Can_be_created_from_int
     [Test]
     public void within_range()
     {
-        Assert.AreEqual(Svo.Year, Year.TryCreate(1979));
+        Year.TryCreate(1979).Should().Be(Svo.Year);
     }
 
     [TestCase(0)]
@@ -250,13 +250,13 @@ public class Has_custom_formatting
     [Test]
     public void default_value_is_represented_as_string_empty()
     {
-        Assert.AreEqual(string.Empty, default(Year).ToString());
+        default(Year).ToString().Should().Be(string.Empty);
     }
 
     [Test]
     public void unknown_value_is_represented_as_unknown()
     {
-        Assert.AreEqual("?", Year.Unknown.ToString());
+        Year.Unknown.ToString().Should().Be("?");
     }
 
     [Test]
@@ -273,7 +273,7 @@ public class Has_custom_formatting
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(expected);
         }
     }
 
@@ -282,7 +282,7 @@ public class Has_custom_formatting
     {
         using (new CultureInfoScope(culture: TestCultures.Nl_NL, cultureUI: TestCultures.En_GB))
         {
-            Assert.AreEqual("1979", Svo.Year.ToString(provider: null));
+            Svo.Year.ToString(provider: null).Should().Be("1979");
         }
     }
 }
@@ -292,14 +292,14 @@ public class Is_comparable
     [Test]
     public void to_null_is_1()
     {
-        Assert.AreEqual(1, Svo.Year.CompareTo(null));
+        Svo.Year.CompareTo(null).Should().Be(1);
     }
 
     [Test]
     public void to_Year_as_object()
     {
         object obj = Svo.Year;
-        Assert.AreEqual(0, Svo.Year.CompareTo(obj));
+        Svo.Year.CompareTo(obj).Should().Be(0);
     }
 
     [Test]
@@ -321,7 +321,7 @@ public class Is_comparable
             };
         var list = new List<Year> { sorted[3], sorted[5], sorted[4], sorted[2], sorted[0], sorted[1] };
         list.Sort();
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 
     [Test]
@@ -367,14 +367,14 @@ public class Casts
     public void explicitly_from_short()
     {
         var casted = (Year)1979;
-        Assert.AreEqual(Svo.Year, casted);
+        casted.Should().Be(Svo.Year);
     }
 
     [Test]
     public void explicitly_to_short()
     {
         var casted = (short)Svo.Year;
-        Assert.AreEqual((short)1979, casted);
+        casted.Should().Be((short)1979);
     }
 }
 
@@ -474,21 +474,21 @@ public class Supports_XML_serialization
     public void using_XmlSerializer_to_serialize()
     {
         var xml = Serialize.Xml(Svo.Year);
-        Assert.AreEqual("1979", xml);
+        xml.Should().Be("1979");
     }
 
     [Test]
     public void using_XmlSerializer_to_deserialize()
     {
         var svo = Deserialize.Xml<Year>("1979");
-        Assert.AreEqual(Svo.Year, svo);
+        svo.Should().Be(Svo.Year);
     }
 
     [Test]
     public void using_DataContractSerializer()
     {
         var round_tripped = SerializeDeserialize.DataContract(Svo.Year);
-        Assert.AreEqual(Svo.Year, round_tripped);
+        round_tripped.Should().Be(Svo.Year);
     }
 
     [Test]
@@ -496,7 +496,7 @@ public class Supports_XML_serialization
     {
         var structure = XmlStructure.New(Svo.Year);
         var round_tripped = SerializeDeserialize.Xml(structure);
-        Assert.AreEqual(structure, round_tripped);
+        round_tripped.Should().Be(structure);
     }
 
     [Test]
@@ -537,7 +537,7 @@ public class Supports_binary_serialization
     public void storing_short_in_SerializationInfo()
     {
         var info = Serialize.GetInfo(Svo.Year);
-        Assert.AreEqual((short)1979, info.GetInt16("Value"));
+        info.GetInt16("Value").Should().Be((short)1979);
     }
 }
 #endif

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -76,7 +76,7 @@ public class Has_constant
     [Test]
     public void Empty_represent_default_value()
     {
-        Assert.AreEqual(default(YesNo), YesNo.Empty);
+        YesNo.Empty.Should().Be(default(YesNo));
     }
 }
 
@@ -146,19 +146,19 @@ public class Can_be_parsed
     [Test]
     public void from_null_string_represents_Empty()
     {
-        Assert.AreEqual(YesNo.Empty, YesNo.Parse(null));
+        YesNo.Parse(null).Should().Be(YesNo.Empty);
     }
 
     [Test]
     public void from_empty_string_represents_Empty()
     {
-        Assert.AreEqual(YesNo.Empty, YesNo.Parse(string.Empty));
+        YesNo.Parse(string.Empty).Should().Be(YesNo.Empty);
     }
 
     [Test]
     public void from_question_mark_represents_Unknown()
     {
-        Assert.AreEqual(YesNo.Unknown, YesNo.Parse("?"));
+        YesNo.Parse("?").Should().Be(YesNo.Unknown);
     }
 
     [TestCase("en", "y")]
@@ -170,7 +170,7 @@ public class Can_be_parsed
         using (culture.Scoped())
         {
             var parsed = YesNo.Parse(input);
-            Assert.AreEqual(Svo.YesNo, parsed);
+            parsed.Should().Be(Svo.YesNo);
         }
     }
 
@@ -197,7 +197,7 @@ public class Can_be_parsed
     [Test]
     public void with_TryParse_returns_SVO()
     {
-        Assert.AreEqual(Svo.YesNo, YesNo.TryParse("yes"));
+        YesNo.TryParse("yes").Should().Be(Svo.YesNo);
     }
 }
 
@@ -206,13 +206,13 @@ public class Has_custom_formatting
     [Test]
     public void default_value_is_represented_as_string_empty()
     {
-        Assert.AreEqual(string.Empty, default(YesNo).ToString());
+        default(YesNo).ToString().Should().Be(string.Empty);
     }
 
     [Test]
     public void unknown_value_is_represented_as_unknown()
     {
-        Assert.AreEqual("unknown", YesNo.Unknown.ToString(CultureInfo.InvariantCulture));
+        YesNo.Unknown.ToString(CultureInfo.InvariantCulture).Should().Be("unknown");
     }
 
     [Test]
@@ -252,7 +252,7 @@ public class Has_custom_formatting
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(expected);
         }
     }
 
@@ -263,7 +263,7 @@ public class Has_custom_formatting
             culture: TestCultures.Nl_NL,
             cultureUI: TestCultures.En_GB))
         {
-            Assert.AreEqual("ja", Svo.YesNo.ToString(provider: null));
+            Svo.YesNo.ToString(provider: null).Should().Be("ja");
         }
     }
 }
@@ -277,7 +277,7 @@ public class Is_comparable
     public void to_YesNo_as_object()
     {
         object obj = Svo.YesNo;
-        Assert.AreEqual(0, Svo.YesNo.CompareTo(obj));
+        Svo.YesNo.CompareTo(obj).Should().Be(0);
     }
 
     [Test]
@@ -300,7 +300,7 @@ public class Is_comparable
         var list = new List<YesNo> { sorted[3], sorted[4], sorted[2], sorted[0], sorted[1] };
         list.Sort();
 
-        Assert.AreEqual(sorted, list);
+        list.Should().BeEquivalentTo(sorted);
     }
 }
 
@@ -310,14 +310,14 @@ public class Casts
     [TestCase("no", false)]
     public void explicitly_from_boolean(YesNo casted, bool boolean)
     {
-        Assert.AreEqual(casted, (YesNo)boolean);
+        ((YesNo)boolean).Should().Be(casted);
     }
 
     [Test]
     public void yes_implicitly_to_true()
     {
         var result = YesNo.Yes ? "passed" : "failed";
-        Assert.AreEqual("passed", result);
+        result.Should().Be("passed");
     }
 
     [Test]
@@ -333,7 +333,7 @@ public class Casts
     public void explicitly_from_nullable_boolean(bool? value, YesNo expected)
     {
         var casted = (YesNo)value;
-        Assert.AreEqual(expected, casted);
+        casted.Should().Be(expected);
     }
 
     [TestCase("", null)]
@@ -343,7 +343,7 @@ public class Casts
     public void explicitly_to_nullable_boolean(YesNo svo, bool? expected)
     {
         var casted = (bool?)svo;
-        Assert.AreEqual(expected, casted);
+        casted.Should().Be(expected);
     }
 
     [TestCase("", null)]
@@ -353,7 +353,7 @@ public class Casts
     public void explicitly_to_boolean(YesNo svo, bool expected)
     {
         var casted = (bool)svo;
-        Assert.AreEqual(expected, casted);
+        casted.Should().Be(expected);
     }
 }
 
@@ -480,21 +480,21 @@ public class Supports_XML_serialization
     public void using_XmlSerializer_to_serialize()
     {
         var xml = Serialize.Xml(Svo.YesNo);
-        Assert.AreEqual("yes", xml);
+        xml.Should().Be("yes");
     }
 
     [Test]
     public void using_XmlSerializer_to_deserialize()
     {
         var svo = Deserialize.Xml<YesNo>("yes");
-        Assert.AreEqual(Svo.YesNo, svo);
+        svo.Should().Be(Svo.YesNo);
     }
 
     [Test]
     public void using_data_contract_serializer()
     {
         var round_tripped = SerializeDeserialize.DataContract(Svo.YesNo);
-        Assert.AreEqual(Svo.YesNo, round_tripped);
+        round_tripped.Should().Be(Svo.YesNo);
     }
 
     [Test]
@@ -503,7 +503,7 @@ public class Supports_XML_serialization
         var structure = XmlStructure.New(Svo.YesNo);
         var round_tripped = SerializeDeserialize.Xml(structure);
 
-        Assert.AreEqual(structure, round_tripped);
+        round_tripped.Should().Be(structure);
     }
 
     [Test]
@@ -545,7 +545,7 @@ public class Supports_binary_serialization
     public void storing_byte_in_SerializationInfo()
     {
         var info = Serialize.GetInfo(Svo.YesNo);
-        Assert.AreEqual((byte)2, info.GetByte("Value"));
+        info.GetByte("Value").Should().Be((byte)2);
     }
 }
 #endif

--- a/specs/Qowaiv.Specs/YesNo_specs.cs
+++ b/specs/Qowaiv.Specs/YesNo_specs.cs
@@ -538,7 +538,7 @@ public class Supports_binary_serialization
     public void using_BinaryFormatter()
     {
         var round_tripped = SerializeDeserialize.Binary(Svo.YesNo);
-        Assert.AreEqual(Svo.YesNo, round_tripped);
+        round_tripped.Should().Be(Svo.YesNo);
     }
 
     [Test]


### PR DESCRIPTION
To prepare for NUnit 4.0 (that no longer has `CollectionAssert`, nor `Assert.AreEqual`), removed the majority of calls to it.