### PR TITLE
Reduce trailing zero's by Percentage manipulations 

### DIFF
--- a/specs/Qowaiv.Benchmarks/DecimalBenchmark.cs
+++ b/specs/Qowaiv.Benchmarks/DecimalBenchmark.cs
@@ -1,0 +1,26 @@
+﻿using Qowaiv;
+
+namespace Benchmarks;
+
+public class DecimalBenchmark
+{
+    public class Scale
+    {
+        [ParamsSource(nameof(Values))]
+        public decimal Value { get; set; }
+
+        public static decimal[] Values => [100, 3.14m, 23.4326m];
+
+        [Benchmark]
+        public Percentage DecimalMath()
+            => Value.Percent();
+
+        [Benchmark]
+        public Percentage Division()
+            => Percentage.Create(Value / 100m);
+
+        [Benchmark]
+        public Percentage Multiplication()
+            => Percentage.Create(Value * 0.01m);
+    }
+}

--- a/specs/Qowaiv.Benchmarks/Program.cs
+++ b/specs/Qowaiv.Benchmarks/Program.cs
@@ -6,6 +6,8 @@ public static class Program
 {
     public static void Main()
     {
+        BenchmarkRunner.Run<DecimalBenchmark>();
+
         BenchmarkRunner.Run<IbanBenchmark.ParseUnformatted>();
         BenchmarkRunner.Run<IbanBenchmark.ParseFormatted>();
 

--- a/specs/Qowaiv.Benchmarks/README.md
+++ b/specs/Qowaiv.Benchmarks/README.md
@@ -30,6 +30,16 @@ tricks we can not rely on.
 | Qowaiv v6    | 29.425 ns |  5.08 |
 | Qowaiv v7    | 26.247 ns |  4.56 |
 
+## Percentage
+Apply a divide by 100, the default operation to convert a decimal to a
+percentage. Note that `DecimalMath` and the division trim, but the multiplication
+does not.
+
+| Method            | 3.14     | 23.4326  | 100      |
+|------------------ |---------:|---------:|---------:|
+| DecimalMath.Scale | 11.10 ns | 13.96 ns | 16.05 ns |
+| value / 100m      | 27.63 ns | 31.83 ns | 14.22 ns |
+| value * 0.01m     | 10.31 ns | 12.26 ns | 13.87 ns |
 
 ## UUID
 By removing `Regex` for the UUID parsing, durations have been reduced.

--- a/specs/Qowaiv.Specs/Percentage_INumber_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_INumber_specs.cs
@@ -167,8 +167,8 @@ public class Percentage_as_INumber
         Number.MinMagnitudeNumber((Percentage)x_, (Percentage)y_).Should().Be((Percentage)Number.MinMagnitudeNumber(x_, y_));
     }
 
-    private const double Min = -79228162514264337593543950335d;
-    private const double Max = +79228162514264337593543950335d;
+    private const double Min = -7922816251426433759354395.0335d;
+    private const double Max = +7922816251426433759354395.0335d;
     private const int Count = 8;
 }
 #endif

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -1,5 +1,35 @@
 ﻿namespace Percentage_specs;
 
+#if NET8_0_OR_GREATER
+public class Decimal_scale
+{
+    [Test]
+    public void _0_for_Percentage_Hudrded()
+    {
+        Scale(Percentage.Hundred).Should().Be(0);
+    }
+
+    [Test]
+    public void _0_for_100_Percent()
+    {
+        Scale(100.Percent()).Should().Be(0);
+        Scale(100d.Percent()).Should().Be(0);
+        Scale(100m.Percent()).Should().Be(0);
+        Scale(100.0m.Percent()).Should().Be(0);
+        Scale(100.00m.Percent()).Should().Be(0);
+    }
+
+    [TestCase("3.14%")]
+    [TestCase("3.140%")]
+    [TestCase("3.1400%")]
+    [TestCase("3.14000%")]
+    public void _minimum_for_parsed(string str)
+        => Scale(Percentage.Parse(str, TestCultures.en)).Should().Be(4);
+
+    private static byte Scale(Percentage p) => ((decimal)p).Scale;
+}
+#endif
+
 public class Is_valid_for
 {
 	[TestCase("1751‱", "en")]
@@ -51,6 +81,14 @@ public class Has_constant
 	[Test]
 	public void Hundred_represent_100_percent()
 		=> Percentage.Hundred.ToString("0%", CultureInfo.InvariantCulture).Should().Be("100%");
+
+    [Test]
+    public void Min_Value()
+        => ((decimal)Percentage.MinValue).Should().Be(decimal.MinValue / 10_000);
+
+    [Test]
+    public void Max_Value()
+        => ((decimal)Percentage.MaxValue).Should().Be(decimal.MaxValue / 10_000);
 }
 
 public class Is_equal_by_value
