### PR TITLE
Improve performance of UUID parsing

### DIFF
--- a/specs/Qowaiv.Benchmarks/Program.cs
+++ b/specs/Qowaiv.Benchmarks/Program.cs
@@ -6,9 +6,10 @@ public static class Program
 {
     public static void Main()
     {
+        BenchmarkRunner.Run<UuidBenchmark.Parse>();
         BenchmarkRunner.Run<UuidBenchmark.StringOutput>();
-        //BenchmarkRunner.Run<UuidBenchmark.Version>();
-        //BenchmarkRunner.Run<IbanBenchmark.ParseUnformatted>();
-        //BenchmarkRunner.Run<IbanBenchmark.ParseFormatted>();
+        BenchmarkRunner.Run<UuidBenchmark.Version>();
+        BenchmarkRunner.Run<IbanBenchmark.ParseUnformatted>();
+        BenchmarkRunner.Run<IbanBenchmark.ParseFormatted>();
     }
 }

--- a/specs/Qowaiv.Benchmarks/Program.cs
+++ b/specs/Qowaiv.Benchmarks/Program.cs
@@ -7,6 +7,8 @@ public static class Program
     public static void Main()
     {
         BenchmarkRunner.Run<UuidBenchmark.Parse>();
-        //BenchmarkRunner.Run<IbanBenchmark.ParseFormatted>();
+        BenchmarkRunner.Run<UuidBenchmark.Version>();
+        BenchmarkRunner.Run<IbanBenchmark.ParseUnformatted>();
+        BenchmarkRunner.Run<IbanBenchmark.ParseFormatted>();
     }
 }

--- a/specs/Qowaiv.Benchmarks/Program.cs
+++ b/specs/Qowaiv.Benchmarks/Program.cs
@@ -6,9 +6,9 @@ public static class Program
 {
     public static void Main()
     {
-        BenchmarkRunner.Run<UuidBenchmark.Parse>();
-        BenchmarkRunner.Run<UuidBenchmark.Version>();
-        BenchmarkRunner.Run<IbanBenchmark.ParseUnformatted>();
-        BenchmarkRunner.Run<IbanBenchmark.ParseFormatted>();
+        BenchmarkRunner.Run<UuidBenchmark.StringOutput>();
+        //BenchmarkRunner.Run<UuidBenchmark.Version>();
+        //BenchmarkRunner.Run<IbanBenchmark.ParseUnformatted>();
+        //BenchmarkRunner.Run<IbanBenchmark.ParseFormatted>();
     }
 }

--- a/specs/Qowaiv.Benchmarks/Program.cs
+++ b/specs/Qowaiv.Benchmarks/Program.cs
@@ -6,7 +6,7 @@ public static class Program
 {
     public static void Main()
     {
-        BenchmarkRunner.Run<IbanBenchmark.ParseUnformatted>();
-        BenchmarkRunner.Run<IbanBenchmark.ParseFormatted>();
+        BenchmarkRunner.Run<UuidBenchmark.Parse>();
+        //BenchmarkRunner.Run<IbanBenchmark.ParseFormatted>();
     }
 }

--- a/specs/Qowaiv.Benchmarks/Qowaiv.Benchmarks.csproj
+++ b/specs/Qowaiv.Benchmarks/Qowaiv.Benchmarks.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.*" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
   </ItemGroup>
 

--- a/specs/Qowaiv.Benchmarks/README.md
+++ b/specs/Qowaiv.Benchmarks/README.md
@@ -24,15 +24,24 @@ By removing `Regex` for the UUID parsing, durations have been reduced.
 | Parse              | Mean     | Ratio |
 |------------------- |---------:|------:|
 | GUID (Guid.Parse)  | 15.63 ns |  1.00 |
-| GUID               | 18.77 ns |  1.20 |
 | Base64             | 18.58 ns |  1.19 |
+| GUID               | 18.77 ns |  1.20 |
 | Base32             | 27.82 ns |  1.78 |
 | Regex + FromBase64 | 92.76 ns |  5.94 |
+
+Reduced the function calls, and string replacements.
+
+| ToString             | Mean     | Ratio |
+|--------------------- |---------:|------:|
+| GUID (Guid.ToString) | 11.10 ns |  1.00 |
+| Base64               | 17.47 ns |  1.57 |
+| GUID                 | 43.03 ns |  3.85 |
+| Convert.ToBase64     | 50.71 ns |  4.57 |
 
 The version of a `UUID` is stored in the upper 4 bits of byte 7. By using the
 `GuidLayout` of `ToByteArray()` to retrieve that those bits is a big improvement.
 
-| Method      | Mean       | Ratio |
+| Version     | Mean       | Ratio |
 |------------ |-----------:|------:|
 | Layout      |   0.584 ns |  1.00 |
 | From byte[] |   3.024 ns |  5.20 |

--- a/specs/Qowaiv.Benchmarks/README.md
+++ b/specs/Qowaiv.Benchmarks/README.md
@@ -1,6 +1,6 @@
 ﻿# Qowaiv Benchmarks
 
-# IBAN
+## IBAN
 By removing `Regex`'s from IBAN, durations of parsing have been reduced
 dramatically.
 
@@ -17,3 +17,14 @@ Formatted v.s. umformatted strings have hardly any effect on the durations.
 | BBAN                |   151.8 ns |  1.00 |
 | Regex               | 2,150.6 ns | 14.19 |
 | Regex (with tweaks) | 1,359.1 ns |  8.98 |
+
+
+## UUID
+By removing `Regex` for the UUID parsing, durations have been reduced.
+| Parse              | Mean     | Ratio |
+|------------------- |---------:|------:|
+| GUID (Guid.Parse)  | 15.63 ns |  1.00 |
+| GUID               | 18.77 ns |  1.20 |
+| Base64             | 18.58 ns |  1.19 |
+| Base32             | 27.82 ns |  1.78 |
+| Regex + FromBase64 | 92.76 ns |  5.94 |

--- a/specs/Qowaiv.Benchmarks/README.md
+++ b/specs/Qowaiv.Benchmarks/README.md
@@ -28,3 +28,11 @@ By removing `Regex` for the UUID parsing, durations have been reduced.
 | Base64             | 18.58 ns |  1.19 |
 | Base32             | 27.82 ns |  1.78 |
 | Regex + FromBase64 | 92.76 ns |  5.94 |
+
+The version of a `UUID` is stored in the upper 4 bits of byte 7. By using the
+`GuidLayout` of `ToByteArray()` to retrieve that those bits is a big improvement.
+
+| Method      | Mean       | Ratio |
+|------------ |-----------:|------:|
+| Layout      |   0.584 ns |  1.00 |
+| From byte[] |   3.024 ns |  5.20 |

--- a/specs/Qowaiv.Benchmarks/UuidBenchmark.Reference.cs
+++ b/specs/Qowaiv.Benchmarks/UuidBenchmark.Reference.cs
@@ -1,0 +1,69 @@
+﻿#pragma warning disable CS8605 // Unboxing a possibly null value.
+
+using Qowaiv;
+using Qowaiv.Identifiers;
+
+namespace Benchmarks;
+
+public partial class UuidBenchmark
+{
+    static readonly OldUidBehavior behavior = new();
+
+    public static partial class Reference
+    {
+
+
+        public static Uuid Convert_FromBase64(string s)
+        {
+            if (behavior.TryParse(s, out var guid))
+            {
+                return (Uuid)(Guid)guid;
+            }
+            else throw new FormatException();
+        }
+    }
+
+    private sealed partial class OldUidBehavior : UuidBehavior
+    {
+        [GeneratedRegex(@"^[a-zA-Z0-9_-]{22}(=){0,2}$")]
+        private static partial Regex GetPattern();
+
+        public override bool TryParse(string? str, out object? id)
+        {
+            if (str is not { Length: > 0 })
+            {
+                id = default;
+                return true;
+            }
+            else if (Guid.TryParse(str, out Guid guid))
+            {
+                id = NullIfEmpty(guid);
+                return true;
+            }
+            else if (GetPattern().IsMatch(str))
+            {
+                id = NullIfEmpty(GuidFromBase64(str));
+                return true;
+            }
+            else
+            {
+                id = default;
+                return false;
+            }
+
+            static object? NullIfEmpty(Guid guid) => guid == Guid.Empty ? null : guid;
+
+            static Guid GuidFromBase64(string s)
+            {
+                var base64 = new char[24];
+                for (int i = 0; i < 22; i++)
+                {
+                    base64[i] = s[i] switch { '-' => '+', '_' => '/', _ => s[i] };
+                }
+                base64[22] = '=';
+                base64[23] = '=';
+                return new Guid(Convert.FromBase64String(new string(base64)));
+            }
+        }
+    }
+}

--- a/specs/Qowaiv.Benchmarks/UuidBenchmark.Reference.cs
+++ b/specs/Qowaiv.Benchmarks/UuidBenchmark.Reference.cs
@@ -26,6 +26,9 @@ public partial class UuidBenchmark
             var version = bytes[7] >> 4;
             return (UuidVersion)version;
         }
+
+        public static string ToString(Guid guid, string format = "S")
+            => behavior.ToString(guid, format, null);
     }
 
     private sealed partial class OldUidBehavior : UuidBehavior
@@ -70,5 +73,20 @@ public partial class UuidBenchmark
                 return new Guid(Convert.FromBase64String(new string(base64)));
             }
         }
+
+        public override string ToString(object? obj, string? format, IFormatProvider? formatProvider)
+            => obj is Guid guid
+            ? ToString(guid, format):
+            base.ToString(obj, format, formatProvider);
+
+        private static string ToString(Guid guid, string? format)
+            => format switch
+            {
+                "S" or "s" => ToBase64(guid),
+                _ => guid.ToString(format),
+            };
+
+        private static string ToBase64(Guid guid)
+            => Convert.ToBase64String(guid.ToByteArray()).Replace('+', '-').Replace('/', '_')[..22];
     }
 }

--- a/specs/Qowaiv.Benchmarks/UuidBenchmark.Reference.cs
+++ b/specs/Qowaiv.Benchmarks/UuidBenchmark.Reference.cs
@@ -11,8 +11,6 @@ public partial class UuidBenchmark
 
     public static partial class Reference
     {
-
-
         public static Uuid Convert_FromBase64(string s)
         {
             if (behavior.TryParse(s, out var guid))
@@ -20,6 +18,13 @@ public partial class UuidBenchmark
                 return (Uuid)(Guid)guid;
             }
             else throw new FormatException();
+        }
+
+        public static UuidVersion GetVersion(Guid guid)
+        {
+            var bytes = guid.ToByteArray();
+            var version = bytes[7] >> 4;
+            return (UuidVersion)version;
         }
     }
 

