### PR TITLE
Add examples to the intellisense of Percentage.Create(), .Percent() a…

### DIFF
--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -161,6 +161,8 @@ public class Is_equal_by_value
 
 public class Can_be_parsed
 {
+    [TestCase("en", "17.51")]
+    [TestCase("nl", "17,51")]
     [TestCase("en", "175.1‰")]
     [TestCase("en", "175.1‰")]
     [TestCase("en", "1751‱")]

--- a/src/Qowaiv/Extensions/Humanizer.Percentage.cs
+++ b/src/Qowaiv/Extensions/Humanizer.Percentage.cs
@@ -5,15 +5,29 @@ namespace Qowaiv;
 /// <summary>Extensions to create <see cref="Percentage" />s, inspired by Humanizer.NET.</summary>
 public static class NumberToPercentageExtensions
 {
-    /// <summary>Interprets the <see cref="int" /> if it was written with a '%' sign.</summary>
+    /// <summary>Interprets the <see cref="int" /> if it was written with a '%' sign.
+    /// <example>E.g:
+    /// 12.Percent() => 12%
+    /// </example>
+    /// </summary>
     [Pure]
     public static Percentage Percent(this int number) => ((decimal)number).Percent();
 
-    /// <summary>Interprets the <see cref="double" /> if it was written with a '%' sign.</summary>
+    /// <summary>Interprets the <see cref="double" /> if it was written with a '%' sign.
+    /// <example>E.g:
+    /// 12.0.Percent() => 12%
+    /// 0.1.Percent() => 0.1%
+    /// </example>
+    /// </summary>
     [Pure]
     public static Percentage Percent(this double number) => Cast.ToDecimal<Percentage>(number).Percent();
 
-    /// <summary>Interprets the <see cref="decimal" /> if it was written with a '%' sign.</summary>
+    /// <summary>Interprets the <see cref="decimal" /> if it was written with a '%' sign.
+    /// <example>E.g:
+    /// 12m.Percent() => 12%
+    /// 0.1m.Percent() => 0.1%
+    /// </example>
+    /// </summary>
     [Pure]
     public static Percentage Percent(this decimal number) => Percentage.Create(DecimalMath.ChangeScale(number, -2));
 }

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -242,20 +242,45 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
     [Pure]
     private string ToXmlString() => ToString(DefaultFormat + PercentSymbol, CultureInfo.InvariantCulture);
 
-    /// <summary>Casts a decimal to a Percentage.</summary>
+    /// <summary>Casts a decimal to a Percentage.
+    /// <example>E.g:
+    /// (Percentage)1.23m => 1.23%
+    /// (Percentage)0.1m => 0.1%
+    /// </example>
+    /// </summary>
     public static explicit operator Percentage(decimal val) => new(val);
 
-    /// <summary>Casts a decimal to a Percentage.</summary>
+    /// <summary>Casts a decimal to a Percentage.
+    /// <example>E.g:
+    /// (Percentage)1.23 => 1.23%
+    /// (Percentage)0.1 => 0.1%
+    /// </example>
+    /// </summary>
     public static explicit operator Percentage(double val) => Create(val);
 
-    /// <summary>Casts a Percentage to a decimal.</summary>
+    /// <summary>Casts a Percentage to a decimal.
+    /// <example>E.g:
+    /// 1.23% => 1.23m
+    /// 0.1% => 0.1m
+    /// </example>
+    /// </summary>
     public static explicit operator decimal(Percentage val) => val.m_Value;
 
-    /// <summary>Casts a Percentage to a double.</summary>
+    /// <summary>Casts a Percentage to a double.
+    /// <example>E.g:
+    /// 1.23% => 1.23
+    /// 0.1% => 0.1
+    /// </example>
+    /// </summary>
     public static explicit operator double(Percentage val) => (double)val.m_Value;
 
     /// <summary>Converts the string to a Percentage.
     /// A return value indicates whether the conversion succeeded.
+    /// <example>E.g:
+    /// "1.23%" => 1.23%
+    /// "175.1‰" => 17.51%
+    /// "0.1" => 0.1%
+    /// </example>
     /// </summary>
     /// <param name="s">
     /// A string containing a Percentage to convert.
@@ -329,7 +354,12 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
         }
     }
 
-    /// <summary>Creates a Percentage from a Decimal.</summary >
+    /// <summary>Creates a Percentage from a Decimal.
+    /// <example>E.g:
+    /// Percentage.Create(1.23m) => 123%
+    /// Percentage.Create(0.1m) => 10%
+    /// </example>
+    /// </summary >
     /// <param name="val" >
     /// A decimal describing a Percentage.
     /// </param >
@@ -339,7 +369,12 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
         ? new(val)
         : throw new ArgumentOutOfRangeException(QowaivMessages.ArgumentOutOfRange_Percentage, (Exception?)null);
 
-    /// <summary>Creates a Percentage from a Double.</summary >
+    /// <summary>Creates a Percentage from a Double.
+    /// <example>E.g:
+    /// Percentage.Create(1.23) => 123%
+    /// Percentage.Create(0.1) => 10%
+    /// </example>
+    /// </summary >
     /// <param name="val" >
     /// A decimal describing a Percentage.
     /// </param >

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,10 +5,12 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>7.1.1</Version>
+    <Version>7.1.2</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
       <![CDATA[
+v7.1.2
+- Add examples to the intellisense of Percentage.Create(), .Percent() and casts from and to numbers.
 v7.1.1
 - Diagnostics contracts compiled internals.
 - Wildcard patterns with trailing chars at the end. #417 (fix)


### PR DESCRIPTION
…nd casts from and to numbers.

Add examples to commonly used method in order to avoid confusion.