### PR TITLE
IBAN human-readable should use non-breaking spaces

### DIFF
--- a/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/IBAN_specs.cs
@@ -1,4 +1,4 @@
-namespace Financial.IBAN_specs;
+namespace Financial.IBAN_specs;
 
 public class Supported
 {
@@ -225,8 +225,10 @@ public class Has_custom_formatting
 
     [TestCase(null, "NL20INGB0001234567", "NL20INGB0001234567")]
     [TestCase("f", "NL20INGB0001234567", "nl20 ingb 0001 2345 67")]
-    [TestCase("h", "NL20INGB0001234567", "nl20 ingb 0001 2345 67")]
-    [TestCase("H", "NL20INGB0001234567", "NL20 INGB 0001 2345 67")]
+    [TestCase("h", "NL20INGB0001234567", "nl20 ingb 0001 2345 67")]
+    [TestCase("H", "NL20INGB0001234567", "NL20 INGB 0001 2345 67")]
+    [TestCase("H", "", "")]
+    [TestCase("H", "?", "?")]
     [TestCase("u", "NL20INGB0001234567", "nl20ingb0001234567")]
     [TestCase("U", "NL20INGB0001234567", "NL20INGB0001234567")]
     [TestCase("m", "NL20INGB0001234567", "nl20ingb0001234567")]

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -116,13 +116,10 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
             while (index < m_Value.Length)
             {
                 buffer[pointer++] = m_Value[index++];
-#pragma warning disable S2583 // Conditionally executed code should be reachable
-                // FP. See: https://github.com/SonarSource/sonar-dotnet/issues/8474
                 if ((index % 4) == 0 && pointer < buffer.Length)
                 {
                     buffer[pointer++] = space;
                 }
-#pragma warning restore S2583 // Conditionally executed code should be reachable
             }
             return new(buffer);
         }
@@ -142,7 +139,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     /// u: as unformatted lowercase (equal to machine readable lowercase).
     /// U: as unformatted uppercase  (equal to machine readable).
     /// h: as human readable lowercase (with non-breaking spaces).
-    /// H: as human readable (equal to machine readable).
+    /// H: as human readable (with non-breaking spaces).
     /// f: as formatted lowercase.
     /// F: as formatted uppercase.
     /// </remarks>
@@ -150,19 +147,19 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     public string ToString(string? format, IFormatProvider? formatProvider)
         => StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted)
         ? formatted
-        : StringFormatter.Apply(this, format.WithDefault("U"), formatProvider, FormatTokens);
+        : StringFormatter.Apply(this, format.WithDefault("M"), formatProvider, FormatTokens);
 
     /// <summary>The format token instructions.</summary>
     private static readonly Dictionary<char, Func<InternationalBankAccountNumber, IFormatProvider, string>> FormatTokens = new()
     {
-        { 'u', (svo, _) => svo.MachineReadable().ToLowerInvariant() },
-        { 'U', (svo, _) => svo.MachineReadable() },
-        { 'm', (svo, _) => svo.MachineReadable().ToLowerInvariant() },
-        { 'M', (svo, _) => svo.MachineReadable() },
-        { 'h', (svo, _) => svo.HumanReadable(' ').ToLowerInvariant() },
-        { 'H', (svo, _) => svo.HumanReadable(' ') },
-        { 'f', (svo, _) => svo.HumanReadable(' ').ToLowerInvariant() },
-        { 'F', (svo, _) => svo.HumanReadable(' ') },
+        ['u'] = (svo, _) => svo.MachineReadable().ToLowerInvariant(),
+        ['U'] = (svo, _) => svo.MachineReadable(),
+        ['m'] = (svo, _) => svo.MachineReadable().ToLowerInvariant(),
+        ['M'] = (svo, _) => svo.MachineReadable(),
+        ['h'] = (svo, _) => svo.HumanReadable((char)160).ToLowerInvariant(),
+        ['H'] = (svo, _) => svo.HumanReadable((char)160),
+        ['f'] = (svo, _) => svo.HumanReadable(' ').ToLowerInvariant(),
+        ['F'] = (svo, _) => svo.HumanReadable(' '),
     };
 
     /// <summary>Gets an XML string representation of the IBAN.</summary>


### PR DESCRIPTION
The documentation states that `"H"` formats as human-readable, applying non-breaking spaces (contrary to `"F"` that uses regular spaces). However, this was not applied.

See #354