--- a/specs/Qowaiv.Benchmarks/UuidBenchmark.cs
+++ b/specs/Qowaiv.Benchmarks/UuidBenchmark.cs
@@ -1,0 +1,90 @@
+﻿using BenchmarkDotNet.Attributes;
+using Qowaiv;
+using Qowaiv.Identifiers;
+
+namespace Benchmarks;
+
+public partial class UuidBenchmark
+{
+    public sealed class ForUuid : UuidBehavior { }
+
+    private const int Iterations = 1000;
+    private static readonly Guid[] Guids = new Guid[Iterations];
+    private static readonly Uuid[] Uuids = new Uuid[Iterations];
+    private static readonly Id<ForUuid>[] IDs = new Id<ForUuid>[Iterations];
+
+    public class Parse: UuidBenchmark
+    {
+        private string[] Strings { get; set; } = [];
+        private string[] Base64s { get; set; } = [];
+        private string[] Base32s { get; set; } = [];
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Strings = Enumerable.Range(0, Iterations).Select(_ => Guid.NewGuid().ToString()).ToArray();
+            Base64s = Enumerable.Range(0, Iterations).Select(_ => Uuid.NewUuid().ToString()).ToArray();
+            Base32s = Enumerable.Range(0, Iterations).Select(_ => Uuid.NewUuid().ToString("H")).ToArray();
+        }
+
+        [Benchmark(Baseline = true)]
+        public Guid[] GUID_Parse()
+        {
+            for (var i = 0; i < Strings.Length; i++)
+            {
+                Guids[i] = Guid.Parse(Strings[i]);
+            }
+            return Guids;
+        }
+        
+        [Benchmark]
+        public Uuid[] UUID_Parse()
+        {
+            for (var i = 0; i < Strings.Length; i++)
+            {
+                Uuids[i] = Uuid.Parse(Strings[i]);
+            }
+            return Uuids;
+        }
+
+        [Benchmark]
+        public Uuid[] UUID_Parse_Base64()
+        {
+            for (var i = 0; i < Strings.Length; i++)
+            {
+                Uuids[i] = Uuid.Parse(Base64s[i]);
+            }
+            return Uuids;
+        }
+
+        [Benchmark]
+        public Uuid[] UUID_Parse_Base32()
+        {
+            for (var i = 0; i < Strings.Length; i++)
+            {
+                Uuids[i] = Uuid.Parse(Base32s[i]);
+            }
+            return Uuids;
+        }
+
+        [Benchmark]
+        public  Id<ForUuid>[] ID_for_UUID_Parse()
+        {
+            for (var i = 0; i < Base64s.Length; i++)
+            {
+                IDs[i] = Id<ForUuid>.Parse(Base64s[i]);
+            }
+            return IDs;
+        }
+
+        [Benchmark]
+        public Uuid[] Convert_fromBase64()
+        {
+            for (var i = 0; i < Base64s.Length; i++)
+            {
+                Uuids[i] = Reference.Convert_FromBase64(Base64s[i]);
+            }
+            return Uuids;
+        }
+    }
+}

--- a/specs/Qowaiv.Benchmarks/UuidBenchmark.cs
+++ b/specs/Qowaiv.Benchmarks/UuidBenchmark.cs
@@ -23,6 +23,7 @@ public partial class UuidBenchmark
         public void Setup()
         {
             Uuids = Enumerable.Range(0, Iterations).Select(_ => Uuid.NewUuid()).ToArray();
+            Guids = Uuids.Select(x => (Guid)x).ToArray();
             Strings = Uuids.Select(g => g.ToString("D")).ToArray();
             Base64s = Uuids.Select(g => g.ToString("S")).ToArray();
             Base32s = Uuids.Select(g => g.ToString("H")).ToArray();
@@ -86,6 +87,58 @@ public partial class UuidBenchmark
                 Uuids[i] = Reference.Convert_FromBase64(Base64s[i]);
             }
             return Uuids;
+        }
+    }
+
+    public class StringOutput : UuidBenchmark
+    {
+        private string[] Strings { get; set; } = new string[Iterations];
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Uuids = Enumerable.Range(0, Iterations).Select(_ => Uuid.NewUuid()).ToArray();
+            Guids = Uuids.Select(x => (Guid)x).ToArray();
+        }
+
+        [Benchmark(Baseline = true)]
+        public string[] GUID_ToString()
+        {
+            for (var i = 0; i < Guids.Length; i++)
+            {
+                Strings[i] = Guids[i].ToString();
+            }
+            return Strings;
+        }
+
+        [Benchmark]
+        public string[] GUID()
+        {
+            for (var i = 0; i < Uuids.Length; i++)
+            {
+                Strings[i] = Uuids[i].ToString("B");
+            }
+            return Strings;
+        }
+
+        [Benchmark]
+        public string[] Base64()
+        {
+            for (var i = 0; i < Uuids.Length; i++)
+            {
+                Strings[i] = Uuids[i].ToJson()!;
+            }
+            return Strings;
+        }
+
+        [Benchmark]
+        public string[] Convert_ToBase64()
+        {
+            for (var i = 0; i < Uuids.Length; i++)
+            {
+                Strings[i] = Reference.ToString(Uuids[i]);
+            }
+            return Strings;
         }
     }
 

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Guid_specs.cs
@@ -102,10 +102,18 @@ public class Supports_type_conversion
         => Converting.To<Uuid>().From(Svo.CustomGuid).Should().Be(Svo.Uuid);
 }
 
-#if NET6_0_OR_GREATER
-
 public class Supports_JSON_serialization
 {
+    [Test]
+    public void writes_null_for_default_value()
+        => JsonTester.Write(default(CustomGuid)).Should().BeNull();
+
+    [Test]
+    public void writes_GUID_for_non_default_value()
+        => JsonTester.Write(Svo.CustomGuid).Should().Be("8a1a8c42-d2ff-e254-e26e-b6abcbf19420");
+
+#if NET6_0_OR_GREATER
+
     [Test]
     public void System_Text_JSON_deserialization_of_dictionary_keys()
     {
@@ -127,8 +135,8 @@ public class Supports_JSON_serialization
         System.Text.Json.JsonSerializer.Serialize(dictionary)
             .Should().Be(@"{"""":17,""8a1a8c42-d2ff-e254-e26e-b6abcbf19420"":42}");
     }
-}
 #endif
+}
 
 #if NET8_0_OR_GREATER
 #else
@@ -155,8 +163,8 @@ public class Is_Open_API_data_type
 {
     [Test]
     public void with_info()
-        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(ForGuid))
-        .Should().Be(new Qowaiv.OpenApi.OpenApiDataType(
+        => OpenApiDataType.FromType(typeof(ForGuid))
+        .Should().Be(new OpenApiDataType(
             dataType: typeof(CustomGuid),
             description: "GUID based identifier",
             example: "8a1a8c42-d2ff-e254-e26e-b6abcbf19420",

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Uuid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Uuid_specs.cs
@@ -1,0 +1,174 @@
+﻿namespace Identifiers.Id_for_Uuid_specs;
+
+public class With_domain_logic
+{
+    [TestCase(true, "Qowaiv_SVOLibrary_GUIA")]
+    [TestCase(false, "")]
+    public void HasValue_is(bool result, CustomUuid svo) => svo.HasValue.Should().Be(result);
+}
+
+public class Is_comparable
+{
+    [Test]
+    public void to_null_is_1() => Svo.CustomUuid.CompareTo(Nil.Object).Should().Be(1);
+
+    [Test]
+    public void to_CustomUuid_as_object()
+    {
+        object obj = Svo.CustomUuid;
+        Svo.CustomUuid.CompareTo(obj).Should().Be(0);
+    }
+
+    [Test]
+    public void to_CustomUuid_only()
+        => Assert.Throws<ArgumentException>(() => Svo.CustomUuid.CompareTo(new object()));
+
+    [Test]
+    public void can_be_sorted_using_compare()
+    {
+        var sorted = new[]
+        {
+            CustomUuid.Empty,
+            CustomUuid.Parse("33ef5805-c472-4b1f-88bb-2f0723c43889"),
+            CustomUuid.Parse("58617a65-2a14-4a9a-82a8-c1a82c956c25"),
+            CustomUuid.Parse("853634b4-e474-4b0f-b9ba-01fc732b56d8"),
+            CustomUuid.Parse("93ca7b43-8fb3-44e5-a21f-feeebb8e0f6f"),
+            CustomUuid.Parse("f5e6c39a-adcf-4eca-bcf2-6b8317ac502c"),
+        };
+
+        var list = new List<CustomUuid> { sorted[3], sorted[4], sorted[5], sorted[2], sorted[0], sorted[1] };
+        list.Sort();
+        list.Should().BeEquivalentTo(sorted);
+    }
+}
+
+public class Supports_type_conversion
+{
+    [Test]
+    public void via_TypeConverter_registered_with_attribute()
+        => typeof(CustomUuid).Should().HaveTypeConverterDefined();
+
+    [Test]
+    public void from_null_string()
+    {
+        using (TestCultures.en_GB.Scoped())
+        {
+            Converting.FromNull<string>().To<CustomUuid>().Should().Be(CustomUuid.Empty);
+        }
+    }
+
+    [Test]
+    public void from_empty_string()
+    {
+        using (TestCultures.en_GB.Scoped())
+        {
+            Converting.From(string.Empty).To<CustomUuid>().Should().Be(CustomUuid.Empty);
+        }
+    }
+
+    [Test]
+    public void from_string()
+    {
+        using (TestCultures.en_GB.Scoped())
+        {
+            Converting.From("Qowaiv_SVOLibrary_GUIA").To<CustomUuid>().Should().Be(Svo.CustomUuid);
+        }
+    }
+
+    [Test]
+    public void to_string()
+    {
+        using (TestCultures.en_GB.Scoped())
+        {
+            Converting.ToString().From(Svo.CustomUuid).Should().Be("Qowaiv_SVOLibrary_GUIA");
+        }
+    }
+
+    [Test]
+    public void from_Guid()
+        => Converting.From(Svo.Guid).To<CustomUuid>().Should().Be(Svo.CustomUuid);
+
+
+    [Test]
+    public void from_Uuid()
+        => Converting.From(Svo.Uuid).To<CustomUuid>().Should().Be(Svo.CustomUuid);
+
+    [Test]
+    public void to_Guid()
+        => Converting.To<Guid>().From(Svo.CustomUuid).Should().Be(Svo.Guid);
+
+    [Test]
+    public void to_Uuid()
+        => Converting.To<Uuid>().From(Svo.CustomUuid).Should().Be(Svo.Uuid);
+}
+
+public class Supports_JSON_serialization
+{
+    [Test]
+    public void writes_null_for_default_value()
+        => JsonTester.Write(default(CustomUuid)).Should().BeNull();
+
+    [Test]
+    public void writes_Base64_string_for_non_default_value()
+        => JsonTester.Write(Svo.CustomUuid).Should().Be("Qowaiv_SVOLibrary_GUIA");
+
+#if NET6_0_OR_GREATER
+
+    [Test]
+    public void System_Text_JSON_deserialization_of_dictionary_keys()
+    {
+        System.Text.Json.JsonSerializer.Deserialize<Dictionary<CustomUuid, int>>(@"{""Qowaiv_SVOLibrary_GUIA"":42}")
+            .Should().BeEquivalentTo(new Dictionary<CustomUuid, int>()
+            {
+                [Svo.CustomUuid] = 42,
+            });
+    }
+
+    [Test]
+    public void System_Text_JSON_serialization_of_dictionary_keys()
+    {
+        var dictionary = new Dictionary<CustomUuid, int>()
+        {
+            [default] = 17,
+            [Svo.CustomUuid] = 42,
+        };
+        System.Text.Json.JsonSerializer.Serialize(dictionary)
+            .Should().Be(@"{"""":17,""Qowaiv_SVOLibrary_GUIA"":42}");
+    }
+#endif
+}
+
+#if NET8_0_OR_GREATER
+#else
+public class Supports_binary_serialization
+{
+    [Test]
+    [Obsolete("Usage of the binary formatter is considered harmful.")]
+    public void using_BinaryFormatter()
+    {
+        var round_tripped = SerializeDeserialize.Binary(Svo.CustomUuid);
+        round_tripped.Should().Be(Svo.CustomUuid);
+    }
+
+    [Test]
+    public void storing_value_in_SerializationInfo()
+    {
+        var info = Serialize.GetInfo(Svo.CustomUuid);
+        info.GetValue("Value", typeof(Guid)).Should().Be(Guid.Parse("Qowaiv_SVOLibrary_GUIA"));
+    }
+}
+#endif
+
+public class Is_Open_API_data_type
+{
+    [Test]
+    public void with_info()
+        => OpenApiDataType.FromType(typeof(ForUuid))
+        .Should().Be(new OpenApiDataType(
+            dataType: typeof(CustomUuid),
+            description: "UUID based identifier",
+            example: "lmZO_haEOTCwGsCcbIZFFg",
+            type: "string",
+            format: "uuid-base64",
+            nullable: true));
+}

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Uuid_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Uuid_specs.cs
@@ -154,7 +154,7 @@ public class Supports_binary_serialization
     public void storing_value_in_SerializationInfo()
     {
         var info = Serialize.GetInfo(Svo.CustomUuid);
-        info.GetValue("Value", typeof(Guid)).Should().Be(Guid.Parse("Qowaiv_SVOLibrary_GUIA"));
+        info.GetValue("Value", typeof(Guid)).Should().Be(Guid.Parse("8A1A8C42-D2FF-E254-E26E-B6ABCBF19420"));
     }
 }
 #endif