@@ -177,6 +215,16 @@ public class Can_not_be_parsed
 		=> style.Invoking(s => Percentage.TryParse("4.5%", s, CultureInfo.InvariantCulture, out _))
 			.Should().Throw<ArgumentOutOfRangeException>()
 			.WithMessage("The number style '*' is not supported.*");
+}
+
+public class Can_be_created
+{
+    [TestCase("-7922816251426433759354395.0336")]
+    [TestCase("+7922816251426433759354395.0336")]
+    public void when_within_the_boundries(decimal d)
+        => d.Invoking(Percentage.Create).Should()
+        .Throw<ArgumentOutOfRangeException>()
+        .WithMessage("Value is either too large or too small for a percentage.");
 }
 
 public class Can_be_created_with_percentage_extension

--- a/src/Qowaiv/Extensions/Humanizer.Percentage.cs
+++ b/src/Qowaiv/Extensions/Humanizer.Percentage.cs
@@ -1,17 +1,19 @@
-﻿namespace Qowaiv;
+﻿using Qowaiv.Mathematics;
+
+namespace Qowaiv;
 
 /// <summary>Extensions to create <see cref="Percentage"/>s, inspired by Humanizer.NET.</summary>
 public static class NumberToPercentageExtensions
 {
     /// <summary>Interprets the <see cref="int"/> if it was written with a '%' sign.</summary>
     [Pure]
-    public static Percentage Percent(this int number) => Percentage.Create(number * 0.01m);
+    public static Percentage Percent(this int number) => ((decimal)number).Percent();
 
     /// <summary>Interprets the <see cref="double"/> if it was written with a '%' sign.</summary>
     [Pure]
-    public static Percentage Percent(this double number) => Percentage.Create(number * 0.01);
+    public static Percentage Percent(this double number) => Cast.ToDecimal<Percentage>(number).Percent();
 
     /// <summary>Interprets the <see cref="decimal"/> if it was written with a '%' sign.</summary>
     [Pure]
-    public static Percentage Percent(this decimal number) => Percentage.Create(number * 0.01m);
+    public static Percentage Percent(this decimal number) => Percentage.Create(DecimalMath.ChangeScale(number, -2));
 }

--- a/src/Qowaiv/Mathematics/DecCalc.cs
+++ b/src/Qowaiv/Mathematics/DecCalc.cs
@@ -91,6 +91,24 @@ internal ref struct DecCalc
         }
     }
 
+    /// <summary>Removes its trailing zero's.</summary>
+    public void RemoveTrailingZeros()
+    {
+        var modulo = 10U;
+        var factor = 1U;
+
+        while (lo % modulo == 0 && factor < DecimalMath.Powers10[DecimalMath.MaxInt32Scale])
+        {
+            factor = modulo;
+            modulo *= 10;
+            scale--;
+        }
+        if (factor != 1)
+        {
+            Divide(factor);
+        }
+    }
+
     [Pure]
     public decimal Value()
     {

--- a/src/Qowaiv/Mathematics/DecimalMath.cs
+++ b/src/Qowaiv/Mathematics/DecimalMath.cs
@@ -117,6 +117,29 @@ internal static class DecimalMath
         }
     }
 
