### PR TITLE
Increase Regex amtch time-outs to 50 ms

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -72,6 +72,7 @@ dotnet_diagnostic.SA1308.severity = none # Fields should begin with 'm_' prefix.
 dotnet_diagnostic.SA1309.severity = none # Fields should begin with underscore.
 dotnet_diagnostic.SA1310.severity = none # Fields should not contain underscores.
 dotnet_diagnostic.SA1311.severity = none # Static read-only fields should begin with upper-case character.
+dotnet_diagnostic.SA1501.severity = none # Statement should not be on single line.
 dotnet_diagnostic.SA1502.severity = none # Element should not be on single line.
 dotnet_diagnostic.SA1503.severity = none # Braces should not be omitted.
 dotnet_diagnostic.SA1513.severity = none # Closing brace should be followed by an empty line.
@@ -93,7 +94,6 @@ dotnet_diagnostic.SA1649.severity = none # File name should match first type nam
 dotnet_diagnostic.SA1401.severity = suggestion # Fields should be private.
 dotnet_diagnostic.SA1402.severity = suggestion # File may only contain one type.
 dotnet_diagnostic.SA1407.severity = suggestion # Arithmetic expressions should declare precedence.
-dotnet_diagnostic.SA1501.severity = suggestion # Statement should not be on single line.
 dotnet_diagnostic.SA1512.severity = suggestion # Single-line comment should be followed by blank line.
 dotnet_diagnostic.SA1515.severity = suggestion # Single-line comment should be preceded by blank line.
 

--- a/props/common.props
+++ b/props/common.props
@@ -6,7 +6,7 @@
     <NuGetAudit>true</NuGetAudit>
     <OutputType>library</OutputType>
   </PropertyGroup>
-  
+
   <PropertyGroup Label="Diagnostics">
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <!--
@@ -15,8 +15,7 @@
     -->
     <NoWarn>$(NoWarn);SYSLIB1044</NoWarn>
   </PropertyGroup>
-  
-  
+
   <PropertyGroup>
     <Title>Qowaiv (Single) Value Object library</Title>
     <Description>

--- a/props/common.props
+++ b/props/common.props
@@ -5,8 +5,17 @@
     <IsPublishable>false</IsPublishable>
     <NuGetAudit>true</NuGetAudit>
     <OutputType>library</OutputType>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
+  
+  <PropertyGroup Label="Diagnostics">
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <!--
+      Some warnings can not be configured in the .editor config:
+      SYSLIB1044: The regex generator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation
+    -->
+    <NoWarn>$(NoWarn);SYSLIB1044</NoWarn>
+  </PropertyGroup>
+  
   
   <PropertyGroup>
     <Title>Qowaiv (Single) Value Object library</Title>

--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -17,7 +17,15 @@ public readonly partial struct DateSpan : IXmlSerializable, IFormattable, IEquat
 #endif
 {
     /// <summary>Represents the pattern of a (potential) valid year.</summary>
-    private static readonly Regex Pattern = new(@"^(?<Years>([+-]?[0-9]{1,4}))Y(?<Months>([+-][0-9]{1,6}))M((?<Days>([+-][0-9]{1,7}))D)?$", RegOptions.IgnoreCase, RegOptions.Timeout);
+    private static readonly Regex Pattern = GetPattern();
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"^(?<Years>([+-]?[0-9]{1,4}))Y(?<Months>([+-][0-9]{1,6}))M((?<Days>([+-][0-9]{1,7}))D)?$", RegOptions.IgnoreCase, RegOptions.TimeoutMilliseconds)]
+    private static partial Regex GetPattern();
+#else
+    [Pure]
+    private static Regex GetPattern() => new(@"^(?<Years>([+-]?[0-9]{1,4}))Y(?<Months>([+-][0-9]{1,6}))M((?<Days>([+-][0-9]{1,7}))D)?$", RegOptions.IgnoreCase, RegOptions.Timeout);
+#endif
 
     /// <summary>Represents the zero date span.</summary>
     public static readonly DateSpan Zero;

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -33,7 +33,15 @@ public readonly partial struct BusinessIdentifierCode : IXmlSerializable, IForma
     /// <remarks>
     /// http://www.codeproject.com/KB/recipes/bicRegexValidator.aspx.
     /// </remarks>
