### PR TITLE
DateTimeOffset.ToLocal only works on my machine

### DIFF
--- a/specs/Qowaiv.Specs/Date_time_offset_specs.cs
+++ b/specs/Qowaiv.Specs/Date_time_offset_specs.cs
@@ -22,7 +22,7 @@ public class Can_be_adjusted_with
 
 public class With_local
 {
-    [Test, Ignore("Investigate while this fails. It seems to be a bug.")]
+    [Test]
     public void represents_a_local_date_time()
     {
         var date = new DateTimeOffset(year: 2017, month: 06, day: 11, hour: 06, minute: 15, second: 00, TimeSpan.FromHours(+2)); 

--- a/specs/Qowaiv.Specs/Date_time_offset_specs.cs
+++ b/specs/Qowaiv.Specs/Date_time_offset_specs.cs
@@ -22,10 +22,11 @@ public class Can_be_adjusted_with
 
 public class With_local
 {
-    [Test]
-    public void represents_a_local_date_time()
+    [TestCase(-234)]
+    [TestCase(+283)]
+    public void represents_a_local_date_time(int offset)
     {
-        var date = new DateTimeOffset(year: 2017, month: 06, day: 11, hour: 06, minute: 15, second: 00, TimeSpan.FromHours(+2)); 
+        var date = new DateTimeOffset(year: 2017, month: 06, day: 11, hour: 06, minute: 15, second: 00, TimeSpan.FromMinutes(offset));
         date.ToLocal().Should().Be(new LocalDateTime(2017, 06, 11, 06, 15));
     }
 }

--- a/src/Qowaiv/Extensions/System.DateTimeOffset.cs
+++ b/src/Qowaiv/Extensions/System.DateTimeOffset.cs
@@ -101,6 +101,5 @@ public static class QowaivDateTimeOffsetExtensions
     /// The date time offset.
     /// </param>
     [Pure]
-    public static LocalDateTime ToLocal(this DateTimeOffset d)
-        => new(d.LocalDateTime.Ticks);
+    public static LocalDateTime ToLocal(this DateTimeOffset d) => new(d.Ticks);
 }

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -12,6 +12,7 @@ ToBeReleased:
 - Email address parsing performance improvements.
 - Add check for percentage.MaxValue and percentage.MinValue when creating a percentage. (fix)
 - Use DecimalMath.Pow10() to convert decimal values to percentages.
+- DateTimeOffset.ToLocal() wrongly converted DateTime before creation LocalDateTime. #404 (fix)
 v7.0.1
 - ISpanFormattable INumbers should be able to provide formatting (.NET 8.0 only). #393 (fix)
 v7.0.0


### PR DESCRIPTION
Wrongly converting it to a (potential wrong) new local date time.