--- a/specs/Qowaiv.Specs/Text/Base32_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base32_specs.cs
@@ -96,7 +96,7 @@ public class GetBytes
         {
             var act = Assert.Catch<FormatException>(() =>
             {
-                Base32.GetBytes("Q0waiv");
+                Base32.GetBytes("Q!waiv");
             });
             act.Message.Should().Be("Not a valid Base32 string");
         }

--- a/specs/Qowaiv.Specs/Text/Base64_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base64_specs.cs
@@ -18,6 +18,14 @@ public class ToString
         var bytes = data.Select(v => (byte)v).ToArray();
         Base64.ToString(bytes).Should().Be(base64);
     }
+
+    [Test]
+    public void GUID_ToString()
+    {
+        var uuid = Uuid.Parse("TEtRfRl700uZmeo6XOS2-Q");
+
+        Base64.ToString(uuid).Should().Be(uuid.ToString());
+    }
 }
 
 public class TryGetBytes_from

--- a/specs/Qowaiv.Specs/Text/Base64_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base64_specs.cs
@@ -18,14 +18,6 @@ public class ToString
         var bytes = data.Select(v => (byte)v).ToArray();
         Base64.ToString(bytes).Should().Be(base64);
     }
-
-    [Test]
-    public void GUID_ToString()
-    {
-        var uuid = Uuid.Parse("TEtRfRl700uZmeo6XOS2-Q");
-
-        Base64.ToString(uuid).Should().Be(uuid.ToString());
-    }
 }
 
 public class TryGetBytes_from

--- a/specs/Qowaiv.Specs/UUID_generation.cs
+++ b/specs/Qowaiv.Specs/UUID_generation.cs
@@ -1,0 +1,67 @@
+﻿#if DEBUG
+namespace UUID_generation;
+
+public class Generates
+{
+    [Test]
+    public void Lookup_Base64()
+    {
+        var bytes = new byte[256];
+        for (var i = 0; i < bytes.Length; i++) { bytes[i] = 255; }
+
+        for (var i = 'A'; i <= 'Z'; i++) { bytes[i] = (byte)(i - 'A'); }
+        for (var i = 'a'; i <= 'z'; i++) { bytes[i] = (byte)(26 + i - 'a'); }
+        for (var i = '0'; i <= '9'; i++) { bytes[i] = (byte)(52 + i - '0'); }
+
+        bytes['-'] = 62; bytes['+'] = 62;
+        bytes['_'] = 63; bytes['/'] = 63;
+
+        var sb = new StringBuilder().Append('[');
+
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            if (i % 16 == 0) sb.AppendLine();
+            var str = Convert.ToString(bytes[i], 16);
+            sb.Append("0x").Append(str.Length == 1 ? "0" : "").Append(str).Append(", ");
+        }
+
+        sb.AppendLine().Append("];");
+
+        Console.WriteLine(sb.Replace("0xff", "None"));
+
+        bytes.Distinct().Should().HaveCount(65);
+    }
+
+    [Test]
+    public void Lookup_Base32()
+    {
+        var values = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        var bytes = new byte[256];
+        for (var i = 0; i < bytes.Length; i++) { bytes[i] = 255; }
+
+        for(byte i = 0; i < 32; i++)
+        {
+            bytes[values[i]] = i;
+            bytes[char.ToLowerInvariant(values[i])] = i;
+        }
+
+        bytes['0'] = bytes['O'];
+        bytes['1'] = bytes['I'];
+
+        var sb = new StringBuilder().Append('[');
+
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            if (i % 16 == 0) sb.AppendLine();
+            var str = Convert.ToString(bytes[i], 16);
+            sb.Append("0x").Append(str.Length == 1 ? "0" : "").Append(str).Append(", ");
+        }
+
+        sb.AppendLine().Append("];");
+
+        Console.WriteLine(sb.Replace("0xff", "None"));
+
+        bytes.Distinct().Should().HaveCount(33);
+    }
+}
+#endif

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -129,6 +129,64 @@ public class Can_be_parsed
         Uuid.Parse(string.Empty).Should().Be(Uuid.Empty);
     }
 
+    public class from_GUID
+    {
+        [Test]
+        public void LowerCase()
+            => Uuid.Parse("8a1a8c42-d2ff-e254-e26e-b6abcbf19420").Should().Be(Svo.Uuid);
+
+        [Test]
+        public void UpperCase()
+            => Uuid.Parse("8A1A8C42-D2FF-E254-E26E-B6ABCBF19420").Should().Be(Svo.Uuid);
+
+        [Test]
+        public void With_brackets()
+            => Uuid.Parse("(8A1A8C42-D2FF-E254-E26E-B6ABCBF19420)").Should().Be(Svo.Uuid);
+
+        [Test]
+        public void With_curly_brackets()
+            => Uuid.Parse("{8A1A8C42-D2FF-E254-E26E-B6ABCBF19420}").Should().Be(Svo.Uuid);
+
+        [Test]
+        public void without_dashes()
+            => Uuid.Parse("8A1A8C42D2FFE254E26EB6ABCBF19420").Should().Be(Svo.Uuid);
+    }
+    
+    public class from_Base64
+    {
+        [TestCase("Qowaiv_SVOLibrary_GUIA=")]
+        [TestCase("Qowaiv_SVOLibrary_GUIA==")]
+        public void with_equal_sign_suffix(string s)
+            => Uuid.Parse(s).Should().Be(Svo.Uuid);
+
+        [Test]
+        public void with_under_scores_equvilent_to_forward_slashes()
+            => Uuid.Parse("Qowaiv/SVOLibrary/GUIA").Should().Be(Uuid.Parse("Qowaiv_SVOLibrary_GUIA"));
+
+        [Test]
+        public void with_dashes_equvilent_to_plusses()
+            => Uuid.Parse("Qowaiv-SVOLibrary-GUIA").Should().Be(Uuid.Parse("Qowaiv+SVOLibrary+GUIA"));
+    }
+
+    public class from_Base32
+    {
+        [Test]
+        public void LowerCase()
+            => Uuid.Parse("ikgbvcx72jkofytow2v4x4muea").Should().Be(Svo.Uuid);
+
+        [Test]
+        public void UpperCase()
+            => Uuid.Parse("IKGBVCX72JKOFYTOW2V4X4MUEA").Should().Be(Svo.Uuid);
+
+        [Test]
+        public void with_0s_equivilent_to_Os()
+            => Uuid.Parse("IKGBVCX72JK0FYT0W2V4X4MUEA").Should().Be(Uuid.Parse("IKGBVCX72JKOFYTOW2V4X4MUEA"));
+
+        [Test]
+        public void with_1s_equivilent_to_Is()
+            => Uuid.Parse("1KGBVCX72JKOFYTOW2V4X4MUEA").Should().Be(Uuid.Parse("IKGBVCX72JKOFYTOW2V4X4MUEA"));
+    }
+    
     [TestCase("en", "Qowaiv_SVOLibrary_GUIA")]
     [TestCase("en", "8A1A8C42-D2FF-E254-E26E-B6ABCBF19420")]
     public void from_string_with_different_formatting_and_cultures(CultureInfo culture, string input)