+    /// <summary>Changes the scale part of the <see cref="decimal"/>.</summary>
+    /// <remarks>
+    /// This is equivalent to multiplying (or dividing) by a power of 10.
+    /// </remarks>
+    [Pure]
+    public static decimal ChangeScale(decimal d, int delta)
+    {
+        var calc = DecCalc.New(d);
+        calc.scale -= delta;
+
+        calc.RemoveTrailingZeros();
+
+        while (calc.scale < 0)
+        {
+            var diffChunk = (-calc.scale > MaxInt32Scale) ? MaxInt32Scale : -calc.scale;
+            var factor = Powers10[diffChunk];
+            calc.Multiply(factor);
+            calc.scale += diffChunk;
+        }
+
+        return calc.Value();
+    }
+
     /// <summary>Gets a (thread static) instance of <see cref="Random"/>.</summary>
     /// <remarks>
     /// creates a new instance if required.

--- a/src/Qowaiv/Percentage.FormatInfo.cs
+++ b/src/Qowaiv/Percentage.FormatInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace Qowaiv;
+﻿using Qowaiv.Mathematics;
+
+namespace Qowaiv;
 
 public readonly partial struct Percentage
 {
@@ -28,11 +30,11 @@ public readonly partial struct Percentage
 
         public readonly Position Position = position;
 
-        public decimal Factor => Symbol switch
+        public int ScaleShift => Symbol switch
         {
-            Symbol.PerMille => 0.001m,
-            Symbol.PerTenThousand => 0.0001m,
-            _ => 0.01m,
+            Symbol.PerMille => -3,
+            Symbol.PerTenThousand => -4,
+            _ => -2,
         };
 
         private static readonly string[] Befores = ["fr-FR", "fa-IR"];
@@ -47,7 +49,7 @@ public readonly partial struct Percentage
                 sb.Append(ToString(Symbol, Provider));
             }
 
