### PR TITLE
Reduce the call stack of ToString()

### DIFF
--- a/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
+++ b/src/Qowaiv.Data.SqlClient/Generated/Timestamp.generated.cs
@@ -84,7 +84,7 @@ public partial struct Timestamp : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the timestamp.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the timestamp.</summary>
     /// <param name="format">
@@ -226,9 +226,9 @@ public partial struct Timestamp
     /// The timestamp if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Timestamp? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Timestamp? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Timestamp?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Timestamp"/>.

--- a/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
+++ b/src/Qowaiv/Generated/Chemistry/CasRegistryNumber.generated.cs
@@ -96,7 +96,7 @@ public partial struct CasRegistryNumber : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the CAS Registry Number.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the CAS Registry Number.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct CasRegistryNumber
     /// The CAS Registry Number if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static CasRegistryNumber? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static CasRegistryNumber? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(CasRegistryNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="CasRegistryNumber"/>.

--- a/src/Qowaiv/Generated/Date.generated.cs
+++ b/src/Qowaiv/Generated/Date.generated.cs
@@ -75,7 +75,7 @@ public partial struct Date : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the date.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the date.</summary>
     /// <param name="format">
@@ -217,9 +217,9 @@ public partial struct Date
     /// The date if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Date? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Date? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Date?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Date"/>.

--- a/src/Qowaiv/Generated/DateSpan.generated.cs
+++ b/src/Qowaiv/Generated/DateSpan.generated.cs
@@ -70,7 +70,7 @@ public partial struct DateSpan : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the date span.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the date span.</summary>
     /// <param name="format">
@@ -212,9 +212,9 @@ public partial struct DateSpan
     /// The date span if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static DateSpan? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static DateSpan? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(DateSpan?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="DateSpan"/>.

--- a/src/Qowaiv/Generated/EmailAddress.generated.cs
+++ b/src/Qowaiv/Generated/EmailAddress.generated.cs
@@ -96,7 +96,7 @@ public partial struct EmailAddress : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the email address.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the email address.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct EmailAddress
     /// The email address if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static EmailAddress? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static EmailAddress? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(EmailAddress?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EmailAddress"/>.

--- a/src/Qowaiv/Generated/Financial/Amount.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Amount.generated.cs
@@ -84,7 +84,7 @@ public partial struct Amount : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the amount.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the amount.</summary>
     /// <param name="format">
@@ -226,9 +226,9 @@ public partial struct Amount
     /// The amount if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Amount? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Amount? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Amount?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Amount"/>.

--- a/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
+++ b/src/Qowaiv/Generated/Financial/BusinessIdentifierCode.generated.cs
@@ -96,7 +96,7 @@ public partial struct BusinessIdentifierCode : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the BIC.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the BIC.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct BusinessIdentifierCode
     /// The BIC if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static BusinessIdentifierCode? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static BusinessIdentifierCode? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(BusinessIdentifierCode?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="BusinessIdentifierCode"/>.

--- a/src/Qowaiv/Generated/Financial/Currency.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Currency.generated.cs
@@ -96,7 +96,7 @@ public partial struct Currency : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the currency.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the currency.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct Currency
     /// The currency if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Currency? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Currency? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Currency?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Currency"/>.

--- a/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
+++ b/src/Qowaiv/Generated/Financial/InternationalBankAccountNumber.generated.cs
@@ -96,7 +96,7 @@ public partial struct InternationalBankAccountNumber : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the IBAN.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the IBAN.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct InternationalBankAccountNumber
     /// The IBAN if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static InternationalBankAccountNumber? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static InternationalBankAccountNumber? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(InternationalBankAccountNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternationalBankAccountNumber"/>.

--- a/src/Qowaiv/Generated/Financial/Money.generated.cs
+++ b/src/Qowaiv/Generated/Financial/Money.generated.cs
@@ -61,7 +61,7 @@ public partial struct Money : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the money.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the money.</summary>
     /// <param name="format">
