### PR TITLE
extend Qowaiv.Clock with a TimeProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,4 +1132,5 @@ public void TestSomething()
 ### TimeProvider
 Since .NET 8.0, Microsoft provides a `TimeProvider`. To benefit from both the
 `Qowaiv.Clock` mechanism, and this time provider, the `Clock.TimeProvider`,
-a singleton which provides access to `Clock.UtcNow()` and `Clock.TimeZone`.
+a singleton which provides access to `Clock.UtcNow()` and `Clock.TimeZone` is
+added.

--- a/README.md
+++ b/README.md
@@ -1128,3 +1128,8 @@ public void TestSomething()
     }
 }
 ```
+
+### TimeProvider
+Since .NET 8.0, Microsoft provides a `TimeProvider`. To benefit from both the
+`Qowaiv.Clock` mechanism, and this time provider, the `Clock.TimeProvider`,
+a singleton which provides access to `Clock.UtcNow()` and `Clock.TimeZone`.

--- a/specs/Qowaiv.Specs/Clock_time_provider_specs.cs
+++ b/specs/Qowaiv.Specs/Clock_time_provider_specs.cs
@@ -1,0 +1,43 @@
+﻿#if NET8_0_OR_GREATER
+
+using FluentAssertions.Extensions;
+
+namespace Clock_specs;
+
+public class Time_provider
+{
+    [Test]
+    public void reflects_time_of_Qowaiv_Clock()
+    {
+        var provider = Clock.TimeProvider;
+
+        using (Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15).AsUtc()))
+        {
+            provider.GetUtcNow().Should().Be(new DateTimeOffset(2017, 06, 11, 06, 15, 00, TimeSpan.Zero));
+        }
+    }
+
+    [Test]
+    public void reflects_time_zone_of_Qowaiv_Clock()
+    {
+        var provider = Clock.TimeProvider;
+
+        using (Clock.SetTimeZoneForCurrentContext(TestTimeZones.LeidenTime))
+        {
+            provider.LocalTimeZone.Should().Be(TestTimeZones.LeidenTime);
+        }
+    }
+
+    [Test]
+    public void reflects_timestamp_of_Qowaiv_Clock()
+    {
+        var provider = Clock.TimeProvider;
+
+        using (Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15).AsUtc()))
+        {
+            provider.GetTimestamp().Should().Be(11.June(2017).At(06, 15).AsUtc().Ticks);
+        }
+    }
+}
+
+#endif

--- a/specs/Qowaiv.Specs/OpenApi/Open_API_specs.cs
+++ b/specs/Qowaiv.Specs/OpenApi/Open_API_specs.cs
@@ -62,9 +62,10 @@ public class README_md
                     @enum = info.Enum?.ToArray(),
                 });
 #if DEBUG
-        Console.WriteLine(JsonConvert.SerializeObject(all, Formatting.Indented, new JsonSerializerSettings
+        Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(all, new System.Text.Json.JsonSerializerOptions
         {
-            NullValueHandling = NullValueHandling.Ignore,
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
         }));
 #endif
         all.Should().NotBeEmpty();

--- a/src/Qowaiv/Clock.cs
+++ b/src/Qowaiv/Clock.cs
@@ -199,4 +199,25 @@ public static class Clock
             SetLocalContextTimeZone(_zone);
         }
     }
+
+#if NET8_0_OR_GREATER
+
+    /// <summary>
+    /// Returns a <see cref="System.TimeProvider"/> implementation depending on
+    /// <see cref="Clock"/>.
+    /// </summary>
+    public static readonly TimeProvider TimeProvider = new ClockProvider();
+
+    private sealed class ClockProvider : TimeProvider
+    {
+        public override TimeZoneInfo LocalTimeZone => TimeZone;
+
+        [Pure]
+        public override DateTimeOffset GetUtcNow() => new(UtcNow(), TimeSpan.Zero);
+
+        [Pure]
+        public override long GetTimestamp() => UtcNow().Ticks;
+    }
+
+#endif
 }

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -16,6 +16,7 @@ v7.0.0
 - Improve parsing of UUID's. #365
 - Introduction of the IUnknown&lt;TSelf&gt; interface. #366
 - Implement IMinMaxValue&lt;TSelf&gt; for SVO's with a min and max value. #362 (breaking)
+- Provide Clock as TimeProvider (.NET 8.0 only). #371
 - Drop Gender. #361  (breaking)
 - Drop public static IsValid(string) methods. #361 (breaking)
 - Seal all JSON converters. #361 (breaking)


### PR DESCRIPTION
Since .NET 8.0, Microsoft provides a `TimeProvider`. To allow people to continue to work with `Qowaiv.Clock` without the burden to have to implement a `TimeProvider` themselves, a singleton is added to `Qowaiv.Clock` that acts identical to `UtcNow()` and `TimeZone` of `Qowaiv.Clock`. Obviously, this functionality is only available for .NET 8.0. 