### PR TITLE
Extend IBAN with `HumanReadable()` and `MachineReadable()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ var iban = InternationalBankAccountNumber.Parse("nl20ingb0001234567");
 iban.Country; // Country.NL
 iban.Length; // 18
 iban.ToString("F"); // NL20 INGB 0001 2345 67
+iban.ToString("H"); // NL20 INGB 0001 2345 67 (with non-breaking spaces).
 ```
 
 An overview with all supported countries and patterns can be found [here](IBAN.md).

--- a/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
@@ -226,9 +226,16 @@ public class Has_custom_formatting
 
     [TestCase(null, "NL20INGB0001234567", "NL20INGB0001234567")]
     [TestCase("f", "NL20INGB0001234567", "nl20 ingb 0001 2345 67")]
-    [TestCase("F", "NL20INGB0001234567", "NL20 INGB 0001 2345 67")]
+    [TestCase("h", "NL20INGB0001234567", "nl20 ingb 0001 2345 67")]
+    [TestCase("H", "NL20INGB0001234567", "NL20 INGB 0001 2345 67")]
     [TestCase("u", "NL20INGB0001234567", "nl20ingb0001234567")]
     [TestCase("U", "NL20INGB0001234567", "NL20INGB0001234567")]
+    [TestCase("m", "NL20INGB0001234567", "nl20ingb0001234567")]
+    [TestCase("M", "NL20INGB0001234567", "NL20INGB0001234567")]
+    [TestCase("F", "HR1723600001101234565", /*.......*/ "HR17 2360 0001 1012 3456 5")]
+    [TestCase("F", "NL20INGB0001234567", /*..........*/ "NL20 INGB 0001 2345 67")]
+    [TestCase("F", "FR1420041010050500013M02606", /*.*/ "FR14 2004 1010 0505 0001 3M02 606")]
+    [TestCase("F", "EE382200221020145685", /*........*/ "EE38 2200 2210 2014 5685")]
     [TestCase("F", "", "")]
     [TestCase("F", "?", "?")]
     public void with_format(string format, InternationalBankAccountNumber svo, string formatted)

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -89,11 +89,21 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     /// expressed in groups of four characters separated by spaces, the last
     /// group being of variable length.
     /// </summary>
+    /// <remarks>
+    /// Uses non-breaking spaces to prevent unintended line-breaks.
+    /// </remarks>
+    [Pure]
+    public string HumanReadable() => HumanReadable((char)0160);
+
+    /// <summary>In order to facilitate reading by humans, an IBAN can be
+    /// expressed in groups of four characters separated by spaces, the last
+    /// group being of variable length.
+    /// </summary>
     /// <param name="space">
-    /// The spacing character to apply, non-breaking space by default.
+    /// The spacing character to apply.
     /// </param>
     [Pure]
