### PR TITLE
Increase code coverage

### DIFF
--- a/specs/Qowaiv.Specs/Date_specs.cs
+++ b/specs/Qowaiv.Specs/Date_specs.cs
@@ -202,6 +202,7 @@ public class Supports_JSON_serialization
     [TestCase("2012-04-23", "2012-04-23")]
     [TestCase("2012-04-23T18:25:43.511Z", "2012-04-23")]
     [TestCase("2012-04-23T10:25:43-05:00", "2012-04-23")]
+    [TestCase(636_327_360_000_000_000L, "2017-06-11")]
     public void System_Text_JSON_deserialization(object json, Date svo)
         => JsonTester.Read_System_Text_JSON<Date>(json).Should().Be(svo);
 

--- a/specs/Qowaiv.Specs/Globalization/Country_specs.cs
+++ b/specs/Qowaiv.Specs/Globalization/Country_specs.cs
@@ -156,7 +156,6 @@ public class Supports_JSON_serialization
 #if NET6_0_OR_GREATER
     [TestCase("Netherlands", "NL")]
     [TestCase("nl", "NL")]
-    [TestCase(4.00, "AF")]
     [TestCase(100L, "BG")]
     [TestCase(null, null)]
     [TestCase("?", "?")]

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -39,7 +39,6 @@ public class Supports_JSON_serialization
 #if NET6_0_OR_GREATER
     [TestCase("", null)]
     [TestCase(null, null)]
-    [TestCase(17.0, 017L)]
     [TestCase(123456789L, 123456789L)]
     [TestCase("123456789", 123456789L)]
     public void System_Text_JSON_deserialization(object json, Int64Id svo)

--- a/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
+++ b/specs/Qowaiv.Specs/Sustainability/Energy_label_specs.cs
@@ -450,6 +450,19 @@ public class Supports_type_conversion
 
 public class Supports_JSON_serialization
 {
+#if NET6_0_OR_GREATER
+    [TestCase("?", "?")]
+    [TestCase("C", "C")]
+    [TestCase("A++", "A++")]
+    public void System_Text_JSON_deserialization(object json, EnergyLabel svo)
+        => JsonTester.Read_System_Text_JSON<EnergyLabel>(json).Should().Be(svo);
+
+    [TestCase("?", "?")]
+    [TestCase("C", "C")]
+    [TestCase("A++", "A++")]
+    public void System_Text_JSON_serialization(EnergyLabel svo, object json)
+        => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+#endif
     [TestCase("?", "unknown")]
     [TestCase("C", "C")]
     [TestCase("A++", "A++")]

--- a/specs/Qowaiv.Specs/Year_specs.cs
+++ b/specs/Qowaiv.Specs/Year_specs.cs
@@ -421,6 +421,10 @@ public class Supports_type_conversion
     }
 
     [Test]
+    public void from_int_0()
+        => Converting.From(0).To<Year>().Should().Be(Year.Empty);
+
+    [Test]
     public void from_int()
         => Converting.From(1979).To<Year>().Should().Be(Svo.Year);
 

--- a/src/Qowaiv.TestTools/Converting.cs
+++ b/src/Qowaiv.TestTools/Converting.cs
@@ -31,11 +31,19 @@ public sealed class ConvertFrom<TFrom>
     /// <summary>Converts the value to the destination type, using its <see cref="TypeConverter"/>.</summary>
     [Pure]
     public To? To<To>()
-#nullable disable // should not be a problem here
-        => typeof(TFrom) == typeof(string)
-        ? (To)Converter<To>().ConvertFromString(Subject as string)
-        : (To)Converter<To>().ConvertFrom(Subject);
-#nullable enable
+    {
+        var converter = Converter<To>();
+
+        if (Subject is { } && !converter.CanConvertFrom(Subject.GetType()))
+        {
+            throw new NotSupportedException($"Converter {converter} can not convert from {Subject}.");
+        }
+        else return typeof(TFrom) == typeof(string)
+            #nullable disable // should not be a problem here
+            ? (To)converter.ConvertFromString(Subject as string)
+            : (To)converter.ConvertFrom(Subject);
+            #nullable enable
+    }
 
     [Pure]
     private static TypeConverter Converter<To>() => TypeDescriptor.GetConverter(typeof(To));

--- a/src/Qowaiv.TestTools/JsonTester.cs
+++ b/src/Qowaiv.TestTools/JsonTester.cs
@@ -21,6 +21,7 @@ public static class JsonTester
             {
                 string str => @$"""{str}""",
                 bool boolean => boolean ? "true" : "false",
+                double dbl => dbl.ToString("0.0###########", CultureInfo.InvariantCulture),
                 IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
                 null => "null",
                 _ => val.ToString() ?? string.Empty,


### PR DESCRIPTION
It turned out that JSON serialization tests for `1.0d` had the same result as `1L`, and that the `ConvertTo` test helper did not touch `CanConvertFrom`. By doing so, the coverage increased. Also added some other tests while in the process.