### PR TITLE
Fix percentage boundaries checks on parsing

### DIFF
--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -212,6 +212,11 @@ public class Can_be_parsed
 			Percentage.TryParse("17.51%").Should().Be(Svo.Percentage);
 		}
 	}
+
+    [Test]
+    public void for_the_max_value()
+       => Percentage.Parse(Percentage.MaxValue.ToJson(), CultureInfo.InvariantCulture)
+       .Should().Be(Percentage.MaxValue);
 }
 
 public class Can_not_be_parsed

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -298,10 +298,10 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
 
         if (s is { Length: > 0 }
             && FormatInfo.TryParse(s, provider, out var info)
-            && decimal.TryParse(info.Format, style, info.Provider, out var dec)
+            && TryDecimal(info, style, out var dec)
             && dec.IsInRange(MinValue.m_Value, MaxValue.m_Value))
         {
-            result = new(DecimalMath.ChangeScale(dec, info.ScaleShift));
+            result = new(dec);
             return true;
         }
         return false;
@@ -312,6 +312,19 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
             if (extra != NumberStyles.None)
             {
                 throw new ArgumentOutOfRangeException(nameof(style), string.Format(QowaivMessages.ArgumentOutOfRange_NumberStyleNotSupported, extra));
+            }
+        }
+
+        static bool TryDecimal(FormatInfo info, NumberStyles style, out decimal dec)
+        {
+            if (decimal.TryParse(info.Format, style, info.Provider, out dec))
+            {
+                dec = DecimalMath.ChangeScale(dec, info.ScaleShift);
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
     }

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,9 +5,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>7.0.3</Version>
+    <Version>7.0.4</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
+v7.0.4
+- Percentage.TryParse should first change the scale, before checking the boundaries. (fix)
 v7.0.3
 - DecimalMath.ChangeScale() should have a value between [0.28]. #405 (fix)
 v7.0.2


### PR DESCRIPTION
The re-scale of parsed decimal was not taken into account *before* checking the boundaries. See #407.