### PR TITLE
Cache results of ToCSharpString

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -34,7 +34,8 @@
       Patrick Evers;
       Renzo Baasdam;
       Vincent Lesierse;
-      Wilko Frieke
+      Wilko Frieke;
+      Wesley Baartman
     </Authors>
     <Owners>Qowaiv community</Owners>
     <PackageTags>

--- a/specs/Qowaiv.Benchmarks/Program.cs
+++ b/specs/Qowaiv.Benchmarks/Program.cs
@@ -6,6 +6,7 @@ public static class Program
 {
     public static void Main()
     {
+        BenchmarkRunner.Run<ToCSharpStringBenchmark>();
         BenchmarkRunner.Run<DecimalBenchmark>();
 
         BenchmarkRunner.Run<EmailBenchmark>();


### PR DESCRIPTION
Used `ConditionalWeakTable` to ensure the cache would be cleared if a `Type` was dynamically loaded and might be dynamically unloaded in the future.

Benchmark results:

```
| Method     | Count | Mean             | Error          | StdDev         | Ratio | Gen0      | Gen1     | Gen2     | Allocated  | Alloc Ratio |
|----------- |------ |-----------------:|---------------:|---------------:|------:|----------:|---------:|---------:|-----------:|------------:|
| No_cache   | 1     |      1,035.30 ns |      20.630 ns |      19.297 ns |  1.00 |    0.1717 |        - |        - |     2176 B |        1.00 |
| With_cache | 1     |         10.66 ns |       0.130 ns |       0.121 ns |  0.01 |    0.0025 |        - |        - |       32 B |        0.01 |
|            |       |                  |                |                |       |           |          |          |            |             |
| No_cache   | 10    |     10,005.35 ns |     107.181 ns |     100.257 ns | 1.000 |    1.7090 |   0.0153 |        - |    21546 B |       1.000 |
| With_cache | 10    |         78.21 ns |       1.470 ns |       1.806 ns | 0.008 |    0.0082 |        - |        - |      104 B |       0.005 |
|            |       |                  |                |                |       |           |          |          |            |             |
| No_cache   | 100   |    102,386.82 ns |   1,928.790 ns |   2,143.845 ns | 1.000 |   17.0898 |   1.5869 |        - |   215244 B |       1.000 |
| With_cache | 100   |        745.93 ns |       3.747 ns |       3.322 ns | 0.007 |    0.0648 |        - |        - |      824 B |       0.004 |
|            |       |                  |                |                |       |           |          |          |            |             |
| No_cache   | 1000  |  1,025,537.06 ns |  11,783.800 ns |  11,022.574 ns | 1.000 |  169.9219 |  83.9844 |        - |  2152227 B |       1.000 |
| With_cache | 1000  |      7,356.69 ns |      41.694 ns |      39.001 ns | 0.007 |    0.6332 |        - |        - |     8024 B |       0.004 |
|            |       |                  |                |                |       |           |          |          |            |             |
| No_cache   | 10000 | 11,389,921.35 ns | 111,847.463 ns | 104,622.186 ns | 1.000 | 1703.1250 | 875.0000 | 421.8750 | 21522193 B |       1.000 |
| With_cache | 10000 |     75,899.93 ns |     662.702 ns |     619.892 ns | 0.007 |    6.2256 |        - |        - |    80024 B |       0.004 |
```