### PR TITLE
DecimalMath.ChangeScale() should have a value between 0 and 28

### DIFF
--- a/specs/Qowaiv.Benchmarks/Program.cs
+++ b/specs/Qowaiv.Benchmarks/Program.cs
@@ -7,7 +7,7 @@ public static class Program
     public static void Main()
     {
         BenchmarkRunner.Run<ToCSharpStringBenchmark>();
-        BenchmarkRunner.Run<DecimalBenchmark>();
+        BenchmarkRunner.Run<DecimalBenchmark.Scale>();
 
         BenchmarkRunner.Run<EmailBenchmark>();
 

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -19,6 +19,13 @@ public class Decimal_scale
         Scale(100.00m.Percent()).Should().Be(0);
     }
 
+    [Test]
+    public void not_bigger_than_28()
+    {
+        var p = (100m / 3).Percent();
+        Scale(p).Should().Be(28);
+    }
+
     [TestCase("3.14%")]
     [TestCase("3.140%")]
     [TestCase("3.1400%")]
@@ -26,7 +33,7 @@ public class Decimal_scale
     public void _minimum_for_parsed(string str)
         => Scale(Percentage.Parse(str, TestCultures.en)).Should().Be(4);
 
-    private static byte Scale(Percentage p) => ((decimal)p).Scale;
+    private static int Scale(Percentage p) => ((decimal)p).Scale;
 }
 #endif
 

--- a/src/Qowaiv/Mathematics/DecimalMath.cs
+++ b/src/Qowaiv/Mathematics/DecimalMath.cs
@@ -136,7 +136,13 @@ internal static class DecimalMath
             calc.Multiply(factor);
             calc.scale += diffChunk;
         }
-
+        while (calc.scale > 28)
+        {
+            var diffChunk = Math.Min(MaxInt32Scale, calc.scale - 28);
+            var factor = Powers10[diffChunk];
+            calc.Divide(factor);
+            calc.scale -= diffChunk;
+        }
         return calc.Value();
     }
 

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,10 +5,12 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>7.0.2</Version>
+    <Version>7.0.3</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
-v7.0.2:
+v7.0.3
+- DecimalMath.ChangeScale() should have a value between [0.28]. #405 (fix)
+v7.0.2
 - Introduction of Year-Month. #295
 - Email address parsing performance improvements.
 - Add check for percentage.MaxValue and percentage.MinValue when creating a percentage. (fix)


### PR DESCRIPTION
With the introduction of `DecimalMath.ChangeScale()` one (tiny) bug, has been created:

```` C#
var p = (100m / 3).Percent();
var d = (decimal)p;

d.Should().Be(1m / 3);
```
This test fails. The reason is that d has a `Scale` value of `29`, instead of the maximum allowed `28`. All `System.Decimal` logic works fine, but the extra digit precision, can chance outcomes (starting with `.ToString()` which will display the extra digit).

Therefore, this PR fixes this.