### PR TITLE
Decorate bool Equals(object) with [NotNullWhen(true)]

### DIFF
--- a/specs/Qowaiv.Specs/SVO_contract_specs.cs
+++ b/specs/Qowaiv.Specs/SVO_contract_specs.cs
@@ -43,7 +43,25 @@ public class Is_decorated_with : SingleValueObjectSpecs
     [TestCaseSource(nameof(AllSvos))]
     public void Open_API_data_type_Legacy(Type svo)
         => svo.Should().BeDecoratedWith<Qowaiv.Json.OpenApiDataTypeAttribute>();
-    
+
+    [TestCaseSource(nameof(AllSvos))]
+    public void NotNullWhen_attribute_on_Equals_object(Type svo)
+    {
+        var equals_object = svo
+            .GetMethods()
+            .Single(m
+                => m.Name == nameof(Equals)
+                && m.GetParameters() is { Length: 1 } p
+                && p[0].ParameterType == typeof(object));
+
+        var attr = equals_object
+            .GetParameters()[0]
+            .GetCustomAttributes<NotNullWhenAttribute>(false)
+            .Single();
+
+        attr.ReturnValue.Should().BeTrue();
+    }
+
     [TestCaseSource(nameof(AllSvosExceptGeneric))]
     public void Open_API_data_type(Type svo)
         => svo.Should().BeDecoratedWith<Qowaiv.OpenApi.OpenApiDataTypeAttribute>();

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -27,7 +27,7 @@ public partial struct Timestamp : IEquatable<Timestamp>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Timestamp other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Timestamp other && Equals(other);
 
     /// <summary>Returns true if this instance and the other timestamp are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Timestamp" /> to compare with.</param>

--- a/src/Qowaiv/Customization/Svo.cs
+++ b/src/Qowaiv/Customization/Svo.cs
@@ -117,7 +117,7 @@ public readonly struct Svo<TSvoBehavior> : IXmlSerializable, IFormattable, IEqua
 
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Svo<TSvoBehavior> other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Svo<TSvoBehavior> other && Equals(other);
 
     /// <summary>Returns true if this instance and the other Single Value Object are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Svo{TSvoBehavior}" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -47,7 +47,7 @@ public partial struct CasRegistryNumber : IEquatable<CasRegistryNumber>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is CasRegistryNumber other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is CasRegistryNumber other && Equals(other);
 
     /// <summary>Returns true if this instance and the other CAS Registry Number are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="CasRegistryNumber" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -18,7 +18,7 @@ public partial struct Date : IEquatable<Date>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Date other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Date other && Equals(other);
 
     /// <summary>Returns true if this instance and the other date are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Date" /> to compare with.</param>

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -27,7 +27,7 @@ public partial struct DateSpan : IEquatable<DateSpan>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is DateSpan other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is DateSpan other && Equals(other);
 
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -47,7 +47,7 @@ public partial struct EmailAddress : IEquatable<EmailAddress>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is EmailAddress other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is EmailAddress other && Equals(other);
 
     /// <summary>Returns true if this instance and the other email address are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="EmailAddress" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -27,7 +27,7 @@ public partial struct Amount : IEquatable<Amount>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Amount other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Amount other && Equals(other);
 
     /// <summary>Returns true if this instance and the other amount are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Amount" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -47,7 +47,7 @@ public partial struct BusinessIdentifierCode : IEquatable<BusinessIdentifierCode
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is BusinessIdentifierCode other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is BusinessIdentifierCode other && Equals(other);
 
     /// <summary>Returns true if this instance and the other BIC are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="BusinessIdentifierCode" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -47,7 +47,7 @@ public partial struct Currency : IEquatable<Currency>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Currency other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Currency other && Equals(other);
 
     /// <summary>Returns true if this instance and the other currency are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Currency" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -47,7 +47,7 @@ public partial struct InternationalBankAccountNumber : IEquatable<InternationalB
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is InternationalBankAccountNumber other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is InternationalBankAccountNumber other && Equals(other);
 
     /// <summary>Returns true if this instance and the other IBAN are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="InternationalBankAccountNumber" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -18,7 +18,7 @@ public partial struct Money : IEquatable<Money>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Money other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Money other && Equals(other);
 
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -47,7 +47,7 @@ public partial struct Gender : IEquatable<Gender>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Gender other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Gender other && Equals(other);
 
     /// <summary>Returns true if this instance and the other gender are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Gender" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -47,7 +47,7 @@ public partial struct Country : IEquatable<Country>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Country other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Country other && Equals(other);
 
     /// <summary>Returns true if this instance and the other country are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Country" /> to compare with.</param>

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -47,7 +47,7 @@ public partial struct HouseNumber : IEquatable<HouseNumber>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is HouseNumber other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is HouseNumber other && Equals(other);
 
     /// <summary>Returns true if this instance and the other house number are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="HouseNumber" /> to compare with.</param>

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -18,7 +18,7 @@ public partial struct StreamSize : IEquatable<StreamSize>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is StreamSize other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is StreamSize other && Equals(other);
 
     /// <summary>Returns true if this instance and the other stream size are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="StreamSize" /> to compare with.</param>

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -18,7 +18,7 @@ public partial struct LocalDateTime : IEquatable<LocalDateTime>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is LocalDateTime other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is LocalDateTime other && Equals(other);
 
     /// <summary>Returns true if this instance and the other local date time are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="LocalDateTime" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -18,7 +18,7 @@ public partial struct Fraction : IEquatable<Fraction>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Fraction other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Fraction other && Equals(other);
 
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -47,7 +47,7 @@ public partial struct Month : IEquatable<Month>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Month other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Month other && Equals(other);
 
     /// <summary>Returns true if this instance and the other month are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Month" /> to compare with.</param>

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -27,7 +27,7 @@ public partial struct MonthSpan : IEquatable<MonthSpan>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is MonthSpan other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is MonthSpan other && Equals(other);
 
     /// <summary>Returns true if this instance and the other month span are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="MonthSpan" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -27,7 +27,7 @@ public partial struct Percentage : IEquatable<Percentage>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Percentage other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Percentage other && Equals(other);
 
     /// <summary>Returns true if this instance and the other percentage are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Percentage" /> to compare with.</param>

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -47,7 +47,7 @@ public partial struct PostalCode : IEquatable<PostalCode>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is PostalCode other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is PostalCode other && Equals(other);
 
     /// <summary>Returns true if this instance and the other postal code are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="PostalCode" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -47,7 +47,7 @@ public partial struct Sex : IEquatable<Sex>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Sex other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Sex other && Equals(other);
 
     /// <summary>Returns true if this instance and the other sex are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Sex" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -27,7 +27,7 @@ public partial struct Elo : IEquatable<Elo>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Elo other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Elo other && Equals(other);
 
     /// <summary>Returns true if this instance and the other elo are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Elo" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