-            sb.Append((value / Factor).ToString(Format, Provider));
+            sb.Append(DecimalMath.ChangeScale(value, -ScaleShift).ToString(Format, Provider));
 
             if (Position == Position.After)
             {

--- a/src/Qowaiv/Percentage.INumber.cs
+++ b/src/Qowaiv/Percentage.INumber.cs
@@ -15,61 +15,61 @@ public readonly partial struct Percentage
     public static Percentage operator -(Percentage p) => new(-p.m_Value);
 
     /// <summary>Multiplies the left and the right percentage.</summary>
-    public static Percentage operator *(Percentage l, Percentage r) => new(l.m_Value * r.m_Value);
+    public static Percentage operator *(Percentage l, Percentage r) => Create(l.m_Value * r.m_Value);
 
     /// <summary>Divides the left by the right percentage.</summary>
-    public static Percentage operator /(Percentage l, Percentage r) => new(l.m_Value / r.m_Value);
+    public static Percentage operator /(Percentage l, Percentage r) => Create(l.m_Value / r.m_Value);
 
     /// <summary>Gets the remainder of the percentage.</summary>
     public static Percentage operator %(Percentage left, Percentage right) => new(left.m_Value % right.m_Value);
 
     /// <summary>Adds the left and the right percentage.</summary>
-    public static Percentage operator +(Percentage l, Percentage r) => new(l.m_Value + r.m_Value);
+    public static Percentage operator +(Percentage l, Percentage r) => Create(l.m_Value + r.m_Value);
 
     /// <summary>Subtracts the right from the left percentage.</summary>
-    public static Percentage operator -(Percentage l, Percentage r) => new(l.m_Value - r.m_Value);
+    public static Percentage operator -(Percentage l, Percentage r) => Create(l.m_Value - r.m_Value);
 
     /// <summary>Multiplies the percentage with the factor.</summary>
-    public static Percentage operator *(Percentage p, decimal factor) => new(p.m_Value * factor);
+    public static Percentage operator *(Percentage p, decimal factor) => Create(p.m_Value * factor);
 
     /// <summary>Multiplies the percentage with the factor.</summary>
-    public static Percentage operator *(Percentage p, double factor) => new(p.m_Value * (decimal)factor);
+    public static Percentage operator *(Percentage p, double factor) => Create(p.m_Value * (decimal)factor);
 
     /// <summary>Multiplies the percentage with the factor.</summary>
-    public static Percentage operator *(Percentage p, float factor) => new(p.m_Value * (decimal)factor);
+    public static Percentage operator *(Percentage p, float factor) => Create(p.m_Value * (decimal)factor);
 
     /// <summary>Multiplies the percentage with the factor.</summary>
-    public static Percentage operator *(Percentage p, long factor) => new(p.m_Value * factor);
+    public static Percentage operator *(Percentage p, long factor) => Create(p.m_Value * factor);
 
     /// <summary>Multiplies the percentage with the factor.</summary>
-    public static Percentage operator *(Percentage p, int factor) => new(p.m_Value * factor);
+    public static Percentage operator *(Percentage p, int factor) => Create(p.m_Value * factor);
 
     /// <summary>Multiplies the percentage with the factor.</summary>
-    public static Percentage operator *(Percentage p, short factor) => new(p.m_Value * factor);
-
-    /// <summary>Multiplies the percentage with the factor.</summary>
-    [CLSCompliant(false)]
-    public static Percentage operator *(Percentage p, ulong factor) => new(p.m_Value * factor);
+    public static Percentage operator *(Percentage p, short factor) => Create(p.m_Value * factor);
 
     /// <summary>Multiplies the percentage with the factor.</summary>
     [CLSCompliant(false)]
-    public static Percentage operator *(Percentage p, uint factor) => new(p.m_Value * factor);
+    public static Percentage operator *(Percentage p, ulong factor) => Create(p.m_Value * factor);
 
     /// <summary>Multiplies the percentage with the factor.</summary>
     [CLSCompliant(false)]
-    public static Percentage operator *(Percentage p, ushort factor) => new(p.m_Value * factor);
+    public static Percentage operator *(Percentage p, uint factor) => Create(p.m_Value * factor);
+
+    /// <summary>Multiplies the percentage with the factor.</summary>
+    [CLSCompliant(false)]
+    public static Percentage operator *(Percentage p, ushort factor) => Create(p.m_Value * factor);
 
     /// <summary>Divides the percentage by the factor.</summary>
-    public static Percentage operator /(Percentage p, decimal factor) => new(p.m_Value / factor);
+    public static Percentage operator /(Percentage p, decimal factor) => Create(p.m_Value / factor);
 
     /// <summary>Divides the percentage by the factor.</summary>
-    public static Percentage operator /(Percentage p, double factor) => new(p.m_Value / (decimal)factor);
+    public static Percentage operator /(Percentage p, double factor) => Create(p.m_Value / (decimal)factor);
 
     /// <summary>Divides the percentage by the factor.</summary>
-    public static Percentage operator /(Percentage p, float factor) => new(p.m_Value / (decimal)factor);
+    public static Percentage operator /(Percentage p, float factor) => Create(p.m_Value / (decimal)factor);
 
     /// <summary>Divides the percentage by the factor.</summary>
-    public static Percentage operator /(Percentage p, long factor) => new(p.m_Value / factor);
+    public static Percentage operator /(Percentage p, long factor) => Create(p.m_Value / factor);
 
     /// <summary>Divides the percentage by the factor.</summary>
     public static Percentage operator /(Percentage p, int factor) => new(p.m_Value / factor);

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -1,4 +1,6 @@
-﻿namespace Qowaiv;
+﻿using Qowaiv.Mathematics;
+
+namespace Qowaiv;
 
 /// <summary>Represents a Percentage.</summary>
 [DebuggerDisplay("{DebuggerDisplay}")]
@@ -29,16 +31,16 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
     public static Percentage Zero => default;
 
     /// <summary>Represents 1 percent.</summary>
-    public static Percentage One => 1.Percent();
+    public static Percentage One => new(0.01m);
 
     /// <summary>Represents 100 percent.</summary>
-    public static Percentage Hundred => 100.Percent();
+    public static Percentage Hundred => new(1);
 
     /// <summary>Gets the minimum value of a percentage.</summary>
-    public static Percentage MinValue => new(decimal.MinValue / 10_000);
+    public static Percentage MinValue => new(-7_922_816_251_426_433_759_354_395.0335m);
 
     /// <summary>Gets the maximum value of a percentage.</summary>
-    public static Percentage MaxValue => new(decimal.MaxValue / 10_000);
+    public static Percentage MaxValue => new(+7_922_816_251_426_433_759_354_395.0335m);
 
     /// <summary>Gets the sign of the percentage.</summary>
     [Pure]
@@ -296,9 +298,10 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
 
         if (s is { Length: > 0 }
             && FormatInfo.TryParse(s, provider, out var info)
-            && decimal.TryParse(info.Format, style, info.Provider, out var dec))
+            && decimal.TryParse(info.Format, style, info.Provider, out var dec)
+            && dec.IsInRange(MinValue.m_Value, MaxValue.m_Value))
         {
-            result = new(dec * info.Factor);
+            result = new(DecimalMath.ChangeScale(dec, info.ScaleShift));
             return true;
         }
         return false;
