### PR TITLE
Add ZeroIfNull as extension on INumberBase<TSelf>

### DIFF
--- a/specs/Qowaiv.Specs/Extensions/Number_specs.cs
+++ b/specs/Qowaiv.Specs/Extensions/Number_specs.cs
@@ -1,0 +1,18 @@
+﻿#if NET8_0_OR_GREATER
+
+using System.Numerics;
+
+namespace Extensions.Number_specs;
+
+public class ZeroIfNull
+{
+    [TestCase(1.0)]
+    [TestCase(3.14)]
+    public void Value_if_not_null(Amount? amount)
+        => amount.ZeroIfNull().Should().Be(amount!.Value);
+
+    [TestCase(null)]
+    public void Zero_if_null(Amount? amount)
+       => amount.ZeroIfNull().Should().Be(Amount.Zero);
+}
+#endif

--- a/src/Qowaiv/Extensions/System.Numerics.INumberBase.cs
+++ b/src/Qowaiv/Extensions/System.Numerics.INumberBase.cs
@@ -1,0 +1,18 @@
+﻿#if NET8_0_OR_GREATER
+
+namespace System.Numerics;
+
+/// <summary>Extensions on <see cref="INumberBase{TSelf}"/>.</summary>
+public static class QowaivNumberBaseExtensions
+{
+    /// <summary>Returns zero is the <paramref name="number"/> is null.</summary>
+    /// <typeparam name="TSelf">
+    /// Type of the number.
+    /// </typeparam>
+    [Pure]
+    public static TSelf ZeroIfNull<TSelf>(this TSelf? number) where TSelf : struct, INumberBase<TSelf>
+        => number is TSelf value
+        ? value
+        : TSelf.Zero;
+}
+#endif

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,10 +5,12 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>7.0.4</Version>
+    <Version>7.0.5</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
       <![CDATA[
+v7.0.5
+- Add ZeroIfNull() on INumberBase<TSelf>.
 v7.0.4
 - Percentage.TryParse should first change the scale, before checking the boundaries. (fix)
 v7.0.3


### PR DESCRIPTION
Nullable numbers (`decimal?`, `Amount?`, `Percentage?`, etc...) should have a fallback value of zero in almost all cases when they have to be used in calculations. This can be achieved in multiple ways:

``` C#
var number = nullable ?? 0m;
var number = nullable.GetValueOrDefault();
var number = nullable is { } val ? val : 0m;
```

From a story telling perspective, however, they are all not really helpful. With:

``` C#
var number = nullable.ZeroIfNull();
````

The story is clear.