### PR TITLE
 Deserializing ID's from JSON numeric nodes takes constrains into account

### DIFF
--- a/specs/Qowaiv.Specs/Identifiers/ID_Cast_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/ID_Cast_specs.cs
@@ -84,10 +84,5 @@ public class Can_not_cast_from
     public void long_to_GUID()
        => ((object)123546L).Invoking(id => (CustomGuid)id)
            .Should().Throw<InvalidCastException>();
-
-    [Test]
-    public void invalid_JSON_input()
-        => (-1L).Invoking(Int64Id.FromJson)
-        .Should().Throw<InvalidCastException>();
 }
 

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
@@ -49,6 +49,37 @@ public class Supports_JSON_serialization
     [TestCase("12345678", 12345678L)]
     public void System_Text_JSON_serialization(Int32Id svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(-2)]
+    [TestCase(17)]
+    [TestCase("17")]
+    [TestCase(int.MaxValue + 1L)]
+    public void taking_constrains_into_account(object json)
+    {
+        json.Invoking(JsonTester.Read_System_Text_JSON<Id<ForEven>>)
+            .Should().Throw<System.Text.Json.JsonException>()
+            .WithMessage("Not a valid identifier.");
+    }
+
+    private sealed class ForEven : Int32IdBehavior
+    {
+        public override bool TryCreate(object? obj, out object? id)
+        {
+            if(obj is int even && even % 2 == 0)
+            {
+                id = even;
+                return true;
+            }
+            {
+                id = null;
+                return false;
+            }
+        }
+
+        public override bool TryParse(string? str, out object? id)
+            => TryCreate(int.TryParse(str, out int even) ? even : null, out id);
+    }
+
 #endif
     [TestCase("", "")]
     [TestCase(12345678L, 12345678)]
@@ -60,13 +91,6 @@ public class Supports_JSON_serialization
     [TestCase("12345678", 12345678L)]
     public void convention_based_serialization(Int32Id svo, object json)
         => JsonTester.Write(svo).Should().Be(json);
-
-    [TestCase("Invalid input", typeof(FormatException))]
-    [TestCase(long.MaxValue, typeof(InvalidCastException))]
-    public void throws_for_invalid_json(object json, Type exceptionType)
-        => json.Invoking(JsonTester.Read<Int32Id>)
-            .Should().Throw<Exception>()
-            .Which.Should().BeOfType(exceptionType);
 }
 
 public class Supports_type_conversion

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
@@ -70,6 +70,7 @@ public class Supports_JSON_serialization
                 id = even;
                 return true;
             }
+            else
             {
                 id = null;
                 return false;

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -68,6 +68,7 @@ public class Supports_JSON_serialization
                 id = even;
                 return true;
             }
+            else
             {
                 id = null;
                 return false;

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -48,7 +48,37 @@ public class Supports_JSON_serialization
     [TestCase(123456789L, "123456789")]
     public void System_Text_JSON_serialization(Int64Id svo, object json)
         => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+    [TestCase(-2)]
+    [TestCase(17)]
+    [TestCase("17")]
+    public void taking_constrains_into_account(object json)
+    {
+        json.Invoking(JsonTester.Read_System_Text_JSON<Id<ForEven>>)
+            .Should().Throw<System.Text.Json.JsonException>()
+            .WithMessage("Not a valid identifier.");
+    }
+
+    private sealed class ForEven : Int64IdBehavior
+    {
+        public override bool TryCreate(object? obj, out object? id)
+        {
+            if (obj is long even && even % 2 == 0)
+            {
+                id = even;
+                return true;
+            }
+            {
+                id = null;
+                return false;
+            }
+        }
+
+        public override bool TryParse(string? str, out object? id)
+            => TryCreate(long.TryParse(str, out long even) ? even : null, out id);
+    }
 #endif
+
     [TestCase("", null)]
     [TestCase(123456789L, 123456789L)]
     [TestCase("123456789", 123456789L)]

--- a/src/Qowaiv/Identifiers/Int32IdBehavior.cs
+++ b/src/Qowaiv/Identifiers/Int32IdBehavior.cs
@@ -37,18 +37,12 @@ public class Int32IdBehavior : IdentifierBehavior
 
     /// <inheritdoc/>
     [Pure]
-    public override object? FromJson(long obj)
+    public override object? FromJson(long obj) => obj switch
     {
-        if (obj == 0)
-        {
-            return null;
-        }
-        else if (obj > 0 && obj <= int.MaxValue)
-        {
-            return (int)obj;
-        }
-        else throw Exceptions.InvalidCast(typeof(int), typeof(Id<>).MakeGenericType(GetType()));
-    }
+        0 => null,
+        _ when obj > 0 && obj <= int.MaxValue && TryCreate(obj, out var created) && created is int id => id,
+        _ => throw Unparsable.ForValue(obj.ToString(), "Not a valid identifier.", typeof(Id<>).MakeGenericType(GetType())),
+    };
 
     /// <inheritdoc/>
     [Pure]