@@ -182,9 +182,9 @@ public partial struct Money
     /// The money if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Money? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Money? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Money?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Money"/>.

--- a/src/Qowaiv/Generated/Globalization/Country.generated.cs
+++ b/src/Qowaiv/Generated/Globalization/Country.generated.cs
@@ -96,7 +96,7 @@ public partial struct Country : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the country.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the country.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct Country
     /// The country if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Country? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Country? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Country?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Country"/>.

--- a/src/Qowaiv/Generated/HouseNumber.generated.cs
+++ b/src/Qowaiv/Generated/HouseNumber.generated.cs
@@ -110,7 +110,7 @@ public partial struct HouseNumber : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the house number.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the house number.</summary>
     /// <param name="format">
@@ -252,9 +252,9 @@ public partial struct HouseNumber
     /// The house number if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static HouseNumber? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static HouseNumber? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(HouseNumber?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="HouseNumber"/>.

--- a/src/Qowaiv/Generated/IO/StreamSize.generated.cs
+++ b/src/Qowaiv/Generated/IO/StreamSize.generated.cs
@@ -196,9 +196,9 @@ public partial struct StreamSize
     /// The stream size if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static StreamSize? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static StreamSize? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(StreamSize?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="StreamSize"/>.

--- a/src/Qowaiv/Generated/LocalDateTime.generated.cs
+++ b/src/Qowaiv/Generated/LocalDateTime.generated.cs
@@ -75,7 +75,7 @@ public partial struct LocalDateTime : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the local date time.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the local date time.</summary>
     /// <param name="format">
@@ -217,9 +217,9 @@ public partial struct LocalDateTime
     /// The local date time if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static LocalDateTime? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static LocalDateTime? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(LocalDateTime?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="LocalDateTime"/>.

--- a/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
+++ b/src/Qowaiv/Generated/Mathematics/Fraction.generated.cs
@@ -61,7 +61,7 @@ public partial struct Fraction : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the fraction.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the fraction.</summary>
     /// <param name="format">
@@ -182,9 +182,9 @@ public partial struct Fraction
     /// The fraction if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Fraction? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Fraction? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Fraction?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Fraction"/>.

--- a/src/Qowaiv/Generated/Month.generated.cs
+++ b/src/Qowaiv/Generated/Month.generated.cs
@@ -96,7 +96,7 @@ public partial struct Month : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the month.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the month.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct Month
     /// The month if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Month? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Month? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Month?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Month"/>.

--- a/src/Qowaiv/Generated/MonthSpan.generated.cs
+++ b/src/Qowaiv/Generated/MonthSpan.generated.cs
@@ -84,7 +84,7 @@ public partial struct MonthSpan : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the month span.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the month span.</summary>
     /// <param name="format">
@@ -226,9 +226,9 @@ public partial struct MonthSpan
     /// The month span if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static MonthSpan? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static MonthSpan? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(MonthSpan?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="MonthSpan"/>.

--- a/src/Qowaiv/Generated/Percentage.generated.cs
+++ b/src/Qowaiv/Generated/Percentage.generated.cs
@@ -84,7 +84,7 @@ public partial struct Percentage : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the percentage.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the percentage.</summary>
     /// <param name="format">
@@ -226,9 +226,9 @@ public partial struct Percentage
     /// The percentage if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Percentage? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Percentage? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Percentage?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Percentage"/>.

--- a/src/Qowaiv/Generated/PostalCode.generated.cs
+++ b/src/Qowaiv/Generated/PostalCode.generated.cs
@@ -96,7 +96,7 @@ public partial struct PostalCode : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the postal code.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the postal code.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct PostalCode
     /// The postal code if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static PostalCode? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static PostalCode? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(PostalCode?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="PostalCode"/>.

