### PR TITLE
Fix code coverage pipeline

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -16,7 +16,12 @@ jobs:
           dotnet test ./specs/Qowaiv.Specs -f net8.0 \
           --configuration Release \
           --collect:"XPlat Code Coverage;Format=lcov"
+      - name: Get path to lcov file
+        id: get_lcov_path
+        shell: bash
+        run: printf '::set-output name=lcov_path::%s\n' TestResults/*/coverage.info
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ${{ steps.get_lcov_path.outputs.lcov_path }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,5 +1,8 @@
 name: Code coverage
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -18,7 +18,7 @@ jobs:
           --collect:"XPlat Code Coverage;Format=lcov"
       - name: Get path to lcov file
         shell: bash
-        run: echo "LCOV_PATH=$(find ./specs/Qowaiv.specs/TestResults -name coverage.info)" >> $GITHUB_ENV
+        run: echo "LCOV_PATH=$(find /home/runner/work/Qowaiv/Qowaiv/specs/Qowaiv.Specs/TestResults -name coverage.info)" >> $GITHUB_ENV
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -17,11 +17,10 @@ jobs:
           --configuration Release \
           --collect:"XPlat Code Coverage;Format=lcov"
       - name: Get path to lcov file
-        id: get_lcov_path
         shell: bash
-        run: printf '::set-output name=lcov_path::%s\n' TestResults/*/coverage.info
+        run: echo "LCOV_PATH=$(find ./specs/Qowaiv.specs/TestResults -name coverage.info)" >> $GITHUB_ENV
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ steps.get_lcov_path.outputs.lcov_path }}
+          path-to-lcov: $LCOV_PATH

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,8 +1,5 @@
 name: Code coverage
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
   build:
@@ -23,4 +20,3 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./specs/Qowaiv.Specs/**/coverage.info

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -23,4 +23,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: $LCOV_PATH
+          path-to-lcov: ${{ env.LCOV_PATH }}


### PR DESCRIPTION
Wrongly assumed that `coverallsapp/github-action@master` supports `/**/` notation. Due to `coverlet.collector` saving `coverage.info` in a randomly generated Guid folder, it seems to be unavoidable to need to determine the path and save it for later, see https://www.github.com/coverallsapp/github-action/issues/36#issuecomment-741141560. Using a slightly different approach as `set-output` is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).