@@ -318,7 +321,10 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
     /// A decimal describing a Percentage.
     /// </param >
     [Pure]
-    public static Percentage Create(decimal val) => new(val);
+    public static Percentage Create(decimal val)
+    => val.IsInRange(MinValue.m_Value, MaxValue.m_Value)
+        ? new(val)
+        : throw new ArgumentOutOfRangeException(QowaivMessages.ArgumentOutOfRange_Percentage, (Exception?)null);
 
     /// <summary>Creates a Percentage from a Double.</summary >
     /// <param name="val" >

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -8,8 +8,11 @@
     <Version>7.0.1</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
+ToBeReleased:
+- Add check for percentage.MaxValue and percentage.MinValue when creating a percentage. (fix)
+- Use DecimalMath.Pow10() to convert decimal values to percentages.
 v7.0.1
-- ISpanFormattable INumbers should be able to provide formatting (.NET 8.0 only). $#393 (fix)
+- ISpanFormattable INumbers should be able to provide formatting (.NET 8.0 only). #393 (fix)
 v7.0.0
 - Drop support for .NET 5 and .NET 7 STS's. #359 (breaking)
 - Drop email address collection. #382 (breaking)

--- a/src/Qowaiv/QowaivMessages.Designer.cs
+++ b/src/Qowaiv/QowaivMessages.Designer.cs
@@ -133,6 +133,15 @@ namespace Qowaiv {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value is either too large or too small for a percentage..
+        /// </summary>
+        public static string ArgumentOutOfRange_Percentage {
+            get {
+                return ResourceManager.GetString("ArgumentOutOfRange_Percentage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Percentages can only round to between -26 and 26 digits of precision..
         /// </summary>
         public static string ArgumentOutOfRange_PercentageRound {

--- a/src/Qowaiv/QowaivMessages.resx
+++ b/src/Qowaiv/QowaivMessages.resx
@@ -207,4 +207,7 @@
   <data name="ArgumentOutOfRange_NumberStyleNotSupported" xml:space="preserve">
     <value>The number style '{0}' is not supported.</value>
   </data>
+  <data name="ArgumentOutOfRange_Percentage" xml:space="preserve">
+    <value>Value is either too large or too small for a percentage.</value>
+  </data>
 </root>


### PR DESCRIPTION
With the introduction of Qowaiv  v7, Some `Percentage` manipulations started to create more trailing zero's than they did before. In most cases this will not be noticed, but at least one scenario is affected:

``` C#
var p = somePercentage * Percentage.Hundred; // this obviously could be the outcome of some decision tree.
JsonSerializer.Seralize(p);
```

The result of the serialization has 2 more trailing zero's than it had with Qowaiv v6.6.2 (and earlier versions). With the introduction of a (for now internal) `DecimalMath` that can change the Scale (moving the decimal separator back- or forward) and apply a `Trim`, these issues are dramatically reduced.

While at it, I noticed that the allowed boundaries of `Percentage` (those of `decimal` divided by 10.000) where not guarded. Now they are.