--- a/src/Qowaiv/Generated/Sex.generated.cs
+++ b/src/Qowaiv/Generated/Sex.generated.cs
@@ -96,7 +96,7 @@ public partial struct Sex : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the sex.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the sex.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct Sex
     /// The sex if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Sex? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Sex? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Sex?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Sex"/>.

--- a/src/Qowaiv/Generated/Statistics/Elo.generated.cs
+++ b/src/Qowaiv/Generated/Statistics/Elo.generated.cs
@@ -84,7 +84,7 @@ public partial struct Elo : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the elo.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the elo.</summary>
     /// <param name="format">
@@ -226,9 +226,9 @@ public partial struct Elo
     /// The elo if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Elo? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Elo? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Elo?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Elo"/>.

--- a/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
+++ b/src/Qowaiv/Generated/Sustainability/EnergyLabel.generated.cs
@@ -96,7 +96,7 @@ public partial struct EnergyLabel : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the EU energy label.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the EU energy label.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct EnergyLabel
     /// The EU energy label if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static EnergyLabel? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static EnergyLabel? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(EnergyLabel?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="EnergyLabel"/>.

--- a/src/Qowaiv/Generated/Uuid.generated.cs
+++ b/src/Qowaiv/Generated/Uuid.generated.cs
@@ -84,7 +84,7 @@ public partial struct Uuid : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the UUID.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the UUID.</summary>
     /// <param name="format">
@@ -226,9 +226,9 @@ public partial struct Uuid
     /// The UUID if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Uuid? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Uuid? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Uuid?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Uuid"/>.

--- a/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
+++ b/src/Qowaiv/Generated/Web/InternetMediaType.generated.cs
@@ -110,7 +110,7 @@ public partial struct InternetMediaType : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the Internet media type.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the Internet media type.</summary>
     /// <param name="format">
@@ -252,9 +252,9 @@ public partial struct InternetMediaType
     /// The Internet media type if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static InternetMediaType? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static InternetMediaType? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(InternetMediaType?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="InternetMediaType"/>.

--- a/src/Qowaiv/Generated/WeekDate.generated.cs
+++ b/src/Qowaiv/Generated/WeekDate.generated.cs
@@ -75,7 +75,7 @@ public partial struct WeekDate : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the week date.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the week date.</summary>
     /// <param name="format">
@@ -196,9 +196,9 @@ public partial struct WeekDate
     /// The week date if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static WeekDate? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static WeekDate? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(WeekDate?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="WeekDate"/>.

--- a/src/Qowaiv/Generated/Year.generated.cs
+++ b/src/Qowaiv/Generated/Year.generated.cs
@@ -96,7 +96,7 @@ public partial struct Year : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the year.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the year.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct Year
     /// The year if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static Year? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static Year? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(Year?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="Year"/>.

--- a/src/Qowaiv/Generated/YesNo.generated.cs
+++ b/src/Qowaiv/Generated/YesNo.generated.cs
@@ -96,7 +96,7 @@ public partial struct YesNo : IFormattable
 {
     /// <summary>Returns a <see cref="string"/> that represents the yes-no.</summary>
     [Pure]
-    public override string ToString() => ToString(provider: null);
+    public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Returns a formatted <see cref="string"/> that represents the yes-no.</summary>
     /// <param name="format">
@@ -238,9 +238,9 @@ public partial struct YesNo
     /// The yes-no if the string was converted successfully, otherwise default.
     /// </returns>
     [Pure]
-    public static YesNo? TryParse(string? s, IFormatProvider? provider) 
-        => TryParse(s, provider, out var val) 
-            ? val 
+    public static YesNo? TryParse(string? s, IFormatProvider? provider)
+        => TryParse(s, provider, out var val)
+            ? val
             : default(YesNo?);
 
     /// <summary>Converts the <see cref="string"/> to <see cref="YesNo"/>.


### PR DESCRIPTION
By implementing `ToString()` as `ToString(string?, IFormatProvider?)` the method call stack is reduced by one.