### PR TITLE
Use coverlet.collector

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -50,15 +50,13 @@ jobs:
           /o:"qowaiv" \
           /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
           /d:sonar.host.url="https://sonarcloud.io" \
-          /d:sonar.cs.opencover.reportsPaths="**/coverage.**.opencover.xml" \
+          /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" \
           /d:sonar.cs.vstest.reportsPaths="**/*.trx"
       - name: Test
         run: |
           dotnet test specs/Qowaiv.Specs --configuration Release \
           --logger "trx;LogFileName=test-results.trx" \
-          /p:CollectCoverage=true \
-          /p:ThresholdType=branch \
-          /p:CoverletOutputFormat=opencover
+          --collect:"XPlat Code Coverage;Format=opencover"
       - name: Stop SonarCloud scanner
         if: success() || failure()
         env:
@@ -68,9 +66,9 @@ jobs:
           ./.sonar/scanner/dotnet-sonarscanner end \
           /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
       - name: Test Report
-        if:  success() || failure()
+        if: success() || failure()
         uses: dorny/test-reporter@v1
         with:
           name: Unit test results
-          path: '**/*.trx'
+          path: "**/*.trx"
           reporter: dotnet-trx

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -14,9 +15,12 @@ jobs:
         with:
           dotnet-version: "8.0.x"
       - name: Generate coverage report
-        run: dotnet test ./specs/Qowaiv.Specs -f net8.0 /p:CollectCoverage=true /p:ThresholdType=branch /p:CoverletOutputFormat=lcov --configuration Release
+        run: |
+          dotnet test ./specs/Qowaiv.Specs -f net8.0 \
+          --configuration Release \
+          --collect:"XPlat Code Coverage;Format=lcov"
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./specs/Qowaiv.Specs/coverage.net8.0.info
+          path-to-lcov: ./specs/Qowaiv.Specs/**/coverage.info

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/Qowaiv/Qowaiv/blob/master/CODE_OF_CONDUCT.md)
-![Build Status](https://github.com/Qowaiv/Qowaiv/workflows/Build%20%26%20Test/badge.svg?branch=master)
+![Build Status](https://github.com/Qowaiv/Qowaiv/actions/workflows/build-test.yaml/badge.svg?branch=master)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Qowaiv_Qowaiv&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Qowaiv_Qowaiv)
 [![Coverage Status](https://coveralls.io/repos/github/Qowaiv/Qowaiv/badge.svg?branch=master)](https://coveralls.io/github/Qowaiv/Qowaiv?branch=master)
 

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -24,7 +24,6 @@
 
   <ItemGroup Label="Build Tools">
     <PackageReference Include="coverlet.collector" Version="*" PrivateAssets="all" />
-    <PackageReference Include="coverlet.msbuild" Version="*" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" PrivateAssets="all" />
     <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Qowaiv/Clock.cs
+++ b/src/Qowaiv/Clock.cs
@@ -26,12 +26,6 @@ namespace Qowaiv;
 /// </example>
 public static class Clock
 {
-    [Obsolete("Don't merge this")]
-    public static void ThisFunctionGeneratesAWarningAndIsNotCoveredByTests()
-    {
-        var unused = 1;
-    }
-
     /// <summary>Gets the UTC (Coordinated Universal Time) zone of the clock.</summary>
     /// <remarks>
     /// To be able to stub the clock, this simple class can be used.

--- a/src/Qowaiv/Clock.cs
+++ b/src/Qowaiv/Clock.cs
@@ -26,6 +26,12 @@ namespace Qowaiv;
 /// </example>
 public static class Clock
 {
+    [Obsolete("Don't merge this")]
+    public static void ThisFunctionGeneratesAWarningAndIsNotCoveredByTests()
+    {
+        var unused = 1;
+    }
+
     /// <summary>Gets the UTC (Coordinated Universal Time) zone of the clock.</summary>
     /// <remarks>
     /// To be able to stub the clock, this simple class can be used.


### PR DESCRIPTION
Some pipeline improvements:
- Use `coverlet.collector` and remove `coverlet.msbuild` as the former is recommended there should not be two packages. Resolves #411.
- Fix readme build icon.

Note: the option `--logger "trx;LogFileName=test-results.trx"` together with `--collect:"XPlat Code Coverage;Format=opencover"` causes duplicate `coverage.opencover.xml` files. This is intended behavior apparently, upon checking SonarCloud it seems to work.