### PR TITLE
JSON-deserialization from decimal.MaxValue (as double) should not fail

### DIFF
--- a/specs/Qowaiv.Specs/Financial/Amount_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Amount_specs.cs
@@ -88,6 +88,20 @@ public class Supports_type_conversion
         public void System_Text_JSON_deserialization(object json, Amount svo)
             => JsonTester.Read_System_Text_JSON<Amount>(json).Should().Be(svo);
 
+        [Test]
+        public void System_Text_JSON_deserialization_min_value()
+        {
+            var amount = System.Text.Json.JsonSerializer.Deserialize<Amount>("-7.922816251426434E+28");
+            amount.Should().Be(Amount.MinValue);
+        }
+
+        [Test]
+        public void System_Text_JSON_deserialization_max_value()
+        {
+            var amount = System.Text.Json.JsonSerializer.Deserialize<Amount>("7.922816251426434E+28");
+            amount.Should().Be(Amount.MaxValue);
+        }
+
         [TestCase(1234.56, 1234.56)]
         public void System_Text_JSON_serialization(Amount svo, object json)
             => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);

--- a/src/Qowaiv/Cast.cs
+++ b/src/Qowaiv/Cast.cs
@@ -12,6 +12,12 @@ internal delegate bool TryParseInvariant<TSvo>(string str, out TSvo result);
 /// <summary>Helper class to facilitate <see cref="InvalidCastException"/> on SVO casting.</summary>
 internal static class Cast
 {
+    private static class Dbl
+    {
+        public const double DecimalMin = (double)decimal.MinValue;
+        public const double DecimalMax = (double)decimal.MaxValue;
+    }
+
     /// <summary>Casts from a primitive (not <see cref="string"/>) to a SVO.</summary>
     [Pure]
     public static TSvo Primitive<TPrimitive, TSvo>(TryCreate<TPrimitive, TSvo> tryCreate, TPrimitive? value)
@@ -39,9 +45,17 @@ internal static class Cast
     public static decimal ToDecimal<TSvo>(double value)
         => double.IsNaN(value)
         || double.IsInfinity(value)
-        || !value.IsInRange((double)decimal.MinValue, (double)decimal.MaxValue)
+        || !value.IsInRange(Dbl.DecimalMin, Dbl.DecimalMax)
         ? throw Exceptions.InvalidCast<double, TSvo>()
-        : (decimal)value;
+        : ToDecimal(value);
+
+    [Pure]
+    private static decimal ToDecimal(double value)
+    {
+        if (value >= Dbl.DecimalMax) return decimal.MaxValue;
+        if (value <= Dbl.DecimalMin) return decimal.MinValue;
+        return (decimal)value;
+    }
 
     /// <summary>Casts a <see cref="double"/> to <see cref="int"/> for the SVO.</summary>
     [Pure]

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,9 +5,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>6.6.1</Version>
+    <Version>6.6.2</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
+v6.6.2
+- JSON-deserialization from decimal.MaxValue (as double) should not fail. #380 (fix)
 v6.6.1
 - Add missing IParsable interface for Id. #372
 v6.6.0

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,7 +9,7 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
 v6.6.2
-- JSON-deserialization from decimal.MaxValue (as double) should not fail. #380 (fix)
+- JSON-deserialization from decimal.MaxValue (as double) should not fail. #386 (fix)
 v6.6.1
 - Add missing IParsable interface for Id. #372
 v6.6.0


### PR DESCRIPTION
When `Amount.Max` is serialized to JSON, its gets the value `7.922816251426434E+28`. This value can not be deserialized, because of rounding/precision issues, that can be demonstrated without any JSON serialization:

``` C#
var dbl = (double)decimal.MaxValue;
var dec = (decimal)dbl;
```

This code fails on the second line saying that `dbl` is either too big or too small.

This p.r. adds some forgiveness when casting back from doubles to decimals, that prevents this issue from occurring.