-    private static readonly Regex Pattern = new(@"^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$", RegOptions.IgnoreCase, RegOptions.Timeout);
+    private static readonly Regex Pattern = GetPattern();
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$", RegOptions.IgnoreCase, RegOptions.TimeoutMilliseconds)]
+    private static partial Regex GetPattern();
+#else
+    [Pure]
+    private static Regex GetPattern() => new(@"^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$", RegOptions.IgnoreCase, RegOptions.Timeout);
+#endif
 
     /// <summary>Represents an empty/not set BIC.</summary>
     public static readonly BusinessIdentifierCode Empty;

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -1,4 +1,5 @@
 ﻿using Qowaiv.Conversion.IO;
+using Qowaiv.Text;
 using System.IO;
 
 namespace Qowaiv.IO;
@@ -538,11 +539,19 @@ public readonly partial struct StreamSize : IXmlSerializable, IFormattable, IEqu
             _ => sb,
         };
 
-    private static readonly Regex FormattedPattern = new("^(?<format>.*)(?<streamSizeMarker> ?[sSfF]i?)$", RegOptions.RightToLeft, RegOptions.Timeout);
     private static readonly string[] ShortLabels = ["B", "kB", "MB", "GB", "TB", "PB", "EB"];
     private static readonly string[] FullLabels = ["byte", "kilobyte", "Megabyte", "Gigabyte", "Terabyte", "Petabyte", "Exabyte"];
     private static readonly string[] ShortLabels1024 = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
     private static readonly string[] FullLabels1024 = ["byte", "kibibyte", "Mebibyte", "Gibibyte", "Tebibyte", "Pebibyte", "Exbibyte"];
+    private static readonly Regex FormattedPattern = GetFormattedPattern();
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex("^(?<format>.*)(?<streamSizeMarker> ?[sSfF]i?)$", RegOptions.RightToLeft, RegOptions.TimeoutMilliseconds)]
+    private static partial Regex GetFormattedPattern();
+#else
+    [Pure]
+    private static Regex GetFormattedPattern() => new("^(?<format>.*)(?<streamSizeMarker> ?[sSfF]i?)$", RegOptions.RightToLeft, RegOptions.Timeout);
+#endif
 
     /// <summary>Casts a stream size to a System.int.</summary>
     public static explicit operator int(StreamSize val) => (int)val.m_Value;

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -1,5 +1,4 @@
 ﻿using Qowaiv.Conversion.IO;
-using Qowaiv.Text;
 using System.IO;
 
 namespace Qowaiv.IO;

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -46,7 +46,7 @@ public readonly partial struct Fraction : IXmlSerializable, IFormattable, IEquat
     /// <summary>Represents the smallest possible value of a <see cref="Fraction"/>.</summary>
     public static readonly Fraction MinValue = New(-long.MaxValue, 1);
 
-    internal static class Formatting
+    internal static partial class Formatting
     {
         public const string SuperScript = "⁰¹²³⁴⁵⁶⁷⁸⁹";
         public const string SubScript = "₀₁₂₃₄₅₆₇₈₉";
@@ -82,10 +82,18 @@ public readonly partial struct Fraction : IXmlSerializable, IFormattable, IEquat
             LongSlash,
         ]);
 
-        public static readonly Regex Pattern = new(
-            @"^(\[(?<Whole>.+)\] ?)?(?<Numerator>.+?)(?<FractionBars>[/:÷⁄∕̷̸])(?<Denominator>.+)$",
-            RegOptions.Default,
-            RegOptions.Timeout);
+        public static readonly Regex Pattern = GetPattern();
+
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"^(\[(?<Whole>.+)\] ?)?(?<Numerator>.+?)(?<FractionBars>[/:÷⁄∕̷̸])(?<Denominator>.+)$", RegOptions.Default, RegOptions.TimeoutMilliseconds)]
+        private static partial Regex GetPattern();
+#else
+    [Pure]
+    private static Regex GetPattern() => new(
+        @"^(\[(?<Whole>.+)\] ?)?(?<Numerator>.+?)(?<FractionBars>[/:÷⁄∕̷̸])(?<Denominator>.+)$",
+        RegOptions.Default,
+        RegOptions.Timeout);;
+#endif
 
         /// <summary>Returns true if the <see cref="char"/> is a supported fraction bar.</summary>
         [Pure]

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -88,11 +88,11 @@ public readonly partial struct Fraction : IXmlSerializable, IFormattable, IEquat
         [GeneratedRegex(@"^(\[(?<Whole>.+)\] ?)?(?<Numerator>.+?)(?<FractionBars>[/:÷⁄∕̷̸])(?<Denominator>.+)$", RegOptions.Default, RegOptions.TimeoutMilliseconds)]
         private static partial Regex GetPattern();
 #else