--- a/specs/Qowaiv.Specs/UUID_specs.cs
+++ b/specs/Qowaiv.Specs/UUID_specs.cs
@@ -225,6 +225,16 @@ public class Can_be_parsed
     }
 }
 
+public class Can_not_be_parsed
+{
+    public class from_Base64
+    {
+        [Test]
+        public void with_suffix_containing_non_equals_char()
+            => Uuid.TryParse("0123456789012345678901=@").Should().BeNull();
+    }
+}
+
 public class Can_be_created
 {
     [Test]

--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -178,7 +178,10 @@ public partial struct Timestamp
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Timestamp Parse(string? s) => Parse(s, null);
+    public static Timestamp Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Timestamp>(s, QowaivMessages.FormatExceptionTimestamp);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
     /// <param name="s">
@@ -194,9 +197,10 @@ public partial struct Timestamp
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Timestamp Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Timestamp>(s, QowaivMessages.FormatExceptionTimestamp);
+    public static Timestamp Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Timestamp>(s, QowaivMessages.FormatExceptionTimestamp);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
     /// <param name="s">
@@ -206,7 +210,10 @@ public partial struct Timestamp
     /// The timestamp if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Timestamp? TryParse(string? s) => TryParse(s, null);
+    public static Timestamp? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Timestamp?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.</summary>
     /// <param name="s">
@@ -219,7 +226,10 @@ public partial struct Timestamp
     /// The timestamp if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Timestamp? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Timestamp?);
+    public static Timestamp? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Timestamp?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Extensions/System.Guid.cs
+++ b/src/Qowaiv/Extensions/System.Guid.cs
@@ -1,4 +1,5 @@
 ﻿using Qowaiv;
+using Qowaiv.Identifiers;
 
 namespace System;
 
@@ -7,10 +8,5 @@ public static class QowaivGuidExtensions
 {
     /// <summary>Gets the version of the <see cref="Guid"/>.</summary>
     [Pure]
-    public static UuidVersion GetVersion(this Guid guid)
-    {
-        var bytes = guid.ToByteArray();
-        var version = bytes[Uuid.IndexOfVersion] >> 4;
-        return (UuidVersion)version;
-    }
+    public static UuidVersion GetVersion(this Guid guid) => GuidLayout.From(guid).Version;
 }

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -190,7 +190,10 @@ public partial struct CasRegistryNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static CasRegistryNumber Parse(string? s) => Parse(s, null);
+    public static CasRegistryNumber Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<CasRegistryNumber>(s, QowaivMessages.FormatExceptionCasRegistryNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="CasRegistryNumber"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct CasRegistryNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static CasRegistryNumber Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<CasRegistryNumber>(s, QowaivMessages.FormatExceptionCasRegistryNumber);
+    public static CasRegistryNumber Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<CasRegistryNumber>(s, QowaivMessages.FormatExceptionCasRegistryNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="CasRegistryNumber"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct CasRegistryNumber
     /// The CAS Registry Number if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static CasRegistryNumber? TryParse(string? s) => TryParse(s, null);
+    public static CasRegistryNumber? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(CasRegistryNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="CasRegistryNumber"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct CasRegistryNumber
     /// The CAS Registry Number if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static CasRegistryNumber? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(CasRegistryNumber?);
+    public static CasRegistryNumber? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(CasRegistryNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="CasRegistryNumber"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -169,7 +169,10 @@ public partial struct Date
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Date Parse(string? s) => Parse(s, null);
+    public static Date Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Date>(s, QowaivMessages.FormatExceptionDate);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
     /// <param name="s">
@@ -185,9 +188,10 @@ public partial struct Date
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Date Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Date>(s, QowaivMessages.FormatExceptionDate);
+    public static Date Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Date>(s, QowaivMessages.FormatExceptionDate);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
     /// <param name="s">
@@ -197,7 +201,10 @@ public partial struct Date
     /// The date if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Date? TryParse(string? s) => TryParse(s, null);
+    public static Date? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Date?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.</summary>
     /// <param name="s">
@@ -210,7 +217,10 @@ public partial struct Date
     /// The date if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Date? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Date?);
+    public static Date? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Date?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -164,7 +164,10 @@ public partial struct DateSpan
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static DateSpan Parse(string? s) => Parse(s, null);
+    public static DateSpan Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<DateSpan>(s, QowaivMessages.FormatExceptionDateSpan);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
     /// <param name="s">
@@ -180,9 +183,10 @@ public partial struct DateSpan
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static DateSpan Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<DateSpan>(s, QowaivMessages.FormatExceptionDateSpan);
+    public static DateSpan Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<DateSpan>(s, QowaivMessages.FormatExceptionDateSpan);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
     /// <param name="s">
@@ -192,7 +196,10 @@ public partial struct DateSpan
     /// The date span if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static DateSpan? TryParse(string? s) => TryParse(s, null);
+    public static DateSpan? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(DateSpan?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.</summary>
     /// <param name="s">
@@ -205,7 +212,10 @@ public partial struct DateSpan
     /// The date span if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static DateSpan? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(DateSpan?);
+    public static DateSpan? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(DateSpan?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -190,7 +190,10 @@ public partial struct EmailAddress
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static EmailAddress Parse(string? s) => Parse(s, null);
+    public static EmailAddress Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<EmailAddress>(s, QowaivMessages.FormatExceptionEmailAddress);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct EmailAddress
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static EmailAddress Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<EmailAddress>(s, QowaivMessages.FormatExceptionEmailAddress);
+    public static EmailAddress Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<EmailAddress>(s, QowaivMessages.FormatExceptionEmailAddress);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct EmailAddress
     /// The email address if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static EmailAddress? TryParse(string? s) => TryParse(s, null);
+    public static EmailAddress? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(EmailAddress?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct EmailAddress
     /// The email address if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static EmailAddress? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(EmailAddress?);
+    public static EmailAddress? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(EmailAddress?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -178,7 +178,10 @@ public partial struct Amount
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Amount Parse(string? s) => Parse(s, null);
+    public static Amount Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Amount>(s, QowaivMessages.FormatExceptionFinancialAmount);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
     /// <param name="s">
@@ -194,9 +197,10 @@ public partial struct Amount
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Amount Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Amount>(s, QowaivMessages.FormatExceptionFinancialAmount);
+    public static Amount Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Amount>(s, QowaivMessages.FormatExceptionFinancialAmount);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
     /// <param name="s">
@@ -206,7 +210,10 @@ public partial struct Amount
     /// The amount if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Amount? TryParse(string? s) => TryParse(s, null);
+    public static Amount? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Amount?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.</summary>
     /// <param name="s">
@@ -219,7 +226,10 @@ public partial struct Amount
     /// The amount if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Amount? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Amount?);
+    public static Amount? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Amount?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -190,7 +190,10 @@ public partial struct BusinessIdentifierCode
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static BusinessIdentifierCode Parse(string? s) => Parse(s, null);
+    public static BusinessIdentifierCode Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<BusinessIdentifierCode>(s, QowaivMessages.FormatExceptionBusinessIdentifierCode);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct BusinessIdentifierCode
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static BusinessIdentifierCode Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<BusinessIdentifierCode>(s, QowaivMessages.FormatExceptionBusinessIdentifierCode);
+    public static BusinessIdentifierCode Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<BusinessIdentifierCode>(s, QowaivMessages.FormatExceptionBusinessIdentifierCode);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct BusinessIdentifierCode
     /// The BIC if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static BusinessIdentifierCode? TryParse(string? s) => TryParse(s, null);
+    public static BusinessIdentifierCode? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(BusinessIdentifierCode?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct BusinessIdentifierCode
     /// The BIC if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static BusinessIdentifierCode? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(BusinessIdentifierCode?);
+    public static BusinessIdentifierCode? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(BusinessIdentifierCode?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -190,7 +190,10 @@ public partial struct Currency
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Currency Parse(string? s) => Parse(s, null);
+    public static Currency Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Currency>(s, QowaivMessages.FormatExceptionCurrency);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct Currency
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Currency Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Currency>(s, QowaivMessages.FormatExceptionCurrency);
+    public static Currency Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Currency>(s, QowaivMessages.FormatExceptionCurrency);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct Currency
     /// The currency if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Currency? TryParse(string? s) => TryParse(s, null);
+    public static Currency? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Currency?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct Currency
     /// The currency if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Currency? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Currency?);
+    public static Currency? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Currency?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -190,7 +190,10 @@ public partial struct InternationalBankAccountNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static InternationalBankAccountNumber Parse(string? s) => Parse(s, null);
+    public static InternationalBankAccountNumber Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<InternationalBankAccountNumber>(s, QowaivMessages.FormatExceptionInternationalBankAccountNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct InternationalBankAccountNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static InternationalBankAccountNumber Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<InternationalBankAccountNumber>(s, QowaivMessages.FormatExceptionInternationalBankAccountNumber);
+    public static InternationalBankAccountNumber Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<InternationalBankAccountNumber>(s, QowaivMessages.FormatExceptionInternationalBankAccountNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct InternationalBankAccountNumber
     /// The IBAN if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static InternationalBankAccountNumber? TryParse(string? s) => TryParse(s, null);
+    public static InternationalBankAccountNumber? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(InternationalBankAccountNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct InternationalBankAccountNumber
     /// The IBAN if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static InternationalBankAccountNumber? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(InternationalBankAccountNumber?);
+    public static InternationalBankAccountNumber? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(InternationalBankAccountNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -134,7 +134,10 @@ public partial struct Money
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Money Parse(string? s) => Parse(s, null);
+    public static Money Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Money>(s, QowaivMessages.FormatExceptionMoney);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
     /// <param name="s">
@@ -150,9 +153,10 @@ public partial struct Money
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Money Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Money>(s, QowaivMessages.FormatExceptionMoney);
+    public static Money Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Money>(s, QowaivMessages.FormatExceptionMoney);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
     /// <param name="s">
@@ -162,7 +166,10 @@ public partial struct Money
     /// The money if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Money? TryParse(string? s) => TryParse(s, null);
+    public static Money? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Money?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.</summary>
     /// <param name="s">
@@ -175,7 +182,10 @@ public partial struct Money
     /// The money if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Money? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Money?);
+    public static Money? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Money?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -190,7 +190,10 @@ public partial struct Country
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Country Parse(string? s) => Parse(s, null);
+    public static Country Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Country>(s, QowaivMessages.FormatExceptionCountry);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct Country
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Country Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Country>(s, QowaivMessages.FormatExceptionCountry);
+    public static Country Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Country>(s, QowaivMessages.FormatExceptionCountry);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct Country
     /// The country if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Country? TryParse(string? s) => TryParse(s, null);
+    public static Country? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Country?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct Country
     /// The country if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Country? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Country?);
+    public static Country? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Country?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -204,7 +204,10 @@ public partial struct HouseNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static HouseNumber Parse(string? s) => Parse(s, null);
+    public static HouseNumber Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<HouseNumber>(s, QowaivMessages.FormatExceptionHouseNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
     /// <param name="s">
@@ -220,9 +223,10 @@ public partial struct HouseNumber
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static HouseNumber Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<HouseNumber>(s, QowaivMessages.FormatExceptionHouseNumber);
+    public static HouseNumber Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<HouseNumber>(s, QowaivMessages.FormatExceptionHouseNumber);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
     /// <param name="s">
@@ -232,7 +236,10 @@ public partial struct HouseNumber
     /// The house number if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static HouseNumber? TryParse(string? s) => TryParse(s, null);
+    public static HouseNumber? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(HouseNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.</summary>
     /// <param name="s">
@@ -245,7 +252,10 @@ public partial struct HouseNumber
     /// The house number if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static HouseNumber? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(HouseNumber?);
+    public static HouseNumber? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(HouseNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -148,7 +148,10 @@ public partial struct StreamSize
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static StreamSize Parse(string? s) => Parse(s, null);
+    public static StreamSize Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<StreamSize>(s, QowaivMessages.FormatExceptionStreamSize);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
     /// <param name="s">
@@ -164,9 +167,10 @@ public partial struct StreamSize
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static StreamSize Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<StreamSize>(s, QowaivMessages.FormatExceptionStreamSize);
+    public static StreamSize Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<StreamSize>(s, QowaivMessages.FormatExceptionStreamSize);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
     /// <param name="s">
@@ -176,7 +180,10 @@ public partial struct StreamSize
     /// The stream size if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static StreamSize? TryParse(string? s) => TryParse(s, null);
+    public static StreamSize? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(StreamSize?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.</summary>
     /// <param name="s">
@@ -189,7 +196,10 @@ public partial struct StreamSize
     /// The stream size if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static StreamSize? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(StreamSize?);
+    public static StreamSize? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(StreamSize?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -169,7 +169,10 @@ public partial struct LocalDateTime
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static LocalDateTime Parse(string? s) => Parse(s, null);
+    public static LocalDateTime Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<LocalDateTime>(s, QowaivMessages.FormatExceptionLocalDateTime);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
     /// <param name="s">
@@ -185,9 +188,10 @@ public partial struct LocalDateTime
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static LocalDateTime Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<LocalDateTime>(s, QowaivMessages.FormatExceptionLocalDateTime);
+    public static LocalDateTime Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<LocalDateTime>(s, QowaivMessages.FormatExceptionLocalDateTime);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
     /// <param name="s">
@@ -197,7 +201,10 @@ public partial struct LocalDateTime
     /// The local date time if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static LocalDateTime? TryParse(string? s) => TryParse(s, null);
+    public static LocalDateTime? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(LocalDateTime?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.</summary>
     /// <param name="s">
@@ -210,7 +217,10 @@ public partial struct LocalDateTime
     /// The local date time if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static LocalDateTime? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(LocalDateTime?);
+    public static LocalDateTime? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(LocalDateTime?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -134,7 +134,10 @@ public partial struct Fraction
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Fraction Parse(string? s) => Parse(s, null);
+    public static Fraction Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Fraction>(s, QowaivMessages.FormatExceptionFraction);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
     /// <param name="s">
@@ -150,9 +153,10 @@ public partial struct Fraction
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Fraction Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Fraction>(s, QowaivMessages.FormatExceptionFraction);
+    public static Fraction Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Fraction>(s, QowaivMessages.FormatExceptionFraction);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
     /// <param name="s">
@@ -162,7 +166,10 @@ public partial struct Fraction
     /// The fraction if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Fraction? TryParse(string? s) => TryParse(s, null);
+    public static Fraction? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Fraction?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.</summary>
     /// <param name="s">
@@ -175,7 +182,10 @@ public partial struct Fraction
     /// The fraction if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Fraction? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Fraction?);
+    public static Fraction? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Fraction?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -190,7 +190,10 @@ public partial struct Month
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Month Parse(string? s) => Parse(s, null);
+    public static Month Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Month>(s, QowaivMessages.FormatExceptionMonth);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct Month
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Month Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Month>(s, QowaivMessages.FormatExceptionMonth);
+    public static Month Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Month>(s, QowaivMessages.FormatExceptionMonth);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct Month
     /// The month if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Month? TryParse(string? s) => TryParse(s, null);
+    public static Month? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Month?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct Month
     /// The month if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Month? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Month?);
+    public static Month? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Month?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -178,7 +178,10 @@ public partial struct MonthSpan
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static MonthSpan Parse(string? s) => Parse(s, null);
+    public static MonthSpan Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<MonthSpan>(s, QowaivMessages.FormatExceptionMonthSpan);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
     /// <param name="s">
@@ -194,9 +197,10 @@ public partial struct MonthSpan
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static MonthSpan Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<MonthSpan>(s, QowaivMessages.FormatExceptionMonthSpan);
+    public static MonthSpan Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<MonthSpan>(s, QowaivMessages.FormatExceptionMonthSpan);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
     /// <param name="s">
@@ -206,7 +210,10 @@ public partial struct MonthSpan
     /// The month span if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static MonthSpan? TryParse(string? s) => TryParse(s, null);
+    public static MonthSpan? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(MonthSpan?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.</summary>
     /// <param name="s">
@@ -219,7 +226,10 @@ public partial struct MonthSpan
     /// The month span if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static MonthSpan? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(MonthSpan?);
+    public static MonthSpan? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(MonthSpan?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -178,7 +178,10 @@ public partial struct Percentage
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Percentage Parse(string? s) => Parse(s, null);
+    public static Percentage Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Percentage>(s, QowaivMessages.FormatExceptionPercentage);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
     /// <param name="s">
@@ -194,9 +197,10 @@ public partial struct Percentage
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Percentage Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Percentage>(s, QowaivMessages.FormatExceptionPercentage);
+    public static Percentage Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Percentage>(s, QowaivMessages.FormatExceptionPercentage);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
     /// <param name="s">
@@ -206,7 +210,10 @@ public partial struct Percentage
     /// The percentage if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Percentage? TryParse(string? s) => TryParse(s, null);
+    public static Percentage? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Percentage?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.</summary>
     /// <param name="s">
@@ -219,7 +226,10 @@ public partial struct Percentage
     /// The percentage if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Percentage? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Percentage?);
+    public static Percentage? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Percentage?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -190,7 +190,10 @@ public partial struct PostalCode
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static PostalCode Parse(string? s) => Parse(s, null);
+    public static PostalCode Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<PostalCode>(s, QowaivMessages.FormatExceptionPostalCode);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct PostalCode
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static PostalCode Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<PostalCode>(s, QowaivMessages.FormatExceptionPostalCode);
+    public static PostalCode Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<PostalCode>(s, QowaivMessages.FormatExceptionPostalCode);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct PostalCode
     /// The postal code if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static PostalCode? TryParse(string? s) => TryParse(s, null);
+    public static PostalCode? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(PostalCode?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct PostalCode
     /// The postal code if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static PostalCode? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(PostalCode?);
+    public static PostalCode? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(PostalCode?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -190,7 +190,10 @@ public partial struct Sex
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Sex Parse(string? s) => Parse(s, null);
+    public static Sex Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Sex>(s, QowaivMessages.FormatExceptionSex);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct Sex
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Sex Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Sex>(s, QowaivMessages.FormatExceptionSex);
+    public static Sex Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Sex>(s, QowaivMessages.FormatExceptionSex);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct Sex
     /// The sex if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Sex? TryParse(string? s) => TryParse(s, null);
+    public static Sex? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Sex?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct Sex
     /// The sex if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Sex? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Sex?);
+    public static Sex? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Sex?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -178,7 +178,10 @@ public partial struct Elo
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Elo Parse(string? s) => Parse(s, null);
+    public static Elo Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Elo>(s, QowaivMessages.FormatExceptionElo);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
     /// <param name="s">
@@ -194,9 +197,10 @@ public partial struct Elo
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Elo Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Elo>(s, QowaivMessages.FormatExceptionElo);
+    public static Elo Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Elo>(s, QowaivMessages.FormatExceptionElo);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
     /// <param name="s">
@@ -206,7 +210,10 @@ public partial struct Elo
     /// The elo if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Elo? TryParse(string? s) => TryParse(s, null);
+    public static Elo? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Elo?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.</summary>
     /// <param name="s">
@@ -219,7 +226,10 @@ public partial struct Elo
     /// The elo if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Elo? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Elo?);
+    public static Elo? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Elo?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
+++ b/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
@@ -190,7 +190,10 @@ public partial struct EnergyLabel
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static EnergyLabel Parse(string? s) => Parse(s, null);
+    public static EnergyLabel Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<EnergyLabel>(s, QowaivMessages.FormatExceptionEnergyLabel);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EnergyLabel"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct EnergyLabel
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static EnergyLabel Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<EnergyLabel>(s, QowaivMessages.FormatExceptionEnergyLabel);
+    public static EnergyLabel Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<EnergyLabel>(s, QowaivMessages.FormatExceptionEnergyLabel);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EnergyLabel"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct EnergyLabel
     /// The EU energy label if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static EnergyLabel? TryParse(string? s) => TryParse(s, null);
+    public static EnergyLabel? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(EnergyLabel?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EnergyLabel"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct EnergyLabel
     /// The EU energy label if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static EnergyLabel? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(EnergyLabel?);
+    public static EnergyLabel? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(EnergyLabel?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EnergyLabel"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -178,7 +178,10 @@ public partial struct Uuid
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Uuid Parse(string? s) => Parse(s, null);
+    public static Uuid Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Uuid>(s, QowaivMessages.FormatExceptionUuid);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
     /// <param name="s">
@@ -194,9 +197,10 @@ public partial struct Uuid
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Uuid Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Uuid>(s, QowaivMessages.FormatExceptionUuid);
+    public static Uuid Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Uuid>(s, QowaivMessages.FormatExceptionUuid);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
     /// <param name="s">
@@ -206,7 +210,10 @@ public partial struct Uuid
     /// The UUID if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Uuid? TryParse(string? s) => TryParse(s, null);
+    public static Uuid? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Uuid?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.</summary>
     /// <param name="s">
@@ -219,7 +226,10 @@ public partial struct Uuid
     /// The UUID if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Uuid? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Uuid?);
+    public static Uuid? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Uuid?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -204,7 +204,10 @@ public partial struct InternetMediaType
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static InternetMediaType Parse(string? s) => Parse(s, null);
+    public static InternetMediaType Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<InternetMediaType>(s, QowaivMessages.FormatExceptionInternetMediaType);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
     /// <param name="s">
@@ -220,9 +223,10 @@ public partial struct InternetMediaType
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static InternetMediaType Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<InternetMediaType>(s, QowaivMessages.FormatExceptionInternetMediaType);
+    public static InternetMediaType Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<InternetMediaType>(s, QowaivMessages.FormatExceptionInternetMediaType);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
     /// <param name="s">
@@ -232,7 +236,10 @@ public partial struct InternetMediaType
     /// The Internet media type if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static InternetMediaType? TryParse(string? s) => TryParse(s, null);
+    public static InternetMediaType? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(InternetMediaType?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.</summary>
     /// <param name="s">
@@ -245,7 +252,10 @@ public partial struct InternetMediaType
     /// The Internet media type if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static InternetMediaType? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(InternetMediaType?);
+    public static InternetMediaType? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(InternetMediaType?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -148,7 +148,10 @@ public partial struct WeekDate
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static WeekDate Parse(string? s) => Parse(s, null);
+    public static WeekDate Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<WeekDate>(s, QowaivMessages.FormatExceptionWeekDate);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
     /// <param name="s">
@@ -164,9 +167,10 @@ public partial struct WeekDate
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static WeekDate Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<WeekDate>(s, QowaivMessages.FormatExceptionWeekDate);
+    public static WeekDate Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<WeekDate>(s, QowaivMessages.FormatExceptionWeekDate);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
     /// <param name="s">
@@ -176,7 +180,10 @@ public partial struct WeekDate
     /// The week date if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static WeekDate? TryParse(string? s) => TryParse(s, null);
+    public static WeekDate? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(WeekDate?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.</summary>
     /// <param name="s">
@@ -189,7 +196,10 @@ public partial struct WeekDate
     /// The week date if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static WeekDate? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(WeekDate?);
+    public static WeekDate? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(WeekDate?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -190,7 +190,10 @@ public partial struct Year
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Year Parse(string? s) => Parse(s, null);
+    public static Year Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Year>(s, QowaivMessages.FormatExceptionYear);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct Year
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static Year Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<Year>(s, QowaivMessages.FormatExceptionYear);
+    public static Year Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<Year>(s, QowaivMessages.FormatExceptionYear);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct Year
     /// The year if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Year? TryParse(string? s) => TryParse(s, null);
+    public static Year? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(Year?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct Year
     /// The year if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Year? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(Year?);
+    public static Year? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(Year?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -190,7 +190,10 @@ public partial struct YesNo
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static YesNo Parse(string? s) => Parse(s, null);
+    public static YesNo Parse(string? s)
+        => TryParse(s, null, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<YesNo>(s, QowaivMessages.FormatExceptionYesNo);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
     /// <param name="s">
@@ -206,9 +209,10 @@ public partial struct YesNo
     /// <paramref name="s"/> is not in the correct format.
     /// </exception>
     [Pure]
-    public static YesNo Parse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider) 
-        ?? throw Unparsable.ForValue<YesNo>(s, QowaivMessages.FormatExceptionYesNo);
+    public static YesNo Parse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var svo)
+            ? svo
+            : throw Unparsable.ForValue<YesNo>(s, QowaivMessages.FormatExceptionYesNo);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
     /// <param name="s">
@@ -218,7 +222,10 @@ public partial struct YesNo
     /// The yes-no if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static YesNo? TryParse(string? s) => TryParse(s, null);
+    public static YesNo? TryParse(string? s)
+        => TryParse(s, null, out var val)
+            ? val
+            : default(YesNo?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.</summary>
     /// <param name="s">
@@ -231,7 +238,10 @@ public partial struct YesNo
     /// The yes-no if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static YesNo? TryParse(string? s, IFormatProvider? provider) => TryParse(s, provider, out var val) ? val : default(YesNo?);
+    public static YesNo? TryParse(string? s, IFormatProvider? provider) 
+        => TryParse(s, provider, out var val) 
+            ? val 
+            : default(YesNo?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.
     /// A return value indicates whether the conversion succeeded.

--- a/src/Qowaiv/Identifiers/GuidBehavior.cs
+++ b/src/Qowaiv/Identifiers/GuidBehavior.cs
@@ -77,7 +77,7 @@ public class GuidBehavior : IdentifierBehavior
     private static string Tostring(Guid id, string format, IFormatProvider? formatProvider)
         => format switch
         {
-            "s" or "S" => ToBase64String(id),
+            "s" or "S" => Base64.ToString(id),
             "h" => Base32.ToString(id.ToByteArray(), true),
             "H" => Base32.ToString(id.ToByteArray(), false),
             "N" or "D" or "B" or "P" => id.ToString(format, formatProvider).ToUpperInvariant(),
@@ -86,14 +86,12 @@ public class GuidBehavior : IdentifierBehavior
         };
 #pragma warning restore S1541 // Methods and properties should not be too complex
 
-    /// <remarks>Avoids invalid URL characters.</remarks>
-    [Pure]
-    private static string ToBase64String(Guid id)
-        => Convert.ToBase64String(id.ToByteArray()).Replace('+', '-').Replace('/', '_')[..22];
-
     /// <inheritdoc/>
     [Pure]
-    public override object? ToJson(object? obj) => ToString(obj, DefaultFormat, CultureInfo.InvariantCulture);
+    public override object? ToJson(object? obj)
+        => obj is Guid guid
+            ? guid.ToString()
+            : null;
 
     /// <inheritdoc/>
     [Pure]

--- a/src/Qowaiv/Identifiers/GuidBehavior.cs
+++ b/src/Qowaiv/Identifiers/GuidBehavior.cs
@@ -99,43 +99,27 @@ public class GuidBehavior : IdentifierBehavior
     [Pure]
     public override bool TryParse(string? str, out object? id)
     {
+        id = null;
         if (str is not { Length: > 0 })
         {
-            id = default;
             return true;
         }
-        else if (Guid.TryParse(str, out Guid guid))
+        else if (Guid.TryParse(str, out var guid))
         {
             id = NullIfEmpty(guid);
             return true;
         }
-        else if (Uuid.Pattern.IsMatch(str))
+        else if (GuidParser.TryBase64(str, out var base64))
         {
-            id = NullIfEmpty(GuidFromBase64(str));
+            id = NullIfEmpty(base64);
             return true;
         }
-        else if (str.Length == 26 && Base32.TryGetBytes(str, out var b32))
+        else if (GuidParser.TryBase32(str, out var base32))
         {
-            id = NullIfEmpty(new Guid(b32));
+            id = NullIfEmpty(base32);
             return true;
         }
-        else
-        {
-            id = default;
-            return false;
-        }
-
-        static Guid GuidFromBase64(string str)
-        {
-            var base64 = new char[24];
-            for (int i = 0; i < 22; i++)
-            {
-                base64[i] = str[i] switch { '-' => '+', '_' => '/', _ => str[i] };
-            }
-            base64[22] = '=';
-            base64[23] = '=';
-            return new Guid(Convert.FromBase64String(new string(base64)));
-        }
+        else return false;
 
         static object? NullIfEmpty(Guid guid) => guid == Guid.Empty ? null : guid;
     }

--- a/src/Qowaiv/Identifiers/GuidLayout.cs
+++ b/src/Qowaiv/Identifiers/GuidLayout.cs
@@ -1,0 +1,43 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Qowaiv.Identifiers;
+
+[StructLayout(LayoutKind.Explicit)]
+internal struct GuidLayout
+{
+    // This will store the result of the parsing. And it will eventually be used to construct a Guid instance.
+    // We'll eventually reinterpret_cast<> a GuidLayout as a Guid, so we need to give it a sequential
+    // layout and ensure that its early fields match the layout of Guid exactly.
+    [FieldOffset(0)]
+    internal uint _a;
+    [FieldOffset(4)]
+    internal uint _bc;
+    [FieldOffset(4)]
+    internal ushort _b;
+    [FieldOffset(6)]
+    internal ushort _c;
+    [FieldOffset(8)]
+    internal uint _defg;
+    [FieldOffset(8)]
+    internal ushort _de;
+    [FieldOffset(8)]
+    internal byte _d;
+    [FieldOffset(10)]
+    internal ushort _fg;
+    [FieldOffset(12)]
+    internal uint _hijk;
+
+    [FieldOffset(7)]
+    internal byte _version;
+
+    /// <summary>Gets the upper 4 bits of byte 7 that holds the version.</summary>
+    public readonly UuidVersion Version => (UuidVersion)(_version >> 4);
+
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly Guid ToGuid() => Unsafe.As<GuidLayout, Guid>(ref Unsafe.AsRef(in this));
+
+    [Pure]
+    public static GuidLayout From(Guid value) => Unsafe.As<Guid, GuidLayout>(ref Unsafe.AsRef(in value));
+}

--- a/src/Qowaiv/Identifiers/GuidParser.cs
+++ b/src/Qowaiv/Identifiers/GuidParser.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace Qowaiv.Identifiers;
 
@@ -137,41 +136,4 @@ internal static class GuidParser
         None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
         None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
     ];
-
-    // This will store the result of the parsing. And it will eventually be used to construct a Guid instance.
-    // We'll eventually reinterpret_cast<> a GuidLayout as a Guid, so we need to give it a sequential
-    // layout and ensure that its early fields match the layout of Guid exactly.
-    [StructLayout(LayoutKind.Explicit)]
-    private struct GuidLayout
-    {
-        [FieldOffset(0)]
-        internal uint _a;
-        [FieldOffset(4)]
-        internal uint _bc;
-        [FieldOffset(4)]
-        internal ushort _b;
-        [FieldOffset(6)]
-        internal ushort _c;
-        [FieldOffset(8)]
-        internal uint _defg;
-        [FieldOffset(8)]
-        internal ushort _de;
-        [FieldOffset(8)]
-        internal byte _d;
-        [FieldOffset(10)]
-        internal ushort _fg;
-        [FieldOffset(12)]
-        internal uint _hijk;
-
-        [FieldOffset(0)]
-        internal ulong lo;
-        [FieldOffset(4)]
-        internal ulong mi;
-        [FieldOffset(8)]
-        internal ulong hi;
-
-        [Pure]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public readonly Guid ToGuid() => Unsafe.As<GuidLayout, Guid>(ref Unsafe.AsRef(in this));
-    }
 }

--- a/src/Qowaiv/Identifiers/GuidParser.cs
+++ b/src/Qowaiv/Identifiers/GuidParser.cs
@@ -1,0 +1,177 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Qowaiv.Identifiers;
+
+/// <summary><see cref="Guid"/> parser for Base64 and Base32 strings.</summary>
+internal static class GuidParser
+{
+    private const byte None = 255;
+
+    /// <summary>Tries to parse a <see cref="Guid"/> from a Base64 string.</summary>
+    [Pure]
+    public static bool TryBase64(string s, out Guid guid)
+    {
+        guid = Guid.Empty;
+
+        // Wrong length.
+        if (s.Length < 22 || s.Length > 24) return false;
+
+        // Invalid suffix.
+        for (var i = 22; i < s.Length; i++) { if (s[i] != '=') return false; }
+
+        var success = true;
+
+#if NET8_0_OR_GREATER
+        GuidLayout layout = default;
+        Span<byte> bytes = MemoryMarshal.AsBytes(new Span<GuidLayout>(ref layout));
+#else
+        var bytes = new byte[16];
+#endif
+        success &= Write0(s[00], bytes, 00);
+        success &= Write1(s[01], bytes, 00);
+        success &= Write2(s[02], bytes, 01);
+        success &= Write3(s[03], bytes, 02);
+        success &= Write0(s[04], bytes, 03);
+        success &= Write1(s[05], bytes, 03);
+        success &= Write2(s[06], bytes, 04);
+        success &= Write3(s[07], bytes, 05);
+        success &= Write0(s[08], bytes, 06);
+        success &= Write1(s[09], bytes, 06);
+        success &= Write2(s[10], bytes, 07);
+        success &= Write3(s[11], bytes, 08);
+        success &= Write0(s[12], bytes, 09);
+        success &= Write1(s[13], bytes, 09);
+        success &= Write2(s[14], bytes, 10);
+        success &= Write3(s[15], bytes, 11);
+        success &= Write0(s[16], bytes, 12);
+        success &= Write1(s[17], bytes, 12);
+        success &= Write2(s[18], bytes, 13);
+        success &= Write3(s[19], bytes, 14);
+        success &= Write0(s[20], bytes, 15);
+        success &= WriteLast(s[21], bytes);
+
+#if NET8_0_OR_GREATER
+        guid = layout.ToGuid();
+#else
+        guid = new Guid(bytes);
+#endif
+        return success;
+
+        // 01234567 01234567 0123456
+        // ..012345 ........ .......
+        static bool Write0(char ch, Span<byte> bytes, int index)
+        {
+            var val = Base64Lookup[(byte)ch];
+            bytes[index] |= (byte)(val << 2);
+            return val != None;
+        }
+
+        // 01234567 01234567 01234567
+        // 67****** ....0123 ........
+        static bool Write1(char ch, Span<byte> bytes, int index)
+        {
+            var val = Base64Lookup[(byte)ch];
+            bytes[index] |= (byte)(val >> 4);
+            bytes[index + 1] |= (byte)(val << 4);
+            return val != None;
+        }
+
+        // 01234567 01234567 01234567
+        // ******** 234**** ......01
+        static bool Write2(char ch, Span<byte> bytes, int index)
+        {
+            var val = Base64Lookup[(byte)ch];
+            bytes[index] |= (byte)(val >> 2);
+            bytes[index + 1] |= (byte)(val << 6);
+            return val != None;
+        }
+
+        // 01234567 01234567 01234567
+        // ******** ******** 012345**
+        static bool Write3(char ch, Span<byte> bytes, int index)
+        {
+            var val = Base64Lookup[(byte)ch];
+            bytes[index] |= val;
+            return val != None;
+        }
+
+        static bool WriteLast(char ch, Span<byte> bytes)
+        {
+            var val = Base64Lookup[(byte)ch];
+            bytes[15] |= (byte)(val >> 4);
+            return val != None;
+        }
+    }
+
+    /// <summary>Tries to parse a <see cref="Guid"/> from a Base64 string.</summary>
+    [Pure]
+    public static bool TryBase32(string s, out Guid guid)
+    {
+        guid = Guid.Empty;
+        if (s.Length == 26 && Base32.TryGetBytes(s, out var base32))
+        {
+            guid = new Guid(base32);
+            return true;
+        }
+        else return false;
+    }
+
+    private static readonly byte[] Base64Lookup =
+    [
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, 0x3e, None, 0x3e, None, 0x3f,
+        0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, None, None, None, None, None, None,
+        None, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, None, None, None, None, 0x3f,
+        None, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, None, None, None, None, None,
+
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    ];
+
+    // This will store the result of the parsing. And it will eventually be used to construct a Guid instance.
+    // We'll eventually reinterpret_cast<> a GuidLayout as a Guid, so we need to give it a sequential
+    // layout and ensure that its early fields match the layout of Guid exactly.
+    [StructLayout(LayoutKind.Explicit)]
+    private struct GuidLayout
+    {
+        [FieldOffset(0)]
+        internal uint _a;
+        [FieldOffset(4)]
+        internal uint _bc;
+        [FieldOffset(4)]
+        internal ushort _b;
+        [FieldOffset(6)]
+        internal ushort _c;
+        [FieldOffset(8)]
+        internal uint _defg;
+        [FieldOffset(8)]
+        internal ushort _de;
+        [FieldOffset(8)]
+        internal byte _d;
+        [FieldOffset(10)]
+        internal ushort _fg;
+        [FieldOffset(12)]
+        internal uint _hijk;
+
+        [FieldOffset(0)]
+        internal ulong lo;
+        [FieldOffset(4)]
+        internal ulong mi;
+        [FieldOffset(8)]
+        internal ulong hi;
+
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly Guid ToGuid() => Unsafe.As<GuidLayout, Guid>(ref Unsafe.AsRef(in this));
+    }
+}

--- a/src/Qowaiv/Identifiers/GuidParser.cs
+++ b/src/Qowaiv/Identifiers/GuidParser.cs
@@ -67,7 +67,7 @@ internal static class GuidParser
         }
 
         // 01234567 01234567 01234567
-        // 67****** ....0123 ........
+        // 45****** ....0123 ........
         static bool Write1(char ch, Span<byte> bytes, int index)
         {
             var val = Base64Lookup[(byte)ch];
@@ -77,7 +77,7 @@ internal static class GuidParser
         }
 
         // 01234567 01234567 01234567
-        // ******** 234**** ......01
+        // ******** 2345**** ......01
         static bool Write2(char ch, Span<byte> bytes, int index)
         {
             var val = Base64Lookup[(byte)ch];

--- a/src/Qowaiv/Identifiers/GuidParser.cs
+++ b/src/Qowaiv/Identifiers/GuidParser.cs
@@ -57,7 +57,7 @@ internal static class GuidParser
 #endif
         return success;
 
-        // 01234567 01234567 0123456
+        // 01234567 01234567 01234567
         // ..012345 ........ .......
         static bool Write0(char ch, Span<byte> bytes, int index)
         {

--- a/src/Qowaiv/Identifiers/UuidBehavior.cs
+++ b/src/Qowaiv/Identifiers/UuidBehavior.cs
@@ -1,4 +1,5 @@
-﻿namespace Qowaiv.Identifiers;
+﻿
+namespace Qowaiv.Identifiers;
 
 /// <summary>Implements <see cref="IIdentifierBehavior"/> for an identifier based on <see cref="Uuid"/>.</summary>
 [OpenApiDataType(description: "UUID based identifier", example: "lmZO_haEOTCwGsCcbIZFFg", type: "string", format: "uuid-base64", nullable: true)]
@@ -11,6 +12,13 @@ public class UuidBehavior : GuidBehavior
 
     /// <summary>Gets the default format used to represent the <see cref="Guid"/> as <see cref="string"/>.</summary>
     protected override string DefaultFormat => "S";
+
+    /// <inheritdoc />
+    [Pure]
+    public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
+        => destinationType == typeof(string)
+            ? ToString(value, DefaultFormat, culture)
+            : base.ConvertTo(context, culture, value, destinationType);
 
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Identifiers/UuidBehavior.cs
+++ b/src/Qowaiv/Identifiers/UuidBehavior.cs
@@ -13,6 +13,13 @@ public class UuidBehavior : GuidBehavior
     protected override string DefaultFormat => "S";
 
     /// <inheritdoc />
+    [Pure]
+    public override object? ToJson(object? obj)
+        => obj is Guid id
+            ? Base64.ToString(id)
+            : null;
+
+    /// <inheritdoc />
     public override bool TryParse(string? str, out object? id)
     {
         id = null;

--- a/src/Qowaiv/Identifiers/UuidBehavior.cs
+++ b/src/Qowaiv/Identifiers/UuidBehavior.cs
@@ -9,6 +9,34 @@ public class UuidBehavior : GuidBehavior
     /// <summary>Initializes a new instance of the <see cref="UuidBehavior"/> class.</summary>
     protected UuidBehavior() { }
 
-    /// <summary>Gets the default format used to represent the <see cref="System.Guid"/> as <see cref="string"/>.</summary>
+    /// <summary>Gets the default format used to represent the <see cref="Guid"/> as <see cref="string"/>.</summary>
     protected override string DefaultFormat => "S";
+
+    /// <inheritdoc />
+    public override bool TryParse(string? str, out object? id)
+    {
+        id = null;
+        if (str is not { Length: > 0 })
+        {
+            return true;
+        }
+        else if (GuidParser.TryBase64(str, out var base64))
+        {
+            id = NullIfEmpty(base64);
+            return true;
+        }
+        else if (Guid.TryParse(str, out var guid))
+        {
+            id = NullIfEmpty(guid);
+            return true;
+        }
+        else if (GuidParser.TryBase32(str, out var base32))
+        {
+            id = NullIfEmpty(base32);
+            return true;
+        }
+        else return false;
+
+        static object? NullIfEmpty(Guid guid) => guid == Guid.Empty ? null : guid;
+    }
 }

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -11,6 +11,8 @@
 v7.0.0
 - Introduction of the IEmpty&lt;TSelf&gt; interface. #364
 - Improve parsing of UUID's.
+- Improve ToString of UUID's. #365
+- Improve parsing of UUID's. #365
 - Implement IMinMaxValue&lt;TSelf&gt; for SVO's with a min and max value. #362 (breaking)
 - Drop Gender. #361  (breaking)
 - Drop public static IsValid(string) methods. #361 (breaking)

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -10,6 +10,7 @@
     <PackageReleaseNotes>
 v7.0.0
 - Introduction of the IEmpty&lt;TSelf&gt; interface. #364
+- Improve parsing of UUID's.
 - Implement IMinMaxValue&lt;TSelf&gt; for SVO's with a min and max value. #362 (breaking)
 - Drop Gender. #361  (breaking)
 - Drop public static IsValid(string) methods. #361 (breaking)

--- a/src/Qowaiv/Text/Base32.cs
+++ b/src/Qowaiv/Text/Base32.cs
@@ -10,15 +10,9 @@ public static class Base32
     private const int BitPerChar = 5;
     private const int BitShift = BitPerByte - BitPerChar;
     private const int BitsMask = 31;
-
+    private const byte None = 255;
     private const string UpperCaseBitChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
     private const string LowerCaseBitChars = "abcdefghijklmnopqrstuvwxyz234567";
-
-    /// <summary>A lookup where the index is the <see cref="int"/> representation of the <see cref="char"/>.</summary>
-    private static readonly byte[] CharValues = [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 26, 27, 28, 29, 30, 31, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 255, 255, 255, 255, 255, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25];
-
-    /// <summary>The 'z' is the highest <see cref="char"/> that can be found in the <see cref="CharValues"/>.</summary>
-    private const char MaxChar = 'z';
 
     /// <summary>Represents a byte array as a <see cref="string"/>.</summary>
     /// <param name="bytes">
@@ -133,12 +127,14 @@ public static class Base32
         foreach (var ch in s)
         {
             // the char is not a valid base32 char.
-            if (ch > MaxChar)
+
+            var charValue = Lookup[(byte)ch];
+
+            if (charValue == None)
             {
                 bytes = [];
                 return false;
             }
-            var charValue = CharValues[ch];
 
             // the char is not a valid base32 char, although it is in the lookup.
             if (charValue == byte.MaxValue)
@@ -168,4 +164,24 @@ public static class Base32
         }
         return true;
     }
+
+    private static readonly byte[] Lookup =
+    [
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 
+        0x0e, 0x08, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, None, None, None, None, None, None, None, None,
+        None, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, None, None, None, None, None,
+        None, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    ];
 }

--- a/src/Qowaiv/Text/Base64.cs
+++ b/src/Qowaiv/Text/Base64.cs
@@ -1,4 +1,6 @@
-﻿namespace Qowaiv.Text;
+﻿using System.Runtime.InteropServices;
+
+namespace Qowaiv.Text;
 
 /// <summary> is a group of similar binary-to-text encoding schemes that
 /// represent binary data in an ASCII string format by translating it into
@@ -45,4 +47,73 @@ public static class Base64
             return false;
         }
     }
+
+    [Pure]
+    internal static string ToString(Guid guid)
+    {
+        Span<char> chars = stackalloc char[22];
+
+#if NET8_0_OR_GREATER
+        ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(new Span<Guid>(ref guid));
+#else
+        ReadOnlySpan<byte> bytes = guid.ToByteArray();
+#endif
+        chars[00] = Read0(bytes, 00);
+        chars[01] = Read1(bytes, 00);
+        chars[02] = Read2(bytes, 01);
+        chars[03] = Read3(bytes, 02);
+        chars[04] = Read0(bytes, 03);
+        chars[05] = Read1(bytes, 03);
+        chars[06] = Read2(bytes, 04);
+        chars[07] = Read3(bytes, 05);
+        chars[08] = Read0(bytes, 06);
+        chars[09] = Read1(bytes, 06);
+        chars[10] = Read2(bytes, 07);
+        chars[11] = Read3(bytes, 08);
+        chars[12] = Read0(bytes, 09);
+        chars[13] = Read1(bytes, 09);
+        chars[14] = Read2(bytes, 10);
+        chars[15] = Read3(bytes, 11);
+        chars[16] = Read0(bytes, 12);
+        chars[17] = Read1(bytes, 12);
+        chars[18] = Read2(bytes, 13);
+        chars[19] = Read3(bytes, 14);
+        chars[20] = Read0(bytes, 15);
+        chars[21] = Base64Chars[(bytes[15] << 4) & 0b11_0000];
+
+#if NET6_0_OR_GREATER
+        return new(chars);
+#else
+        return new(chars.ToArray());
+#endif
+        // 01234567 01234567 0123456
+        // ..012345 ........ .......
+        static char Read0(ReadOnlySpan<byte> bytes, int index)
+            => Base64Chars[bytes[index] >> 2];
+
+        // 01234567 01234567 01234567
+        // 45****** ....0123 ........
+        static char Read1(ReadOnlySpan<byte> bytes, int index)
+        {
+            var hi = (bytes[index + 0] << 4) & 0b11_0000;
+            var lo = (bytes[index + 1] >> 4) & 0b00_1111;
+            return Base64Chars[lo | hi];
+        }
+
+        // 01234567 01234567 01234567
+        // ******** 2345**** ......01
+        static char Read2(ReadOnlySpan<byte> bytes, int index)
+        {
+            var hi = (bytes[index + 0] << 2) & 0b11_1100;
+            var lo = (bytes[index + 1] >> 6) & 0b00_0011;
+            return Base64Chars[lo | hi];
+        }
+
+        // 01234567 01234567 01234567
+        // ******** ******** 012345**
+        static char Read3(ReadOnlySpan<byte> bytes, int index)
+            => Base64Chars[bytes[index] & 0b11_1111];
+    }
+
+    private const string Base64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 }

--- a/src/Qowaiv/Text/Base64.cs
+++ b/src/Qowaiv/Text/Base64.cs
@@ -86,7 +86,8 @@ public static class Base64
 #else
         return new(chars.ToArray());
 #endif
-        // 01234567 01234567 0123456
+
+        // 01234567 01234567 01234567
         // ..012345 ........ .......
         static char Read0(ReadOnlySpan<byte> bytes, int index)
             => Base64Chars[bytes[index] >> 2];

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -199,13 +199,28 @@ public readonly partial struct Uuid : IXmlSerializable, IFormattable, IEquatable
     [Pure]
     public static bool TryParse(string? s, IFormatProvider? provider, out Uuid result)
     {
-        result = default;
-        if (behavior.TryParse(s, out var id))
+        result = Empty;
+
+        if (s is not { Length: > 0 })
         {
-            result = id is Guid guid ? new Uuid(guid) : Empty;
             return true;
         }
-        return false;
+        else if (GuidParser.TryBase64(s, out var base64))
+        {
+            result = base64;
+            return true;
+        }
+        else if (Guid.TryParse(s, out var guid))
+        {
+            result = guid;
+            return true;
+        }
+        else if (GuidParser.TryBase32(s, out var base32))
+        {
+            result = base32;
+            return true;
+        }
+        else return false;
     }
 
     /// <summary>Generates an <see cref="Uuid"/> applying a <see cref="MD5"/> hash on the data.</summary>

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -32,18 +32,7 @@ public readonly partial struct Uuid : IXmlSerializable, IFormattable, IEquatable
     public static readonly int ArraySize = 16;
 
     /// <summary>The index of the byte containing the version of a UUID is 7.</summary>
-    internal const int IndexOfVersion = 7;
-
-    /// <summary>Represents the pattern of a (potential) valid GUID.</summary>
-    internal static readonly Regex Pattern = GetPattern();
-
-#if NET8_0_OR_GREATER
-    [GeneratedRegex(@"^[a-zA-Z0-9_-]{22}(=){0,2}$", RegOptions.Default, RegOptions.TimeoutMilliseconds)]
-    private static partial Regex GetPattern();
-#else
-    [Pure]
-    private static Regex GetPattern() => new(@"^[a-zA-Z0-9_-]{22}(=){0,2}$", RegOptions.Default, RegOptions.Timeout);
-#endif
+    private const int IndexOfVersion = 7;
 
     /// <summary>Get the version of the UUID.</summary>
     public UuidVersion Version => m_Value.GetVersion();

--- a/src/Qowaiv/Uuid.cs
+++ b/src/Qowaiv/Uuid.cs
@@ -57,7 +57,7 @@ public readonly partial struct Uuid : IXmlSerializable, IFormattable, IEquatable
     /// The serialized JSON string.
     /// </returns>
     [Pure]
-    public string? ToJson() => m_Value == Guid.Empty ? null : ToString(CultureInfo.InvariantCulture);
+    public string? ToJson() => HasValue ? Base64.ToString(m_Value) : null;
 
     /// <summary>Returns a <see cref="string"/> that represents the current UUID for debug purposes.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -109,7 +109,7 @@ public readonly partial struct Uuid : IXmlSerializable, IFormattable, IEquatable
 
     /// <summary>Gets an XML string representation of the UUID.</summary>
     [Pure]
-    private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
+    private string ToXmlString() => HasValue ? Base64.ToString(m_Value) : string.Empty;
 
     /// <summary>Casts a Qowaiv.UUID to a System.GUID.</summary>
     public static implicit operator Guid(Uuid val) => val.m_Value;


### PR DESCRIPTION
Parsing UUID's (the base64 string representation) was dramatically slower than parsing a regular `GUID`. By dropping the `Regex`, using an `unsafe` cast (trick that MS does as well), times improved.

By reducing the function calls (for all parse methods) durations where even reduced more (basically 12 ns).

After these changes, the overhead for using `UUID` instead of MS's `GUID` is (almost) neglectable.

| Parse              | Mean     | Ratio |
|------------------- |---------:|------:|
| GUID (Guid.Parse)  | 15.63 ns |  1.00 |
| GUID               | 18.77 ns |  1.20 |
| Base64             | 18.58 ns |  1.19 |
| Base32             | 27.82 ns |  1.78 |
| Regex + FromBase64 | 92.76 ns |  5.94 |

ToString has also been improved, but is still 57% slower than writing a GUID.

| ToString             | Mean     | Ratio |
|--------------------- |---------:|------:|
| GUID (Guid.ToString) | 11.10 ns |  1.00 |
| Base64               | 17.47 ns |  1.57 |
| GUID                 | 43.03 ns |  3.85 |
| Convert.ToBase64     | 50.71 ns |  4.57 |

The version of a `UUID` is stored in the upper 4 bits of byte 7. By using the
`GuidLayout` of `ToByteArray()` to retrieve that those bits is a big improvement as well.

| Method      | Mean       | Ratio |
|------------ |-----------:|------:|
| Layout      |   0.584 ns |  1.00 |
| From byte[] |   3.024 ns |  5.20 |