### PR TITLE
Introduction FileInfo.Lock() to lock files during a test

### DIFF
--- a/specs/Qowaiv.Specs/Clock_specs.cs
+++ b/specs/Qowaiv.Specs/Clock_specs.cs
@@ -103,24 +103,6 @@ public class For_current_execution_context_and_scope
         Clock.UtcNow().Should().NotBe(Svo.DateTime);
         Clock.TimeZone.Should().NotBe(Svo.TimeZone);
     }
-
-    [Test]
-    public async Task can_run_in_parallel_without_interference()
-    {
-        var tasks = Enumerable.Range(1900, 2000).Select(Test).ToArray();
-        var executionContexts = await Task.WhenAll(tasks);
-        executionContexts.Should().OnlyHaveUniqueItems();
-
-        async Task<int> Test(int year)
-        {
-            using (Clock.SetTimeForCurrentContext(() => new DateTime(year, 06, 11, 16, 15, 00, 000, DateTimeKind.Local)))
-            {
-                await Task.Delay(10);
-                Clock.UtcNow().Should().Be(new DateTime(year, 06, 11, 16, 15, 00, 000, DateTimeKind.Local));
-                return ExecutionContext.Capture()?.GetHashCode() ?? 0;
-            }
-        }
-    }
 }
 
 public class Today

--- a/specs/Qowaiv.Specs/TestTools/_specs/FileLock_specs.cs
+++ b/specs/Qowaiv.Specs/TestTools/_specs/FileLock_specs.cs
@@ -1,0 +1,30 @@
+namespace TestTools.IO.FileLock_specs;
+
+public class Locks
+{
+    [Test]
+    public void file_for_specified_scope()
+    {
+        using var dir = new TemporaryDirectory();
+
+        var file = dir.CreateFile("test.txt");
+        
+        using (var writer = new StreamWriter(file.FullName, false))
+        {
+            writer.Write("Unit Test");
+        }
+
+        using (var @lock = file.Lock())
+        {
+            file.Invoking(ReadContent).Should().Throw<IOException>();
+        }
+
+        ReadContent(file).Should().Be("Unit Test");
+    }
+
+    private static string ReadContent(FileInfo file)
+    {
+        using var reader = file.OpenText();
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Qowaiv.TestTools/IO/FileExtensions.cs
+++ b/src/Qowaiv.TestTools/IO/FileExtensions.cs
@@ -1,0 +1,11 @@
+using System.IO;
+
+namespace Qowaiv.TestTools.IO;
+
+/// <summary>Extensions on <see cref="FileInfo"/>.</summary>
+public static class FileExtensions
+{
+    /// <summary>Creates a lock on a <see cref="FileInfo"/>.</summary>
+    [Impure]
+    public static FileLock Lock(this FileInfo file) => new(file);
+}

--- a/src/Qowaiv.TestTools/IO/FileLock.cs
+++ b/src/Qowaiv.TestTools/IO/FileLock.cs
@@ -1,0 +1,36 @@
+using System.IO;
+
+namespace Qowaiv.TestTools.IO;
+
+/// <summary>Creates a lock on a file for its existence.</summary>
+[DebuggerDisplay("{Info}")]
+public sealed class FileLock : IDisposable
+{
+    internal FileLock(FileInfo file)
+    {
+        Info = Guard.NotNull(file);
+        Stream = new(file.FullName, FileMode.Open, FileAccess.Read, FileShare.None);
+    }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly FileInfo Info;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly FileStream Stream;
+
+    /// <summary>Casts the temporary directory to a <see cref="FileInfo" />.</summary>
+    [return: NotNullIfNotNull(nameof(@lock))]
+    public static implicit operator FileInfo?(FileLock? @lock) => @lock?.Info;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (!Disposed)
+        {
+            Stream.Dispose();
+            Disposed = true;
+        }
+    }
+
+    private bool Disposed;
+}

--- a/src/Qowaiv.TestTools/IO/TemporaryDirectory.cs
+++ b/src/Qowaiv.TestTools/IO/TemporaryDirectory.cs
@@ -41,16 +41,11 @@ public sealed class TemporaryDirectory : IDisposable
     public FileInfo CreateFile(string fileName) => new(Path.Combine(FullName, fileName));
 
     /// <summary>Disposes the temporary directory by deleting it and its content.</summary>
-    public void Dispose() => Dispose(true);
-
-    private void Dispose(bool disposing)
+    public void Dispose()
     {
         if (!isDisposed)
         {
-            if (disposing)
-            {
-                Root.Delete(true);
-            }
+            Root.Delete(true);
             isDisposed = true;
         }
     }

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -10,6 +10,8 @@
     <ProductName>Qowaiv Test Tools</ProductName>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased
+- Introduction FileInfo.Lock() to lock files during a test.
 v7.0.1
 - Update Qowaiv.Diagnostics.Contracts to 2.0.0. #418
 v7.0.0

--- a/src/Qowaiv.TestTools/README.md
+++ b/src/Qowaiv.TestTools/README.md
@@ -11,7 +11,7 @@ This package contains helpers to make writing unit tests for SVO's easier.
 ## IO
 
 ### Temporary directory
-Testing IO can be clumbersum. The `TemporaryDirectory` can help by creating a
+Testing IO can be cumbersome. The `TemporaryDirectory` can help by creating a
 directory that only exists for the duration of a test:
 
 ``` C#

--- a/src/Qowaiv.TestTools/README.md
+++ b/src/Qowaiv.TestTools/README.md
@@ -36,7 +36,6 @@ using (var @lock = file.Lock())
 {
      file.OpenRead(); // Throws IOException.
 }
-
 ```
 
 ## Further reading

--- a/src/Qowaiv.TestTools/README.md
+++ b/src/Qowaiv.TestTools/README.md
@@ -8,5 +8,36 @@ both inside and outside a Domain-driven context.
 ## Package
 This package contains helpers to make writing unit tests for SVO's easier.
 
+## IO
+
+### Temporary directory
+Testing IO can be clumbersum. The `TemporaryDirectory` can help by creating a
+directory that only exists for the duration of a test:
+
+``` C#
+using (var directory = new TemporaryDirectory()
+{
+     var file = directory.CraeteFile("somefile.txt");
+     // ..
+}
+```
+
+On the dispose, the directory, and all it children will be deleted.
+
+### File lock
+To test IO related unhappy flows, it can be useful to create a temporary lock
+on a file. This can be done as follows:
+
+``` C#
+
+var file = new FileInfo("somefile.txt");
+
+using (var @lock = file.Lock())
+{
+     file.OpenRead(); // Throws IOException.
+}
+
+```
+
 ## Further reading
 More info can be found at https://github.com/Qowaiv/Qowaiv.


### PR DESCRIPTION
To test IO related unhappy flows, it can be useful to create a temporary lock on a file. This can be done as follows:

``` C#

var file = new FileInfo("somefile.txt");

using (var @lock = file.Lock())
{
     file.OpenRead(); // Throws IOException.
}
```