-    [Pure]
-    private static Regex GetPattern() => new(
-        @"^(\[(?<Whole>.+)\] ?)?(?<Numerator>.+?)(?<FractionBars>[/:÷⁄∕̷̸])(?<Denominator>.+)$",
-        RegOptions.Default,
-        RegOptions.Timeout);;
+        [Pure]
+        private static Regex GetPattern() => new(
+            @"^(\[(?<Whole>.+)\] ?)?(?<Numerator>.+?)(?<FractionBars>[/:÷⁄∕̷̸])(?<Denominator>.+)$",
+            RegOptions.Default,
+            RegOptions.Timeout);
 #endif
 
         /// <summary>Returns true if the <see cref="char"/> is a supported fraction bar.</summary>

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,6 +9,7 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 ToBeReleased
+- Increase regex timo-out to 50 ms. #346
 - Decorate bool Equals(object) with [NotNullWhen(true)]. #345
 - TryApplyCustomFormatter should return false if the provider returns null. #341
 - Add Amount.Min() and Amount.Max(). #342

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,7 +9,7 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 ToBeReleased
-- Increase regex timo-out to 50 ms. #346
+- Increase regex time-out to 50 ms. #346
 - Decorate bool Equals(object) with [NotNullWhen(true)]. #345
 - TryApplyCustomFormatter should return false if the provider returns null. #341
 - Add Amount.Min() and Amount.Max(). #342

--- a/src/Qowaiv/Text/RegOptions.cs
+++ b/src/Qowaiv/Text/RegOptions.cs
@@ -6,7 +6,7 @@ internal static class RegOptions
 #if DEBUG
     public const int TimeoutMilliseconds = 50;
 #else
-    public const int MatchTimeoutMilliseconds = 100;
+    public const int TimeoutMilliseconds = 100;
 #endif
 
     /// <summary>

--- a/src/Qowaiv/Text/RegOptions.cs
+++ b/src/Qowaiv/Text/RegOptions.cs
@@ -3,15 +3,18 @@
 /// <summary>Centralized place to define <see cref="Regex"/> options.</summary>
 internal static class RegOptions
 {
+#if DEBUG
+    public const int TimeoutMilliseconds = 50;
+#else
+    public const int MatchTimeoutMilliseconds = 100;
+#endif
+
     /// <summary>
     /// To prevent DoS attacks exploiting regular expressions on user input,
-    /// the match time-out is set 1 ms.
+    /// the match time-out is set 50 ms.
     /// </summary>
-#if DEBUG
-    public static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(100);
-#else
-    public static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(10);
-#endif
+    public static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(TimeoutMilliseconds);
+
     public static readonly TimeSpan Replacement = TimeSpan.FromMilliseconds(100);
 
 #if NET7_0_OR_GREATER

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -36,7 +36,15 @@ public readonly partial struct Uuid : IXmlSerializable, IFormattable, IEquatable
     internal const int IndexOfVersion = 7;
 
     /// <summary>Represents the pattern of a (potential) valid GUID.</summary>
-    internal static readonly Regex Pattern = new(@"^[a-zA-Z0-9_-]{22}(=){0,2}$", RegOptions.Default, RegOptions.Timeout);
+    internal static readonly Regex Pattern = GetPattern();
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"^[a-zA-Z0-9_-]{22}(=){0,2}$", RegOptions.Default, RegOptions.TimeoutMilliseconds)]
+    private static partial Regex GetPattern();
+#else
+    [Pure]
+    private static Regex GetPattern() => new(@"^[a-zA-Z0-9_-]{22}(=){0,2}$", RegOptions.Default, RegOptions.Timeout);
+#endif
 
     /// <summary>Represents an empty/not set UUID.</summary>
     public static readonly Uuid Empty;

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -62,7 +62,7 @@ public readonly partial struct InternetMediaType : IXmlSerializable, IFormattabl
         @"(?<Subtype>[a-z0-9]+([\-\.][a-z0-9]+)*)" +
         @"(\+(?<Suffix>(xml|json|ber|der|fastinfoset|wbxml|zip|cbor)))?$",
         RegOptions.IgnoreCase,