--- a/src/Qowaiv/Identifiers/Int64IdBehavior.cs
+++ b/src/Qowaiv/Identifiers/Int64IdBehavior.cs
@@ -39,12 +39,12 @@ public class Int64IdBehavior : IdentifierBehavior
 
     /// <inheritdoc/>
     [Pure]
-    public sealed override object? FromJson(long obj)
+    public sealed override object? FromJson(long obj) => obj switch
     {
-        if (obj == 0) return null;
-        else if (obj > 0) return obj;
-        else throw Exceptions.InvalidCast(typeof(long), typeof(Id<>).MakeGenericType(GetType()));
-    }
+        0 => null,
+        _ when obj > 0 && TryCreate(obj, out var created) && created is long id => id,
+        _ => throw Unparsable.ForValue(obj.ToString(), "Not a valid identifier.", typeof(Id<>).MakeGenericType(GetType())),
+    };
 
     /// <inheritdoc/>
     [Pure]

--- a/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
+++ b/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
@@ -82,7 +82,7 @@ public sealed class IdJsonConverter : JsonConverterFactory
         }
 
         /// <inheritdoc />
--        public override Id<TBehavior> ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override Id<TBehavior> ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             => Id<TBehavior>.FromJson(reader.GetString());
 
         /// <inheritdoc />

--- a/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
+++ b/src/Qowaiv/Json/Identifiers/IdJsonConverter.cs
@@ -48,8 +48,12 @@ public sealed class IdJsonConverter : JsonConverterFactory
             }
             catch (Exception x)
             {
-                if (x is JsonException) throw;
-                else throw new JsonException(x.Message, x);
+                var inner = x;
+                while (inner is TargetInvocationException && inner.InnerException is { })
+                {
+                    inner = inner.InnerException;
+                }
+                throw new JsonException(inner.Message, inner);
             }
         }
 
@@ -77,17 +81,13 @@ public sealed class IdJsonConverter : JsonConverterFactory
             }
         }
 
-#if NET6_0_OR_GREATER
-
         /// <inheritdoc />
-        public override Id<TBehavior> ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+-        public override Id<TBehavior> ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             => Id<TBehavior>.FromJson(reader.GetString());
 
         /// <inheritdoc />
         public override void WriteAsPropertyName(Utf8JsonWriter writer, Id<TBehavior> value, JsonSerializerOptions options)
             => writer.WritePropertyName(value.ToJson()?.ToString() ?? string.Empty);
-
-#endif
     }
 
     [Pure]

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -29,7 +29,7 @@ v7.0.0
 - Seal all JSON converters. #361 (breaking)
 - Allign Parse and TryParse provider naming with IParsable. #360 (breaking)
 - Drop support for .NET 5 and .NET 7 STS's. #359 (breaking)
-- Deserializing ID's from JSON numeric nodes takes constrains into account.
+- Deserializing ID's from JSON numeric nodes takes constrains into account. #374
 v6.6.0
 - Add former countries. #357
 - Update display names countries (EN, DE, NL). #356

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -29,6 +29,7 @@ v7.0.0
 - Seal all JSON converters. #361 (breaking)
 - Allign Parse and TryParse provider naming with IParsable. #360 (breaking)
 - Drop support for .NET 5 and .NET 7 STS's. #359 (breaking)
+- Deserializing ID's from JSON numeric nodes takes constrains into account.
 v6.6.0
 - Add former countries. #357
 - Update display names countries (EN, DE, NL). #356


### PR DESCRIPTION
When an (numeric) identifier was deserializing, the constraints defined (in `TryCreate`) where not triggered.