+++ b/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
@@ -47,7 +47,7 @@ public partial struct EnergyLabel : IEquatable<EnergyLabel>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is EnergyLabel other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is EnergyLabel other && Equals(other);
 
     /// <summary>Returns true if this instance and the other EU energy label are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="EnergyLabel" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -35,7 +35,7 @@ public partial struct Uuid : IEquatable<Uuid>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Uuid other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Uuid other && Equals(other);
 
     /// <summary>Returns true if this instance and the other UUID are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Uuid" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -47,7 +47,7 @@ public partial struct InternetMediaType : IEquatable<InternetMediaType>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is InternetMediaType other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is InternetMediaType other && Equals(other);
 
     /// <summary>Returns true if this instance and the other Internet media type are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="InternetMediaType" /> to compare with.</param>
@@ -70,6 +70,9 @@ public partial struct InternetMediaType : IEquatable<InternetMediaType>
 }
 
 public partial struct InternetMediaType : IComparable, IComparable<InternetMediaType>
+#if NET7_0_OR_GREATER
+    , IComparisonOperators<InternetMediaType, InternetMediaType, bool>
+#endif
 {
     /// <inheritdoc />
     [Pure]
@@ -84,6 +87,17 @@ public partial struct InternetMediaType : IComparable, IComparable<InternetMedia
 #nullable disable
     public int CompareTo(InternetMediaType other) => Comparer<string>.Default.Compare(m_Value, other.m_Value);
 #nullable enable
+    /// <summary>Returns true if the left operator is less then the right operator, otherwise false.</summary>
+    public static bool operator <(InternetMediaType l, InternetMediaType r) => l.CompareTo(r) < 0;
+
+    /// <summary>Returns true if the left operator is greater then the right operator, otherwise false.</summary>
+    public static bool operator >(InternetMediaType l, InternetMediaType r) => l.CompareTo(r) > 0;
+
+    /// <summary>Returns true if the left operator is less then or equal the right operator, otherwise false.</summary>
+    public static bool operator <=(InternetMediaType l, InternetMediaType r) => l.CompareTo(r) <= 0;
+
+    /// <summary>Returns true if the left operator is greater then or equal the right operator, otherwise false.</summary>
+    public static bool operator >=(InternetMediaType l, InternetMediaType r) => l.CompareTo(r) >= 0;
 }
 
 public partial struct InternetMediaType : IFormattable

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -18,7 +18,7 @@ public partial struct WeekDate : IEquatable<WeekDate>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is WeekDate other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is WeekDate other && Equals(other);
 
     /// <summary>Returns true if this instance and the other week date are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="WeekDate" /> to compare with.</param>

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -47,7 +47,7 @@ public partial struct Year : IEquatable<Year>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is Year other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Year other && Equals(other);
 
     /// <summary>Returns true if this instance and the other year are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="Year" /> to compare with.</param>

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -47,7 +47,7 @@ public partial struct YesNo : IEquatable<YesNo>
 {
     /// <inheritdoc />
     [Pure]
-    public override bool Equals(object? obj) => obj is YesNo other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is YesNo other && Equals(other);
 
     /// <summary>Returns true if this instance and the other yes-no are equal, otherwise false.</summary>
     /// <param name="other">The <see cref="YesNo" /> to compare with.</param>

--- a/src/Qowaiv/Identifiers/Id.cs
+++ b/src/Qowaiv/Identifiers/Id.cs
@@ -102,7 +102,7 @@ public readonly struct Id<TIdentifier> : IXmlSerializable, IFormattable, IEquata
 
     /// <inheritdoc/>
     [Pure]
-    public override bool Equals(object? obj) => obj is Id<TIdentifier> other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Id<TIdentifier> other && Equals(other);
 
     /// <summary>Returns true if this instance and the other identifier are equal, otherwise false.</summary>
     /// <param name="other">

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,6 +9,7 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 ToBeReleased
+- Decorate bool Equals(object) with [NotNullWhen(true)]. #345
 - TryApplyCustomFormatter should return false if the provider returns null. #341
 - Add Amount.Min() and Amount.Max(). #342
 - Extend API with overloads for DateOnly. #339


### PR DESCRIPTION
To improve the not null validation of the Roslyn compiler, all `bool Equal(object)` methods should be decorated with `[NotNullWhen(true)]`. It allows to compiler to benefit from the method result.