### PR TITLE
Align Parse and TryParse provider naming with IParsable

### DIFF
--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -184,7 +184,7 @@ public partial struct Timestamp
     /// <param name="s">
     /// A string containing the timestamp to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -194,8 +194,8 @@ public partial struct Timestamp
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Timestamp Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Timestamp Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Timestamp>(s, QowaivMessages.FormatExceptionTimestamp);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
@@ -212,14 +212,14 @@ public partial struct Timestamp
     /// <param name="s">
     /// A string containing the timestamp to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The timestamp if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Timestamp? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Timestamp?);
+    public static Timestamp? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Timestamp?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv.Data.SqlClient/Qowaiv.Data.SqlClient.csproj
+++ b/src/Qowaiv.Data.SqlClient/Qowaiv.Data.SqlClient.csproj
@@ -9,7 +9,7 @@
     <PackageId>Qowaiv.Data.SqlClient</PackageId>
     <PackageReleaseNotes>
 v7.0.0
-- Drop support for .NET 5 and .NET 7 STS's.
+- Drop support for .NET 5 and .NET 7 STS's. #359 (breaking)
 v6.4.0
 - Support .NET 7.0. #261
 - Regular expressions are culture invariant. #285

--- a/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
+++ b/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
@@ -104,7 +104,7 @@ public readonly partial struct Timestamp : IXmlSerializable, IFormattable, IEqua
     /// <param name="s">
     /// A string containing a timestamp to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -113,17 +113,17 @@ public readonly partial struct Timestamp : IXmlSerializable, IFormattable, IEqua
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Timestamp result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Timestamp result)
     {
         result = default;
         if (s is not { Length: > 0 }) { return false; }
         if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
-            ulong.TryParse(s[2..], NumberStyles.HexNumber, formatProvider, out var val))
+            ulong.TryParse(s[2..], NumberStyles.HexNumber, provider, out var val))
         {
             result = Create(val);
             return true;
         }
