### PR TITLE
Non continous SVO's are preferably not serialized for their default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ based contract.
 * [Qowaiv.Json.Newtonsoft](https://www.nuget.org/packages/Qowaiv.Json.Newtonsoft/)  
 * [Qowaiv.Text.Json.Serialization](https://www.nuget.org/packages/Qowaiv.Text.Json.Serialization/)  
 
-For the .NET 6.0, and higher versions of the package, when using `System.Text.Json`,
+For .NET 6.0, and higher versions of the package, when using `System.Text.Json`,
 no custom serialization registration is required for Qowaiv SVO's: all have been
 decorated with the `[JsonConverter]` attribute.
 

--- a/README.md
+++ b/README.md
@@ -703,11 +703,28 @@ based contract.
 * [Qowaiv.Json.Newtonsoft](https://www.nuget.org/packages/Qowaiv.Json.Newtonsoft/)  
 * [Qowaiv.Text.Json.Serialization](https://www.nuget.org/packages/Qowaiv.Text.Json.Serialization/)  
 
-For the .NET 5.0, and higher versions of the package, when using `System.Text.Json`,
+For the .NET 6.0, and higher versions of the package, when using `System.Text.Json`,
 no custom serialization registration is required for Qowaiv SVO's: all have been
 decorated with the `[JsonConverter]` attribute.
 
-#### OpenAPI Specification
+#### Do not serialize empty SVO's
+Since .NET 8.0, it is possible to register modifiers for the `System.Text.Json.TypeInfoResolver`.
+This allows to change serialization behavior. On of the things to change is
+`ShouldSerialize(object model, object? prop)`. This can be useful if you do not
+want to serialize empty SVO's (such as `EmailAddress.Empty`). To get this
+(non-default) behavior you have to provide `JsonSerializerOptions` when serializing:
+
+``` C#
+var options = new JsonSerializerOptions()
+{
+    TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+    {
+        Modifiers = { Qowaiv.Json.ModifyTypeInfo.IgnoreEmptySvos },
+    },
+};
+```
+
+### OpenAPI Specification
 The [OpenAPI Specification](https://swagger.io/docs/specification/about/)
 (formerly Swagger Specification) is an API description format for REST API's.
 

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ decorated with the `[JsonConverter]` attribute.
 
 #### Do not serialize empty SVO's
 Since .NET 8.0, it is possible to register modifiers for the `System.Text.Json.TypeInfoResolver`.
-This allows to change serialization behavior. On of the things to change is
+This allows you to change serialization behavior, for example by editing
 `ShouldSerialize(object model, object? prop)`. This can be useful if you do not
 want to serialize empty SVO's (such as `EmailAddress.Empty`). To get this
 (non-default) behavior you have to provide `JsonSerializerOptions` when serializing:

--- a/specs/Qowaiv.Specs/Json/ModifyTypeInfo_specs.cs
+++ b/specs/Qowaiv.Specs/Json/ModifyTypeInfo_specs.cs
@@ -1,0 +1,37 @@
+#if NET8_0_OR_GREATER
+
+using Qowaiv.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Json.ModifyTypeInfo_specs;
+
+public class IgnoreEmptySvos
+{
+    internal static readonly JsonSerializerOptions Options = new()
+    {
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        {
+            Modifiers = { ModifyTypeInfo.IgnoreEmptySvos },
+        },
+    };
+
+    [Test]
+    public void ignores_empty_svos()
+    {
+        var json = JsonSerializer.Serialize(new WithNonContinuousSvo { Iban = default }, Options);
+        json.Should().Be("{}");
+    }
+
+    [Test]
+    public void serializes_non_empty_svos()
+    {
+        var json = JsonSerializer.Serialize(new WithNonContinuousSvo { Iban = Svo.Iban }, Options);
+        json.Should().Be(@"{""Iban"":""NL20INGB0001234567""}");
+    }
+
+    private sealed class WithNonContinuousSvo { public InternationalBankAccountNumber Iban { get; init; } }
+}
+
+
+#endif

--- a/src/Qowaiv/Json/ModifyTypeInfo.cs
+++ b/src/Qowaiv/Json/ModifyTypeInfo.cs
@@ -1,0 +1,38 @@
+#if NET8_0_OR_GREATER
+
+using System.Text.Json.Serialization.Metadata;
+
+namespace Qowaiv.Json;
+
+/// <summary>Helper to modify <see cref="JsonTypeInfo"/>'s.</summary>
+public static class ModifyTypeInfo
+{
+    /// <summary>
+    /// Updates all properties that implement <see cref="IEmpty{TSelf}"/> not
+    /// to serialize when <see cref="IEmpty{TSelf}.HasValue"/> is false.
+    /// </summary>
+    public static void IgnoreEmptySvos(JsonTypeInfo info)
+    {
+        Guard.NotNull(info);
+
+        foreach (var prop in info.Properties.Where(IsApplicable))
+        {
+            prop.ShouldSerialize = ShouldSerialize(Activator.CreateInstance(prop.PropertyType)!);
+        }
+    }
+
+    /// <summary>True when the propValue is different to the empty/default value.</summary>
+    [Pure]
+    private static Func<object, object?, bool> ShouldSerialize(object emptyValue) =>
+        (_, propValue) => !emptyValue.Equals(propValue);
+
+    /// <summary>Is applicable for structs implementing <see cref="IEmpty{TSelf}"/>.</summary>
+    [Pure]
+    private static bool IsApplicable(JsonPropertyInfo prop)
+        => prop.PropertyType is { IsValueType: true, IsGenericType: false }
+        && prop.PropertyType
+            .GetInterfaces()
+            .Exists(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEmpty<>));
+}
+
+#endif

--- a/src/Qowaiv/Json/ModifyTypeInfo.cs
+++ b/src/Qowaiv/Json/ModifyTypeInfo.cs
@@ -21,7 +21,7 @@ public static class ModifyTypeInfo
         }
     }
 
-    /// <summary>True when the propValue is different to the empty/default value.</summary>
+    /// <summary>True when the propValue is not equal to the empty/default value.</summary>
     [Pure]
     private static Func<object, object?, bool> ShouldSerialize(object emptyValue) =>
         (_, propValue) => !emptyValue.Equals(propValue);

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,10 +5,12 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>7.1.2</Version>
+    <Version>7.1.3</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
       <![CDATA[
+v7.1.3
+- Provide way to skip the JSON serialization of empty SVO's with ModifyTypeInfo.IgnoreEmptySvos. #427
 v7.1.2
 - Add examples to the intellisense of Percentage.Create(), .Percent() and casts from and to numbers.
 v7.1.1


### PR DESCRIPTION
I'm not certain if this `System.Text.Json` customization code should be in the Qowaiv core package in the first place, but besides, the use case is clear: For non-continuous SVO's (such as IBAN, emailadress, etc...) the JSON serialization value of the default/empty values is `null` (when `HasValue` is `false`).

Since .NET 8.0, it is possible to register modifiers to the `TypeInfoResolver`. One of them, is to assign `ShouldSerialize`. That option is used here. Using of this feature is straightforward:

``` C#
new JsonSerializerOptions()
{
    TypeInfoResolver = new DefaultJsonTypeInfoResolver()
    {
        Modifiers = { ModifyTypeInfo.IgnoreEmptySvos },
    },
};
```