### PR TITLE
Amount used decimal precision to serialize to JSON

### DIFF
--- a/specs/Qowaiv.Specs/Financial/Amount_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Amount_specs.cs
@@ -120,16 +120,24 @@ public class Supports_type_conversion
             amount.Should().Be(Amount.MinValue);
         }
 
-        [Test]
-        public void System_Text_JSON_deserialization_max_value()
+        [TestCase("7.922816251426434E+28")]
+        [TestCase("79228162514264337593543950335")]
+        public void System_Text_JSON_deserialization_max_value(string json)
         {
-            var amount = System.Text.Json.JsonSerializer.Deserialize<Amount>("7.922816251426434E+28");
+            var amount = System.Text.Json.JsonSerializer.Deserialize<Amount>(json);
             amount.Should().Be(Amount.MaxValue);
         }
 
         [TestCase(1234.56, 1234.56)]
         public void System_Text_JSON_serialization(Amount svo, object json)
             => JsonTester.Write_System_Text_JSON(svo).Should().Be(json);
+
+        [Test]
+        public void System_Text_JSON_serialization_Max_value()
+        {
+           var json = System.Text.Json.JsonSerializer.Serialize(Amount.MaxValue);
+            json.Should().Be("79228162514264337593543950335");
+        }
 #endif
         [TestCase("1234.56", 1234.56)]
         [TestCase(1234.56, 1234.56)]
@@ -140,6 +148,10 @@ public class Supports_type_conversion
         [TestCase(1234.56, 1234.56)]
         public void convention_based_serialization(Amount svo, object json)
             => JsonTester.Write(svo).Should().Be(json);
+
+        [Test]
+        public void convention_based_serialization_max_value()
+            => JsonTester.Write(Amount.MaxValue).Should().Be(79228162514264337593543950335M);
 
         [TestCase("Invalid input", typeof(FormatException))]
         [TestCase("2017-06-11", typeof(FormatException))]

--- a/src/Qowaiv/Financial/Amount.cs
+++ b/src/Qowaiv/Financial/Amount.cs
@@ -130,7 +130,7 @@ public readonly partial struct Amount : IXmlSerializable, IFormattable, IEquatab
     /// enough to have a <see cref="string"/> representation of -0.
     /// </remarks>
     [Pure]
-    public double ToJson() => (double)m_Value;
+    public decimal ToJson() => m_Value;
 
     /// <summary>Returns a <see cref="string"/> that represents the current Amount for debug purposes.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -146,6 +146,16 @@ public readonly partial struct Amount : IXmlSerializable, IFormattable, IEquatab
     /// <summary>Gets an XML string representation of the amount.</summary>
     [Pure]
     private string ToXmlString() => ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>Deserializes the amount from a JSON number.</summary>
+    /// <param name="json">
+    /// The JSON number to deserialize.
+    /// </param>
+    /// <returns>
+    /// The deserialized amount.
+    /// </returns>
+    [Pure]
+    public static Amount FromJson(decimal json) => new(json);
 
     /// <summary>Deserializes the amount from a JSON number.</summary>
     /// <param name="json">

--- a/src/Qowaiv/Json/Financial/AmountJsonConverter.cs
+++ b/src/Qowaiv/Json/Financial/AmountJsonConverter.cs
@@ -18,6 +18,10 @@ public class AmountJsonConverter : SvoJsonConverter<Amount>
 
     /// <inheritdoc />
     [Pure]
+    protected override Amount FromJson(decimal json) => Amount.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
     protected override Amount FromJson(double json) => Amount.FromJson(json);
 
     /// <inheritdoc />

--- a/src/Qowaiv/Json/Mathematics/FractionJsonConverter.cs
+++ b/src/Qowaiv/Json/Mathematics/FractionJsonConverter.cs
@@ -18,6 +18,10 @@ public class FractionJsonConverter : SvoJsonConverter<Fraction>
 
     /// <inheritdoc />
     [Pure]
+    protected override Fraction FromJson(decimal json) => Fraction.FromJson(json);
+
+    /// <inheritdoc />
+    [Pure]
     protected override Fraction FromJson(double json) => Fraction.FromJson(json);
 
     /// <inheritdoc />

--- a/src/Qowaiv/Json/SvoJsonConverter.cs
+++ b/src/Qowaiv/Json/SvoJsonConverter.cs
@@ -109,6 +109,10 @@ public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo : 
     [Pure]
     protected virtual TSvo FromJson(long json) => FromJson(json.ToString(CultureInfo.InvariantCulture));
 
+    /// <summary>Creates the SVO based on its JSON (decimal) number representation.</summary>
+    [Pure]
+    protected virtual TSvo FromJson(decimal json) => FromJson((double)json);
+
     /// <summary>Creates the SVO based on its JSON (double) number representation.</summary>
     [Pure]
     protected virtual TSvo FromJson(double json) => FromJson(json.ToString(CultureInfo.InvariantCulture));
@@ -123,9 +127,13 @@ public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo : 
         {
             return FromJson(num);
         }
-        else if (reader.TryGetDouble(out double dec))
+        else if (reader.TryGetDecimal(out decimal dec))
         {
             return FromJson(dec);
+        }
+        else if (reader.TryGetDouble(out double dbl))
+        {
+            return FromJson(dbl);
         }
         else throw new JsonException($"QowaivJsonConverter does not support writing from {reader.GetString()}.");
     }

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -333,6 +333,16 @@ public readonly partial struct Fraction : IXmlSerializable, IFormattable, IEquat
     /// The deserialized fraction.
     /// </returns>
     [Pure]
+    public static Fraction FromJson(decimal json) => Cast(json);
+
+    /// <summary>Deserializes the fraction from a JSON number.</summary>
+    /// <param name = "json">
+    /// The JSON number to deserialize.
+    /// </param>
+    /// <returns>
+    /// The deserialized fraction.
+    /// </returns>
+    [Pure]
     public static Fraction FromJson(double json) => Cast(json);
 
     /// <summary>Deserializes the fraction from a JSON number.</summary>


### PR DESCRIPTION
`Amount.MaxValue` now serializes as `79228162514264337593543950335` instead of `7.922816251426434E+28`.