-        else if (ulong.TryParse(s, NumberStyles.Number, formatProvider, out val))
+        else if (ulong.TryParse(s, NumberStyles.Number, provider, out val))
         {
             result = new Timestamp(val);
             return true;

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -9,7 +9,7 @@
     <PackageId>Qowaiv.TestTools</PackageId>
     <PackageReleaseNotes>
 v7.0.0
-- Drop support for .NET 5 and .NET 7 STS's.
+- Drop support for .NET 5 and .NET 7 STS's. #359 (breaking)
 - TestCultures properties lowercased. (breaking)
 - No Serializer.Binary for .NET 8. (breaking)
 - Introduction of the EmptyTestClass attribute.

--- a/src/Qowaiv/Chemistry/CasRegistryNumber.cs
+++ b/src/Qowaiv/Chemistry/CasRegistryNumber.cs
@@ -94,7 +94,7 @@ public readonly partial struct CasRegistryNumber : IXmlSerializable, IFormattabl
     /// <param name="s">
     /// A string containing the CAS Registry Number to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -104,7 +104,7 @@ public readonly partial struct CasRegistryNumber : IXmlSerializable, IFormattabl
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
     [Pure]
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out CasRegistryNumber result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out CasRegistryNumber result)
     {
         result = default;
         var str = s.Unify();
@@ -112,7 +112,7 @@ public readonly partial struct CasRegistryNumber : IXmlSerializable, IFormattabl
         {
             return true;
         }
-        else if (Qowaiv.Unknown.IsUnknown(str, formatProvider as CultureInfo))
+        else if (Qowaiv.Unknown.IsUnknown(str, provider as CultureInfo))
         {
             result = Unknown;
             return true;

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -489,7 +489,7 @@ public readonly partial struct Date : IXmlSerializable, IFormattable, IEquatable
     /// <param name="s">
     /// A string containing a Date to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -498,8 +498,8 @@ public readonly partial struct Date : IXmlSerializable, IFormattable, IEquatable
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Date result)
-        => TryParse(s, formatProvider, DateTimeStyles.None, out result);
+    public static bool TryParse(string? s, IFormatProvider? provider, out Date result)
+        => TryParse(s, provider, DateTimeStyles.None, out result);
 
     /// <summary>Converts the string to a date.
     /// A return value indicates whether the conversion succeeded.
@@ -507,7 +507,7 @@ public readonly partial struct Date : IXmlSerializable, IFormattable, IEquatable
     /// <param name="s">
     /// A string containing a Date to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="styles">
@@ -521,9 +521,9 @@ public readonly partial struct Date : IXmlSerializable, IFormattable, IEquatable
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, DateTimeStyles styles, out Date result)
+    public static bool TryParse(string? s, IFormatProvider? provider, DateTimeStyles styles, out Date result)
     {
-        if (DateTime.TryParse(s, formatProvider, styles, out DateTime dt))
+        if (DateTime.TryParse(s, provider, styles, out DateTime dt))
         {
             result = new Date(dt);
             return true;

--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -361,7 +361,7 @@ public readonly partial struct DateSpan : IXmlSerializable, IFormattable, IEquat
     /// <param name="s">
     /// A string containing a date span to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -370,7 +370,7 @@ public readonly partial struct DateSpan : IXmlSerializable, IFormattable, IEquat
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out DateSpan result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out DateSpan result)
     {
         result = default;
 
@@ -383,9 +383,9 @@ public readonly partial struct DateSpan : IXmlSerializable, IFormattable, IEquat
 
         if (match.Success)
         {
-            var y = IntFromGroup(match, nameof(Years), formatProvider);
-            var m = IntFromGroup(match, nameof(Months), formatProvider);
-            var d = IntFromGroup(match, nameof(Days), formatProvider);
+            var y = IntFromGroup(match, nameof(Years), provider);
+            var m = IntFromGroup(match, nameof(Months), provider);
+            var d = IntFromGroup(match, nameof(Days), provider);
 
             var months = (y * 12) + m;
             var totalDays = d + (months * DaysPerMonth);

--- a/src/Qowaiv/EmailAddress.cs
+++ b/src/Qowaiv/EmailAddress.cs
@@ -141,7 +141,7 @@ public readonly partial struct EmailAddress : IXmlSerializable, IFormattable, IE
     /// <param name="s">
     /// A string containing an email address to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -150,14 +150,14 @@ public readonly partial struct EmailAddress : IXmlSerializable, IFormattable, IE
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out EmailAddress result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out EmailAddress result)
     {
         result = default;
         if (string.IsNullOrEmpty(s))
         {
             return true;
         }
-        else if (Qowaiv.Unknown.IsUnknown(s, formatProvider as CultureInfo))
+        else if (Qowaiv.Unknown.IsUnknown(s, provider as CultureInfo))
         {
             result = Unknown;
             return true;

--- a/src/Qowaiv/EmailAddressCollection.cs
+++ b/src/Qowaiv/EmailAddressCollection.cs
@@ -301,7 +301,7 @@ public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSer
     /// <param name="s">
     /// A string containing an email address to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -311,8 +311,8 @@ public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSer
     /// s is not in the correct format.
     /// </exception>
     [Pure]
-    public static EmailAddressCollection Parse(string? s, IFormatProvider? formatProvider)
-        => TryParse(s, formatProvider, out EmailAddressCollection val)
+    public static EmailAddressCollection Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out EmailAddressCollection val)
         ? val
         : throw Unparsable.ForValue<EmailAddressCollection>(s, QowaivMessages.FormatExceptionEmailAddressCollection);
 
@@ -358,7 +358,7 @@ public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSer
     /// <param name="s">
     /// A string containing an email address to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -367,7 +367,7 @@ public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSer
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out EmailAddressCollection result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out EmailAddressCollection result)
     {
         result = [];
         if (s is { Length: > 0 })
@@ -375,7 +375,7 @@ public class EmailAddressCollection : ISet<EmailAddress>, ISerializable, IXmlSer
             var strs = s.Split(Separators, StringSplitOptions.RemoveEmptyEntries).Select(str => str.Trim());
             foreach (var str in strs)
             {
-                if (EmailAddress.TryParse(str, formatProvider, out EmailAddress email))
+                if (EmailAddress.TryParse(str, provider, out EmailAddress email))
                 {
                     result.Add(email);
                 }

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -523,7 +523,7 @@ public readonly partial struct Amount : IXmlSerializable, IFormattable, IEquatab
     /// <param name="s">
     /// A string containing an Amount to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -532,10 +532,10 @@ public readonly partial struct Amount : IXmlSerializable, IFormattable, IEquatab
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Amount result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Amount result)
     {
         result = default;
-        if (Money.TryParse(s, formatProvider, out Money money))
+        if (Money.TryParse(s, provider, out Money money))
         {
             result = (Amount)(decimal)money;
             return true;

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -115,7 +115,7 @@ public readonly partial struct BusinessIdentifierCode : IXmlSerializable, IForma
     /// <param name="s">
     /// A string containing a BIC to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -124,7 +124,7 @@ public readonly partial struct BusinessIdentifierCode : IXmlSerializable, IForma
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out BusinessIdentifierCode result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out BusinessIdentifierCode result)
     {
         result = default;
         var str = s.Unify();
@@ -132,7 +132,7 @@ public readonly partial struct BusinessIdentifierCode : IXmlSerializable, IForma
         {
             return true;
         }
-        else if (str.IsUnknown(formatProvider))
+        else if (str.IsUnknown(provider))
         {
             result = Unknown;
             return true;

--- a/src/Qowaiv/Financial/Currency.cs
+++ b/src/Qowaiv/Financial/Currency.cs
@@ -192,7 +192,7 @@ public readonly partial struct Currency : IXmlSerializable, IFormattable, IForma
     /// <param name="s">
     /// A string containing a currency to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -201,7 +201,7 @@ public readonly partial struct Currency : IXmlSerializable, IFormattable, IForma
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Currency result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Currency result)
     {
         result = Empty;
         var str = s.Unify();
@@ -209,12 +209,12 @@ public readonly partial struct Currency : IXmlSerializable, IFormattable, IForma
         {
             return true;
         }
-        else if (str.IsUnknown(formatProvider) || str.Equals(Unknown.Symbol))
+        else if (str.IsUnknown(provider) || str.Equals(Unknown.Symbol))
         {
             result = Unknown;
             return true;
         }
-        else if (ParseValues.TryGetValue(formatProvider, str, out var val))
+        else if (ParseValues.TryGetValue(provider, str, out var val))
         {
             result = new Currency(val);
             return true;

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -176,7 +176,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     /// <param name="s">
     /// A string containing an IBAN to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -185,7 +185,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out InternationalBankAccountNumber result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out InternationalBankAccountNumber result)
     {
         result = default;
 
@@ -201,7 +201,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
             {
                 return true;
             }
-            if (str.IsUnknown(formatProvider))
+            if (str.IsUnknown(provider))
             {
                 result = Unknown;
                 return true;

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -539,7 +539,7 @@ public readonly partial struct Money : IXmlSerializable, IFormattable, IEquatabl
     /// <param name="s">
     /// A string containing Money to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -548,12 +548,12 @@ public readonly partial struct Money : IXmlSerializable, IFormattable, IEquatabl
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Money result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Money result)
     {
         result = default;
 
         var currency = Currency.Empty;
-        var signs = formatProvider.NegativeSign() + formatProvider.PositiveSign();
+        var signs = provider.NegativeSign() + provider.PositiveSign();
         var span = s.CharSpan().TrimLeft(ch => CandidateCurrency(ch, signs), out var candidate);
 
         if (candidate.IsEmpty())
@@ -562,7 +562,7 @@ public readonly partial struct Money : IXmlSerializable, IFormattable, IEquatabl
         }
 
         if ((candidate.IsEmpty() || Currency.TryParse(candidate.ToString(), out currency))
-            && decimal.TryParse(span.ToString(), NumberStyles.Currency, formatProvider, out var amount))
+            && decimal.TryParse(span.ToString(), NumberStyles.Currency, provider, out var amount))
         {
             result = amount + currency;
             return true;

--- a/src/Qowaiv/Gender.cs
+++ b/src/Qowaiv/Gender.cs
@@ -166,7 +166,7 @@ public readonly partial struct Gender : IXmlSerializable, IFormattable, IEquatab
     /// <param name="s">
     /// A string containing a Gender to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -175,7 +175,7 @@ public readonly partial struct Gender : IXmlSerializable, IFormattable, IEquatab
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Gender result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Gender result)
     {
         result = Empty;
         var str = s.Unify();
@@ -186,7 +186,7 @@ public readonly partial struct Gender : IXmlSerializable, IFormattable, IEquatab
         }
         else
         {
-            var c = formatProvider as CultureInfo ?? CultureInfo.CurrentCulture;
+            var c = provider as CultureInfo ?? CultureInfo.CurrentCulture;
             AddCulture(c);
             if (Parsings[c].TryGetValue(str, out byte val) ||
                 Parsings[CultureInfo.InvariantCulture].TryGetValue(str, out val))

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -190,7 +190,7 @@ public partial struct CasRegistryNumber
     /// <param name="s">
     /// A string containing the CAS Registry Number to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct CasRegistryNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static CasRegistryNumber Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static CasRegistryNumber Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<CasRegistryNumber>(s, QowaivMessages.FormatExceptionCasRegistryNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="CasRegistryNumber"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct CasRegistryNumber
     /// <param name="s">
     /// A string containing the CAS Registry Number to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The CAS Registry Number if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static CasRegistryNumber? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(CasRegistryNumber?);
+    public static CasRegistryNumber? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(CasRegistryNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="CasRegistryNumber"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -175,7 +175,7 @@ public partial struct Date
     /// <param name="s">
     /// A string containing the date to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -185,8 +185,8 @@ public partial struct Date
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Date Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Date Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Date>(s, QowaivMessages.FormatExceptionDate);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
@@ -203,14 +203,14 @@ public partial struct Date
     /// <param name="s">
     /// A string containing the date to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The date if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Date? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Date?);
+    public static Date? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Date?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -170,7 +170,7 @@ public partial struct DateSpan
     /// <param name="s">
     /// A string containing the date span to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -180,8 +180,8 @@ public partial struct DateSpan
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static DateSpan Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static DateSpan Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<DateSpan>(s, QowaivMessages.FormatExceptionDateSpan);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
@@ -198,14 +198,14 @@ public partial struct DateSpan
     /// <param name="s">
     /// A string containing the date span to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The date span if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static DateSpan? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(DateSpan?);
+    public static DateSpan? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(DateSpan?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -190,7 +190,7 @@ public partial struct EmailAddress
     /// <param name="s">
     /// A string containing the email address to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct EmailAddress
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static EmailAddress Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static EmailAddress Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<EmailAddress>(s, QowaivMessages.FormatExceptionEmailAddress);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct EmailAddress
     /// <param name="s">
     /// A string containing the email address to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The email address if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static EmailAddress? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(EmailAddress?);
+    public static EmailAddress? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(EmailAddress?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -184,7 +184,7 @@ public partial struct Amount
     /// <param name="s">
     /// A string containing the amount to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -194,8 +194,8 @@ public partial struct Amount
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Amount Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Amount Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Amount>(s, QowaivMessages.FormatExceptionFinancialAmount);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
@@ -212,14 +212,14 @@ public partial struct Amount
     /// <param name="s">
     /// A string containing the amount to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The amount if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Amount? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Amount?);
+    public static Amount? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Amount?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -190,7 +190,7 @@ public partial struct BusinessIdentifierCode
     /// <param name="s">
     /// A string containing the BIC to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct BusinessIdentifierCode
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static BusinessIdentifierCode Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static BusinessIdentifierCode Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<BusinessIdentifierCode>(s, QowaivMessages.FormatExceptionBusinessIdentifierCode);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct BusinessIdentifierCode
     /// <param name="s">
     /// A string containing the BIC to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The BIC if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static BusinessIdentifierCode? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(BusinessIdentifierCode?);
+    public static BusinessIdentifierCode? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(BusinessIdentifierCode?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -190,7 +190,7 @@ public partial struct Currency
     /// <param name="s">
     /// A string containing the currency to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct Currency
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Currency Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Currency Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Currency>(s, QowaivMessages.FormatExceptionCurrency);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct Currency
     /// <param name="s">
     /// A string containing the currency to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The currency if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Currency? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Currency?);
+    public static Currency? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Currency?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -190,7 +190,7 @@ public partial struct InternationalBankAccountNumber
     /// <param name="s">
     /// A string containing the IBAN to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct InternationalBankAccountNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static InternationalBankAccountNumber Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static InternationalBankAccountNumber Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<InternationalBankAccountNumber>(s, QowaivMessages.FormatExceptionInternationalBankAccountNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct InternationalBankAccountNumber
     /// <param name="s">
     /// A string containing the IBAN to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The IBAN if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static InternationalBankAccountNumber? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(InternationalBankAccountNumber?);
+    public static InternationalBankAccountNumber? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(InternationalBankAccountNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -140,7 +140,7 @@ public partial struct Money
     /// <param name="s">
     /// A string containing the money to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -150,8 +150,8 @@ public partial struct Money
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Money Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Money Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Money>(s, QowaivMessages.FormatExceptionMoney);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
@@ -168,14 +168,14 @@ public partial struct Money
     /// <param name="s">
     /// A string containing the money to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The money if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Money? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Money?);
+    public static Money? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Money?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Gender.generated.cs
+++ b/src/Qowaiv/Generated/Gender.generated.cs
@@ -190,7 +190,7 @@ public partial struct Gender
     /// <param name="s">
     /// A string containing the gender to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct Gender
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Gender Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Gender Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Gender>(s, QowaivMessages.FormatExceptionGender);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Gender"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct Gender
     /// <param name="s">
     /// A string containing the gender to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The gender if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Gender? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Gender?);
+    public static Gender? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Gender?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Gender"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -190,7 +190,7 @@ public partial struct Country
     /// <param name="s">
     /// A string containing the country to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct Country
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Country Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Country Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Country>(s, QowaivMessages.FormatExceptionCountry);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct Country
     /// <param name="s">
     /// A string containing the country to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The country if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Country? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Country?);
+    public static Country? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Country?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -204,7 +204,7 @@ public partial struct HouseNumber
     /// <param name="s">
     /// A string containing the house number to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -214,8 +214,8 @@ public partial struct HouseNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static HouseNumber Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static HouseNumber Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<HouseNumber>(s, QowaivMessages.FormatExceptionHouseNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
@@ -232,14 +232,14 @@ public partial struct HouseNumber
     /// <param name="s">
     /// A string containing the house number to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The house number if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static HouseNumber? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(HouseNumber?);
+    public static HouseNumber? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(HouseNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -154,7 +154,7 @@ public partial struct StreamSize
     /// <param name="s">
     /// A string containing the stream size to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -164,8 +164,8 @@ public partial struct StreamSize
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static StreamSize Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static StreamSize Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<StreamSize>(s, QowaivMessages.FormatExceptionStreamSize);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
@@ -182,14 +182,14 @@ public partial struct StreamSize
     /// <param name="s">
     /// A string containing the stream size to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The stream size if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static StreamSize? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(StreamSize?);
+    public static StreamSize? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(StreamSize?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -175,7 +175,7 @@ public partial struct LocalDateTime
     /// <param name="s">
     /// A string containing the local date time to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -185,8 +185,8 @@ public partial struct LocalDateTime
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static LocalDateTime Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static LocalDateTime Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<LocalDateTime>(s, QowaivMessages.FormatExceptionLocalDateTime);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
@@ -203,14 +203,14 @@ public partial struct LocalDateTime
     /// <param name="s">
     /// A string containing the local date time to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The local date time if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static LocalDateTime? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(LocalDateTime?);
+    public static LocalDateTime? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(LocalDateTime?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -140,7 +140,7 @@ public partial struct Fraction
     /// <param name="s">
     /// A string containing the fraction to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -150,8 +150,8 @@ public partial struct Fraction
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Fraction Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Fraction Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Fraction>(s, QowaivMessages.FormatExceptionFraction);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
@@ -168,14 +168,14 @@ public partial struct Fraction
     /// <param name="s">
     /// A string containing the fraction to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The fraction if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Fraction? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Fraction?);
+    public static Fraction? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Fraction?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -190,7 +190,7 @@ public partial struct Month
     /// <param name="s">
     /// A string containing the month to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct Month
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Month Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Month Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Month>(s, QowaivMessages.FormatExceptionMonth);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct Month
     /// <param name="s">
     /// A string containing the month to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The month if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Month? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Month?);
+    public static Month? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Month?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -184,7 +184,7 @@ public partial struct MonthSpan
     /// <param name="s">
     /// A string containing the month span to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -194,8 +194,8 @@ public partial struct MonthSpan
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static MonthSpan Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static MonthSpan Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<MonthSpan>(s, QowaivMessages.FormatExceptionMonthSpan);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
@@ -212,14 +212,14 @@ public partial struct MonthSpan
     /// <param name="s">
     /// A string containing the month span to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The month span if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static MonthSpan? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(MonthSpan?);
+    public static MonthSpan? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(MonthSpan?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -184,7 +184,7 @@ public partial struct Percentage
     /// <param name="s">
     /// A string containing the percentage to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -194,8 +194,8 @@ public partial struct Percentage
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Percentage Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Percentage Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Percentage>(s, QowaivMessages.FormatExceptionPercentage);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
@@ -212,14 +212,14 @@ public partial struct Percentage
     /// <param name="s">
     /// A string containing the percentage to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The percentage if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Percentage? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Percentage?);
+    public static Percentage? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Percentage?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -190,7 +190,7 @@ public partial struct PostalCode
     /// <param name="s">
     /// A string containing the postal code to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct PostalCode
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static PostalCode Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static PostalCode Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<PostalCode>(s, QowaivMessages.FormatExceptionPostalCode);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct PostalCode
     /// <param name="s">
     /// A string containing the postal code to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The postal code if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static PostalCode? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(PostalCode?);
+    public static PostalCode? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(PostalCode?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -190,7 +190,7 @@ public partial struct Sex
     /// <param name="s">
     /// A string containing the sex to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct Sex
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Sex Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Sex Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Sex>(s, QowaivMessages.FormatExceptionSex);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct Sex
     /// <param name="s">
     /// A string containing the sex to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The sex if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Sex? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Sex?);
+    public static Sex? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Sex?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -184,7 +184,7 @@ public partial struct Elo
     /// <param name="s">
     /// A string containing the elo to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -194,8 +194,8 @@ public partial struct Elo
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Elo Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Elo Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Elo>(s, QowaivMessages.FormatExceptionElo);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
@@ -212,14 +212,14 @@ public partial struct Elo
     /// <param name="s">
     /// A string containing the elo to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The elo if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Elo? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Elo?);
+    public static Elo? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Elo?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
+++ b/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
@@ -190,7 +190,7 @@ public partial struct EnergyLabel
     /// <param name="s">
     /// A string containing the EU energy label to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct EnergyLabel
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static EnergyLabel Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static EnergyLabel Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<EnergyLabel>(s, QowaivMessages.FormatExceptionEnergyLabel);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EnergyLabel"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct EnergyLabel
     /// <param name="s">
     /// A string containing the EU energy label to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The EU energy label if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static EnergyLabel? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(EnergyLabel?);
+    public static EnergyLabel? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(EnergyLabel?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EnergyLabel"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -178,7 +178,7 @@ public partial struct Uuid
     /// <param name="s">
     /// A string containing the UUID to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -188,8 +188,8 @@ public partial struct Uuid
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Uuid Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Uuid Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Uuid>(s, QowaivMessages.FormatExceptionUuid);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
@@ -206,14 +206,14 @@ public partial struct Uuid
     /// <param name="s">
     /// A string containing the UUID to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The UUID if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Uuid? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Uuid?);
+    public static Uuid? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Uuid?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -204,7 +204,7 @@ public partial struct InternetMediaType
     /// <param name="s">
     /// A string containing the Internet media type to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -214,8 +214,8 @@ public partial struct InternetMediaType
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static InternetMediaType Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static InternetMediaType Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<InternetMediaType>(s, QowaivMessages.FormatExceptionInternetMediaType);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
@@ -232,14 +232,14 @@ public partial struct InternetMediaType
     /// <param name="s">
     /// A string containing the Internet media type to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The Internet media type if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static InternetMediaType? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(InternetMediaType?);
+    public static InternetMediaType? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(InternetMediaType?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -154,7 +154,7 @@ public partial struct WeekDate
     /// <param name="s">
     /// A string containing the week date to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -164,8 +164,8 @@ public partial struct WeekDate
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static WeekDate Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static WeekDate Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<WeekDate>(s, QowaivMessages.FormatExceptionWeekDate);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
@@ -182,14 +182,14 @@ public partial struct WeekDate
     /// <param name="s">
     /// A string containing the week date to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The week date if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static WeekDate? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(WeekDate?);
+    public static WeekDate? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(WeekDate?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -190,7 +190,7 @@ public partial struct Year
     /// <param name="s">
     /// A string containing the year to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct Year
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Year Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static Year Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<Year>(s, QowaivMessages.FormatExceptionYear);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct Year
     /// <param name="s">
     /// A string containing the year to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The year if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Year? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(Year?);
+    public static Year? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Year?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -190,7 +190,7 @@ public partial struct YesNo
     /// <param name="s">
     /// A string containing the yes-no to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
@@ -200,8 +200,8 @@ public partial struct YesNo
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static YesNo Parse(string? s, IFormatProvider? formatProvider) 
-        => TryParse(s, formatProvider) 
+    public static YesNo Parse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider) 
         ?? throw Unparsable.ForValue<YesNo>(s, QowaivMessages.FormatExceptionYesNo);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
@@ -218,14 +218,14 @@ public partial struct YesNo
     /// <param name="s">
     /// A string containing the yes-no to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <returns>
     /// The yes-no if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static YesNo? TryParse(string? s, IFormatProvider? formatProvider) => TryParse(s, formatProvider, out var val) ? val : default(YesNo?);
+    public static YesNo? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(YesNo?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -225,7 +225,7 @@ public readonly partial struct Country : IXmlSerializable, IFormattable, IEquata
     /// <param name="s">
     /// A string containing a Country to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The format provider.
     /// </param>
     /// <param name="result">
@@ -234,7 +234,7 @@ public readonly partial struct Country : IXmlSerializable, IFormattable, IEquata
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Country result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Country result)
     {
         result = Empty;
         var str = s.Unify();
@@ -242,12 +242,12 @@ public readonly partial struct Country : IXmlSerializable, IFormattable, IEquata
         {
             return true;
         }
-        else if (str.IsUnknown(formatProvider))
+        else if (str.IsUnknown(provider))
         {
             result = Unknown;
             return true;
         }
-        else if (ParseValues.TryGetValue(formatProvider, str, out var val))
+        else if (ParseValues.TryGetValue(provider, str, out var val))
         {
             result = new Country(val);
             return true;

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -128,7 +128,7 @@ public readonly partial struct HouseNumber : IXmlSerializable, IFormattable, IEq
     /// <param name="s">
     /// A string containing a house number to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -137,14 +137,14 @@ public readonly partial struct HouseNumber : IXmlSerializable, IFormattable, IEq
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out HouseNumber result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out HouseNumber result)
     {
         result = default;
         if (string.IsNullOrEmpty(s))
         {
             return true;
         }
-        var culture = formatProvider as CultureInfo ?? CultureInfo.InvariantCulture;
+        var culture = provider as CultureInfo ?? CultureInfo.InvariantCulture;
         if (Qowaiv.Unknown.IsUnknown(s, culture))
         {
             result = Unknown;

--- a/src/Qowaiv/IO/StreamSize.cs
+++ b/src/Qowaiv/IO/StreamSize.cs
@@ -582,7 +582,7 @@ public readonly partial struct StreamSize : IXmlSerializable, IFormattable, IEqu
     /// <param name="s">
     /// A string containing a stream size to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -591,7 +591,7 @@ public readonly partial struct StreamSize : IXmlSerializable, IFormattable, IEqu
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out StreamSize result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out StreamSize result)
     {
         result = default;
         if (string.IsNullOrEmpty(s)) return false;
@@ -601,14 +601,14 @@ public readonly partial struct StreamSize : IXmlSerializable, IFormattable, IEqu
             var size = GetWithoutStreamSizeMarker(s, streamSizeMarker);
             var factor = GetMultiplier(streamSizeMarker);
 
-            if (long.TryParse(size, NumberStyles.Number, formatProvider, out long sizeInt64) &&
+            if (long.TryParse(size, NumberStyles.Number, provider, out long sizeInt64) &&
                 sizeInt64 <= long.MaxValue / factor &&
                 sizeInt64 >= long.MinValue / factor)
             {
                 result = new StreamSize(sizeInt64 * factor);
                 return true;
             }
-            else if (decimal.TryParse(size, NumberStyles.Number, formatProvider, out decimal sizeDecimal) &&
+            else if (decimal.TryParse(size, NumberStyles.Number, provider, out decimal sizeDecimal) &&
                 sizeDecimal <= decimal.MaxValue / factor &&
                 sizeDecimal >= decimal.MinValue / factor)
             {

--- a/src/Qowaiv/LocalDateTime.cs
+++ b/src/Qowaiv/LocalDateTime.cs
@@ -602,7 +602,7 @@ public readonly partial struct LocalDateTime : IXmlSerializable, IFormattable, I
     /// <param name="s">
     /// A string containing a local date time to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -611,9 +611,9 @@ public readonly partial struct LocalDateTime : IXmlSerializable, IFormattable, I
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out LocalDateTime result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out LocalDateTime result)
     {
-        return TryParse(s, formatProvider, DateTimeStyles.None, out result);
+        return TryParse(s, provider, DateTimeStyles.None, out result);
     }
 
     /// <summary>Converts the string to a local date time.
@@ -622,7 +622,7 @@ public readonly partial struct LocalDateTime : IXmlSerializable, IFormattable, I
     /// <param name="s">
     /// A string containing a local date time to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="styles">
@@ -636,9 +636,9 @@ public readonly partial struct LocalDateTime : IXmlSerializable, IFormattable, I
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, DateTimeStyles styles, out LocalDateTime result)
+    public static bool TryParse(string? s, IFormatProvider? provider, DateTimeStyles styles, out LocalDateTime result)
     {
-        if (DateTime.TryParse(s, formatProvider, styles, out DateTime dt))
+        if (DateTime.TryParse(s, provider, styles, out DateTime dt))
         {
             result = new LocalDateTime(dt);
             return true;

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -638,7 +638,7 @@ public readonly partial struct Fraction : IXmlSerializable, IFormattable, IEquat
     /// <param name = "s">
     /// A string containing the fraction to convert.
     /// </param>
-    /// <param name = "formatProvider">
+    /// <param name = "provider">
     /// The specified format provider.
     /// </param>
     /// <param name = "result">
@@ -647,9 +647,9 @@ public readonly partial struct Fraction : IXmlSerializable, IFormattable, IEquat
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Fraction result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Fraction result)
     {
-        if (s is { Length: > 0 } && FractionParser.Parse(s, formatProvider) is { } fraction)
+        if (s is { Length: > 0 } && FractionParser.Parse(s, provider) is { } fraction)
         {
             result = fraction;
             return true;

--- a/src/Qowaiv/Month.cs
+++ b/src/Qowaiv/Month.cs
@@ -201,7 +201,7 @@ public readonly partial struct Month : IXmlSerializable, IFormattable, IEquatabl
     /// <param name="s">
     /// A string containing a month to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -210,7 +210,7 @@ public readonly partial struct Month : IXmlSerializable, IFormattable, IEquatabl
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Month result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Month result)
     {
         result = default;
         var str = s.Unify();
@@ -218,17 +218,17 @@ public readonly partial struct Month : IXmlSerializable, IFormattable, IEquatabl
         {
             return true;
         }
-        else if (str.IsUnknown(formatProvider))
+        else if (str.IsUnknown(provider))
         {
             result = Unknown;
             return true;
         }
-        else if (byte.TryParse(s, NumberStyles.None, formatProvider, out var n) && IsValid(n))
+        else if (byte.TryParse(s, NumberStyles.None, provider, out var n) && IsValid(n))
         {
             result = new Month(n);
             return true;
         }
-        else if (ParseValues.TryGetValue(formatProvider, str, out byte m))
+        else if (ParseValues.TryGetValue(provider, str, out byte m))
         {
             result = new Month(m);
             return true;

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -261,7 +261,7 @@ public readonly partial struct MonthSpan : IXmlSerializable, IFormattable, IEqua
     /// <param name = "s">
     /// A string containing the month span to convert.
     /// </param>
-    /// <param name = "formatProvider">
+    /// <param name = "provider">
     /// The specified format provider.
     /// </param>
     /// <param name = "result">
@@ -270,19 +270,19 @@ public readonly partial struct MonthSpan : IXmlSerializable, IFormattable, IEqua
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out MonthSpan result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out MonthSpan result)
     {
         result = default;
         if (string.IsNullOrEmpty(s))
         {
             return true;
         }
-        else if (int.TryParse(s, NumberStyles.Integer, formatProvider, out var months)
+        else if (int.TryParse(s, NumberStyles.Integer, provider, out var months)
             && TryCreate(months, out result))
         {
             return true;
         }
-        else if (DateSpan.TryParse(s, formatProvider, out var dateSpan))
+        else if (DateSpan.TryParse(s, provider, out var dateSpan))
         {
             result = FromMonths(dateSpan.TotalMonths);
             return true;

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -670,7 +670,7 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
     /// <param name="s">
     /// A string containing a Percentage to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The format provider.
     /// </param>
     /// <param name="result">
@@ -679,12 +679,12 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Percentage result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Percentage result)
     {
         result = Zero;
 
         if (s is { Length: > 0 }
-            && FormatInfo.TryParse(s, formatProvider, out var info)
+            && FormatInfo.TryParse(s, provider, out var info)
             && decimal.TryParse(info.Format, NumberStyles.Number, info.Provider, out var dec))
         {
             result = new(dec * info.Factor);

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -95,7 +95,7 @@ public readonly partial struct PostalCode : IXmlSerializable, IFormattable, IEqu
     /// <param name="s">
     /// A string containing a postal code to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -104,7 +104,7 @@ public readonly partial struct PostalCode : IXmlSerializable, IFormattable, IEqu
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out PostalCode result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out PostalCode result)
     {
         result = default;
         var str = s.Unify();
@@ -112,7 +112,7 @@ public readonly partial struct PostalCode : IXmlSerializable, IFormattable, IEqu
         {
             return true;
         }
-        else if (str.IsUnknown(formatProvider))
+        else if (str.IsUnknown(provider))
         {
             result = Unknown;
             return true;

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,7 +9,8 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 v7.0.0
-- Drop support for .NET 5 and .NET 7 STS's.
+- Allign Parse and TryParse provider naming with IParsable. #360 (breaking)
+- Drop support for .NET 5 and .NET 7 STS's. #359 (breaking)
 v6.6.0
 - Add former countries. #357
 - Update display names countries (EN, DE, NL). #356

--- a/src/Qowaiv/Sex.cs
+++ b/src/Qowaiv/Sex.cs
@@ -168,7 +168,7 @@ public readonly partial struct Sex : IXmlSerializable, IFormattable, IEquatable<
     /// <param name="s">
     /// A string containing a Sex to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -177,10 +177,10 @@ public readonly partial struct Sex : IXmlSerializable, IFormattable, IEquatable<
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Sex result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Sex result)
     {
         result = Empty;
-        if (ParseValues.TryGetValue(formatProvider, s.Unify(), out var val))
+        if (ParseValues.TryGetValue(provider, s.Unify(), out var val))
         {
             result = new Sex(val);
             return true;

--- a/src/Qowaiv/Statistics/Elo.cs
+++ b/src/Qowaiv/Statistics/Elo.cs
@@ -197,7 +197,7 @@ public readonly partial struct Elo : IXmlSerializable, IFormattable, IEquatable<
     /// <param name="s">
     /// A string containing an Elo to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The format provider.
     /// </param>
     /// <param name="result">
@@ -206,14 +206,14 @@ public readonly partial struct Elo : IXmlSerializable, IFormattable, IEquatable<
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Elo result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Elo result)
     {
         result = Zero;
         if (s is { Length: > 0 })
         {
             var str = s[^1] == '*' ? s[..^1] : s;
 
-            if (double.TryParse(str, NumberStyles.Number, formatProvider, out var d) && !double.IsNaN(d) && !double.IsInfinity(d))
+            if (double.TryParse(str, NumberStyles.Number, provider, out var d) && !double.IsNaN(d) && !double.IsInfinity(d))
             {
                 result = new Elo(d);
                 return true;

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -236,7 +236,7 @@ public readonly partial struct WeekDate : IXmlSerializable, IFormattable, IEquat
     /// <param name="s">
     /// A string containing a week date to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -245,15 +245,15 @@ public readonly partial struct WeekDate : IXmlSerializable, IFormattable, IEquat
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out WeekDate result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out WeekDate result)
     {
         result = MinValue;
         var match = Pattern.Match(s ?? string.Empty);
         if (match.Success)
         {
-            var year = int.Parse(match.Groups["year"].Value, formatProvider);
-            var week = int.Parse(match.Groups["week"].Value, formatProvider);
-            var day = int.Parse(match.Groups["day"].Value, formatProvider);
+            var year = int.Parse(match.Groups["year"].Value, provider);
+            var week = int.Parse(match.Groups["week"].Value, provider);
+            var day = int.Parse(match.Groups["day"].Value, provider);
 
             if (TryCreate(year, week, day, out Date dt))
             {

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -116,7 +116,7 @@ public readonly partial struct Year : IXmlSerializable, IFormattable, IEquatable
     /// <param name="s">
     /// A string containing a year to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -125,19 +125,19 @@ public readonly partial struct Year : IXmlSerializable, IFormattable, IEquatable
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out Year result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out Year result)
     {
         result = default;
         if (string.IsNullOrEmpty(s))
         {
             return true;
         }
-        else if (Qowaiv.Unknown.IsUnknown(s, formatProvider as CultureInfo ?? CultureInfo.InvariantCulture))
+        else if (Qowaiv.Unknown.IsUnknown(s, provider as CultureInfo ?? CultureInfo.InvariantCulture))
         {
             result = Unknown;
             return true;
         }
-        else if (short.TryParse(s, NumberStyles.None, formatProvider, out var year)
+        else if (short.TryParse(s, NumberStyles.None, provider, out var year)
             && year >= MinValue.m_Value
             && year <= MaxValue.m_Value)
         {

--- a/src/Qowaiv/YesNo.cs
+++ b/src/Qowaiv/YesNo.cs
@@ -168,7 +168,7 @@ public readonly partial struct YesNo : IXmlSerializable, IFormattable, IEquatabl
     /// <param name="s">
     /// A string containing a yes-no to convert.
     /// </param>
-    /// <param name="formatProvider">
+    /// <param name="provider">
     /// The specified format provider.
     /// </param>
     /// <param name="result">
@@ -177,7 +177,7 @@ public readonly partial struct YesNo : IXmlSerializable, IFormattable, IEquatabl
     /// <returns>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
-    public static bool TryParse(string? s, IFormatProvider? formatProvider, out YesNo result)
+    public static bool TryParse(string? s, IFormatProvider? provider, out YesNo result)
     {
         result = Empty;
         var str = s.Unify();
@@ -186,12 +186,12 @@ public readonly partial struct YesNo : IXmlSerializable, IFormattable, IEquatabl
         {
             return true;
         }
-        else if (str.IsUnknown(formatProvider))
+        else if (str.IsUnknown(provider))
         {
             result = Unknown;
             return true;
         }
-        else if (ParseValues.TryGetValue(formatProvider, str, out var val))
+        else if (ParseValues.TryGetValue(provider, str, out var val))
         {
             result = new YesNo(val);
             return true;


### PR DESCRIPTION
As pointed out by @pmdevers  in #281 (and #273): The `IParsable<TSelf>` contract specifies the `IFormatProvider` arguments as `provider`, not `formatProvider`. As this is a beaking change it has been postponed until now. 