### PR TITLE
Add .NET 9.0 targets

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,6 +20,7 @@ jobs:
             3.1.x
             6.0.x
             8.0.x
+            9.0.x
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Setup .NET 8.0
+      - name: Setup .NET 9.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "9.0.x"
       - name: Generate coverage report
         run: |
-          dotnet test ./specs/Qowaiv.Specs -f net8.0 \
+          dotnet test ./specs/Qowaiv.Specs -f net9.0 \
           --configuration Release \
           --collect:"XPlat Code Coverage;Format=lcov"
       - name: Get path to lcov file

--- a/props/common.props
+++ b/props/common.props
@@ -58,7 +58,7 @@ inside and outside a Domain-driven context.
     </PackageTags>
     <Company>Qowaiv community</Company>
     <Copyright>Copyright © Qowaiv community 2013-current</Copyright>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>13.0</LangVersion>
     <!-- We ship package versions for obsolete target frameworks too -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>

--- a/specs/Qowaiv.Benchmarks/Qowaiv.Benchmarks.csproj
+++ b/specs/Qowaiv.Benchmarks/Qowaiv.Benchmarks.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>exe</OutputType>
     <Nullable>enable</Nullable>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Benchmarks</RootNamespace>
     <!-- We do not care about strong names for benchmarking -->
     <NoWarn>CS8002</NoWarn>

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <DefineConstants>CONTRACTS_FULL</DefineConstants>
   </PropertyGroup>
 

--- a/specs/Qowaiv.Wikipedia/Qowaiv.Wikipedia.csproj
+++ b/specs/Qowaiv.Wikipedia/Qowaiv.Wikipedia.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <DefineConstants>CONTRACTS_FULL</DefineConstants>
   </PropertyGroup>
 

--- a/src/Qowaiv.Data.SqlClient/Qowaiv.Data.SqlClient.csproj
+++ b/src/Qowaiv.Data.SqlClient/Qowaiv.Data.SqlClient.csproj
@@ -3,7 +3,7 @@
   <Import Project="../../props/package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>7.0.1</Version>
     <PackageId>Qowaiv.Data.SqlClient</PackageId>

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -3,7 +3,7 @@
   <Import Project="../../props/package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>7.0.1</Version>
     <PackageId>Qowaiv.TestTools</PackageId>

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -3,7 +3,7 @@
   <Import Project="../../props/package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>7.1.3</Version>
     <PackageId>Qowaiv</PackageId>


### PR DESCRIPTION
Not sure yet if we'll benefit from any .NET 9.0 feature, or C# 13 feature, but lets keep up with the latest anyway.