-        RegOptions.Timeout)
+        RegOptions.Timeout);
 #endif
 
     /// <summary>Represents an empty/not set Internet media type.</summary>

--- a/src/Qowaiv/Web/InternetMediaType.cs
+++ b/src/Qowaiv/Web/InternetMediaType.cs
@@ -47,12 +47,23 @@ namespace Qowaiv.Web;
 public readonly partial struct InternetMediaType : IXmlSerializable, IFormattable, IEquatable<InternetMediaType>, IComparable, IComparable<InternetMediaType>
 {
     /// <summary>Represents the pattern of a (potential) valid Internet media type.</summary>
-    private static readonly Regex Pattern = new(
+    private static readonly Regex Pattern = GetPattern();
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(
+        @"^(?<TopLevel>(x\-[a-z]+|application|audio|example|image|message|model|multipart|text|video))/" +
+        @"(?<Subtype>[a-z0-9]+([\-\.][a-z0-9]+)*)" +
+        @"(\+(?<Suffix>(xml|json|ber|der|fastinfoset|wbxml|zip|cbor)))?$", RegOptions.IgnoreCase, RegOptions.TimeoutMilliseconds)]
+    private static partial Regex GetPattern();
+#else
+    [Pure]
+    private static Regex GetPattern() => new(
         @"^(?<TopLevel>(x\-[a-z]+|application|audio|example|image|message|model|multipart|text|video))/" +
         @"(?<Subtype>[a-z0-9]+([\-\.][a-z0-9]+)*)" +
         @"(\+(?<Suffix>(xml|json|ber|der|fastinfoset|wbxml|zip|cbor)))?$",
         RegOptions.IgnoreCase,
-        RegOptions.Timeout);
+        RegOptions.Timeout)
+#endif
 
     /// <summary>Represents an empty/not set Internet media type.</summary>
     public static readonly InternetMediaType Empty;

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -43,10 +43,18 @@ public readonly partial struct WeekDate : IXmlSerializable, IFormattable, IEquat
 #endif
 {
     /// <summary>Represents the pattern of a (potential) valid week date.</summary>
-    private static readonly Regex Pattern = new(
+    private static readonly Regex Pattern = GetPattern();
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"^(?<year>[0-9]{1,4})[ -]?W?(?<week>(0?[1-9]|[1-4][0-9]|5[0-3]))[ -]?(?<day>[1-7])$", RegOptions.IgnoreCase, RegOptions.TimeoutMilliseconds)]
+    private static partial Regex GetPattern();
+#else
+    [Pure]
+    private static Regex GetPattern() => new(
         @"^(?<year>[0-9]{1,4})[ -]?W?(?<week>(0?[1-9]|[1-4][0-9]|5[0-3]))[ -]?(?<day>[1-7])$",
         RegOptions.IgnoreCase,
         RegOptions.Timeout);
+#endif
 
     /// <summary>Represents the minimum value of the week date.</summary>
     public static readonly WeekDate MinValue = new(Date.MinValue);


### PR DESCRIPTION
Regular expressions can be challenging thing; in general, Qowaiv tries not te rely on them, but sometimes its hard to avoid. To prevent security issues, time-outs haven set to all regular expressions, but it turns out, those time-outs are a bit too strict:

> Message: 
System.Text.RegularExpressions.RegexMatchTimeoutException : The Regex engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.
>
> Stack Trace: 
RegexRunner.<CheckTimeout>g__ThrowRegexTimeout|25_0()
Regex1_TryMatchAtCurrentPosition(RegexRunner, ReadOnlySpan`1)
Regex1_Scan(RegexRunner, ReadOnlySpan`1)
Regex.ScanInternal(RegexRunnerMode mode, Boolean reuseMatchObject, String input, Int32 beginning, RegexRunner runner, ReadOnlySpan`1 span, Boolean returnNullIfReuseMatchObject)
Regex.RunSingleMatch(RegexRunnerMode mode, Int32 prevlen, String input, Int32 beginning, Int32 length, Int32 startat)
Regex.Match(String input)
StreamSize.ToString(String format, IFormatProvider formatProvider)

Therefore, the time-outs haven been increased from 10 ms to 50 ms, and for .NET 7 and up, the `GeneratedRegex` attribute is used where possible.