-    public string HumanReadable(char space = (char)0160)
+    public string HumanReadable(char space)
     {
         if (m_Value == default)
         {

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -115,9 +115,11 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
         }
         else
         {
-            var buffer = new char[m_Value.Length + (m_Value.Length - 1) / 4];
-            var pointer = 0;
             var index = 0;
+            var pointer = 0;
+            var spacing = (m_Value.Length - 1) / 4;
+            var buffer = new char[m_Value.Length + spacing];
+
             while (index < m_Value.Length)
             {
                 buffer[pointer++] = m_Value[index++];

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -61,15 +61,15 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     /// The serialized JSON string.
     /// </returns>
     [Pure]
-    public string? ToJson() => m_Value == default ? null : ToUnformattedString();
+    public string? ToJson() => m_Value == default ? null : MachineReadable();
 
     /// <summary>Returns a <see cref="string"/> that represents the current IBAN for debug purposes.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => this.DebuggerDisplay("{0:F}");
 
-    /// <summary>Formats the IBAN without spaces.</summary>
+    /// <summary>Represents the IBAN a string without formatting.</summary>
     [Pure]
-    private string ToUnformattedString()
+    public string MachineReadable()
     {
         if (m_Value == default)
         {
@@ -85,38 +85,40 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
         }
     }
 
-    /// <summary>Formats the IBAN without spaces as lowercase.</summary>
+    /// <summary>In order to facilitate reading by humans, an IBAN can be
+    /// expressed in groups of four characters separated by spaces, the last
+    /// group being of variable length.
+    /// </summary>
+    /// <param name="space">
+    /// The spacing character to apply, non-breaking space by default.
+    /// </param>
     [Pure]
-    private string ToUnformattedLowercaseString() => ToUnformattedString().ToLowerInvariant();
-
-    /// <summary>Formats the IBAN with spaces.</summary>
-    [Pure]
-    private string ToFormattedString()
+    public string HumanReadable(char space = (char)0160)
     {
         if (m_Value == default)
         {
             return string.Empty;
         }
-        if (m_Value == Unknown.m_Value)
+        else if (m_Value == Unknown.m_Value)
         {
             return "?";
         }
-        return string.Join(" ", Chunk(m_Value));
-
-        static IEnumerable<string> Chunk(string str)
+        else
         {
-            for (var i = 0; i < str.Length; i += 4)
+            var buffer = new char[m_Value.Length + (m_Value.Length - 1) / 4];
+            var pointer = 0;
+            var index = 0;
+            while (index < m_Value.Length)
             {
-                yield return str.Length - i > 4
-                    ? str.Substring(i, 4)
-                    : str[i..];
+                buffer[pointer++] = m_Value[index++];
+                if ((index % 4) == 0 && pointer < buffer.Length)
+                {
+                    buffer[pointer++] = space;
+                }
             }
+            return new(buffer);
         }
     }
-
-    /// <summary>Formats the IBAN with spaces as lowercase.</summary>
-    [Pure]
-    private string ToFormattedLowercaseString() => ToFormattedString().ToLowerInvariant();
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the current IBAN.</summary>
     /// <param name="format">
@@ -127,9 +129,12 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     /// </param>
     /// <remarks>
     /// The formats:
-    ///
-    /// u: as unformatted lowercase.
-    /// U: as unformatted uppercase.
+    /// m: as machine readable lowercase.
+    /// M: as machine readable.
+    /// u: as unformatted lowercase (equal to machine readable lowercase).
+    /// U: as unformatted uppercase  (equal to machine readable).
+    /// h: as human readable lowercase (with non-breaking spaces).
+    /// H: as human readable (equal to machine readable).
     /// f: as formatted lowercase.
     /// F: as formatted uppercase.
     /// </remarks>
@@ -142,15 +147,19 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     /// <summary>The format token instructions.</summary>
     private static readonly Dictionary<char, Func<InternationalBankAccountNumber, IFormatProvider, string>> FormatTokens = new()
     {
-        { 'u', (svo, _) => svo.ToUnformattedLowercaseString() },
-        { 'U', (svo, _) => svo.ToUnformattedString() },
-        { 'f', (svo, _) => svo.ToFormattedLowercaseString() },
-        { 'F', (svo, _) => svo.ToFormattedString() },
+        { 'u', (svo, _) => svo.MachineReadable().ToLowerInvariant() },
+        { 'U', (svo, _) => svo.MachineReadable() },
+        { 'm', (svo, _) => svo.MachineReadable().ToLowerInvariant() },
+        { 'M', (svo, _) => svo.MachineReadable() },
+        { 'h', (svo, _) => svo.HumanReadable(' ').ToLowerInvariant() },
+        { 'H', (svo, _) => svo.HumanReadable(' ') },
+        { 'f', (svo, _) => svo.HumanReadable(' ').ToLowerInvariant() },
+        { 'F', (svo, _) => svo.HumanReadable(' ') },
     };
 
     /// <summary>Gets an XML string representation of the IBAN.</summary>
     [Pure]
-    private string ToXmlString() => ToUnformattedString();
+    private string ToXmlString() => MachineReadable();
 
     /// <summary>Converts the string to an IBAN.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -67,7 +67,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => this.DebuggerDisplay("{0:F}");
 
-    /// <summary>Represents the IBAN a string without formatting.</summary>
+    /// <summary>Represents the IBAN as a <see cref="string"/> without formatting.</summary>
     [Pure]
     public string MachineReadable()
     {
@@ -85,10 +85,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
         }
     }
 
-    /// <summary>In order to facilitate reading by humans, an IBAN can be
-    /// expressed in groups of four characters separated by spaces, the last
-    /// group being of variable length.
-    /// </summary>
+    /// <inheritdoc cref="HumanReadable(char)" />
     /// <remarks>
     /// Uses non-breaking spaces to prevent unintended line-breaks.
     /// </remarks>

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,6 +9,7 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 ToBeReleased
+- Add HumanReadable() and MachineReadable() methods to IBAN. #354
 - Rewrite of IBAN parsing/validation. #351
 - Added the Central African Republic, Russia, and Sudan's IBAN patterns. #349
 - Increase regex time-out to 50 ms. #346


### PR DESCRIPTION
The terms  **Human Readable** and **Machine Readable** are part of the IBAN domain. Hence the decision to make methods with these names publicly accessible. To prevent unintended line-breaks within an IBAN, `HumanReadable()` uses non-breaking spaces by default.  Added `h`, `H`, `m`, and `M` as formatting arguments.