### PR TITLE
Allow IBAN's to be defined with an IBAN/IBAN:/(IBAN) prefix

### DIFF
--- a/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
@@ -441,6 +441,9 @@ public class Input_is_invalid_when
     [TestCase("iban : NL20INGB0001234567")]
     [TestCase("(IB AN) NL20INGB0001234567")]
     [TestCase("IBA-N NL20INGB0001234567")]
+    [TestCase("IBAN IBAN NL20INGB0001234567")]
+    [TestCase("(IBAN) IBAN NL20INGB0001234567")]
+    [TestCase("IBAN (IBAN) NL20INGB0001234567")]
     public void string_with_malformed_IBAN_prefix(string str)
         => InternationalBankAccountNumber.TryParse(str).Should().BeNull();
 

--- a/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
@@ -436,6 +436,14 @@ public class Input_is_invalid_when
     public void other_than_alpha_numeric()
         => InternationalBankAccountNumber.TryParse("AE20 #$12 0070 3456 7890 1234 5678").Should().BeNull();
 
+    [TestCase("ibanNL20INGB0001234567")]
+    [TestCase("iban :NL20INGB0001234567")]
+    [TestCase("iban : NL20INGB0001234567")]
+    [TestCase("(IB AN) NL20INGB0001234567")]
+    [TestCase("IBA-N NL20INGB0001234567")]
+    public void string_with_malformed_IBAN_prefix(string str)
+        => InternationalBankAccountNumber.TryParse(str).Should().BeNull();
+
     [TestCase("MU60 BOMM 0835 4151 5881 3959 000A BC")]
     [TestCase("MU53 BOMM 0835 4151 5881 3959 000Z ZZ")]
     public void Mauritius_does_not_end_with_currency_code(string iban)
@@ -461,6 +469,22 @@ public class Input_is_invalid_when
 
 public class Input_is_valid
 {
+    [TestCase("iban NL20INGB0001234567")]
+    [TestCase("iban:NL20INGB0001234567")]
+    [TestCase("iban: NL20INGB0001234567")]
+    [TestCase("(iban)NL20INGB0001234567")]
+    [TestCase("(iban) NL20INGB0001234567")]
+    [TestCase("(Iban) NL20INGB0001234567")]
+    [TestCase("(IBAN) NL20INGB0001234567")]
+    [TestCase("Iban-NL20INGB0001234567")]
+    [TestCase("Iban NL20INGB0001234567")]
+    [TestCase("IBAN NL20INGB0001234567")]
+    [TestCase(" IBAN NL20INGB0001234567")]
+    [TestCase(" IBAN\tNL20INGB0001234567")]
+    [TestCase(" IBAN  NL20INGB0001234567")]
+    public void string_with_IBAN_prefix(string str)
+        => InternationalBankAccountNumber.Parse(str).Should().Be(Svo.Iban);
+
     [TestCase("US70 ABCD 1234")]
     [TestCase("US41 1234 5678 90AB CDEF GHIJ KLMN OPQR")]
     [TestCase("US19 T3NB 32YP 2588 8395 8870 7523 1343 8517")]

--- a/src/Qowaiv/Financial/IbanParser.Bban.cs
+++ b/src/Qowaiv/Financial/IbanParser.Bban.cs
@@ -33,8 +33,12 @@ internal static partial class IbanParser
     [Pure]
     private static int Id(Country country) => ((country.Name[0] - 'A') * 26) + country.Name[1] - 'A';
 
-    private record struct BbanData(int Index, string Pattern)
+    private readonly struct BbanData(int index, string pattern)
     {
+        public readonly int Index = index;
+
+        public readonly string Pattern = pattern;
+
         public readonly string Code => Pattern[..2];
     }
 

--- a/src/Qowaiv/Financial/IbanParser.cs
+++ b/src/Qowaiv/Financial/IbanParser.cs
@@ -14,6 +14,7 @@ internal static partial class IbanParser
         var index = 0;
         var pos = 0;
         var id = 0;
+        var prefixed = false;
 
         while (index < str.Length)
         {
@@ -30,11 +31,12 @@ internal static partial class IbanParser
                 {
                     return bban.Parse(str, index, id);
                 }
-                else if (HasIbanPrefix(id, str, index))
+                else if (!prefixed && HasIbanPrefix(id, str, index))
                 {
                     pos = 0;
                     id = 0;
                     index += 3;
+                    prefixed = true;
                 }
                 else return null;
             }
@@ -42,9 +44,10 @@ internal static partial class IbanParser
             {
                 return null;
             }
-            else if (HasIbanPrefix(str, index))
+            else if (!prefixed && HasIbanPrefix(str, index))
             {
                 index += 5;
+                prefixed = true;
             }
             else if (!IsMarkup(ch))
             {

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,6 +9,7 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 ToBeReleased
+- Support IBAN prefix while parsing. #353
 - Rewrite of IBAN parsing/validation. #351
 - Added the Central African Republic, Russia, and Sudan's IBAN patterns. #349
 - Increase regex time-out to 50 ms. #346


### PR DESCRIPTION
Parsing is about being forgiving on the input. It turns out, that both `"(IBAN) NL20INGB0001234567"`, `"IBAN NL20INGB0001234567"`, and ``"IBAN: NL20INGB0001234567"`` are not uncommon ways of representing IBAN's. Therefor, with this PR, those prefixes are allowed (and removed from) input strings.