### PR TITLE
Add deconstructors for relevent types

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ Represents a date, so without hours (minutes, seconds, milliseconds), opposed to
 var date = new Date(2017, 06, 11);
 var next = date++; // 2017-06-12
 var casted = (Date)new DateTime(2017, 06, 11, 06, 15);
+var (year, month, day) = date; // deconstructs.
 ```
 
 As, since .NET 6.0, `System.DateOnly` is available, `Qowaiv.Date` can be casted to (and from)
-this type, if (and only if), the .NET 6.0 version of the package is used.
+this type, if (and only if), the .NET 8.0 version or higher of the package is used.
 
 ### Date span
 Represents a date span. Opposed to a `TimeSpan` its duration is (a bit) resilient;
@@ -80,6 +81,7 @@ var span = new DateSpan(years: 3, months: 2, days: -4);
 var age = DateSpan.Age(new Date(2017, 06, 11)); // 2Y+0M+121D on 2019-10-10
 var duration = DateSpan.Subtract(new Date(2019, 06, 10), new Date(2017, 06, 11)); // 1Y+11M+30D
 var date = new Date(2016, 06, 03).Add(age); // 2018-10-02
+var (years, months, days) = span; // deconstructs.
 ```
 
 ### Email address
@@ -100,11 +102,7 @@ email.ToString(); // test@qowaiv.org
 quoted.ToString(); // email@qowaiv.org
 ip_based.IsIPBased; // true
 ip_based.WithDisplayName("Jimi Hendrix"); // Jimi Hendrix <test@[172.16.254.1]>
-
 ```
-
-### Email address collection
-Represents a collection of unique email addresses, excluding the empty and unknown email address.
 
 ### Stream size
 Represents the size of a file or stream.
@@ -164,6 +162,7 @@ Is a subset of the date span, so without the days precision.
 var ctor = new MonthSpan(years: 5, months: 6); // 69 months.
 var months = MonthSpan.FromMonths(13);
 var years = MonthSpan.FromYears(3); // 35 months.
+var (years, months) = ctor; // deconstructs.
 
 // operations
 var delta = MonthSpan.Subtract(new Date(2020, 04, 01), new Date(2020, 02, 28)); // 1 month.
@@ -232,6 +231,12 @@ sex.ToString("h", new CultureInfo("en-GB")); // Mrs.
 ### Week date
 Represents a week based date.
 
+``` C#
+var date = new WeekDate(2017, 23, 7);
+var next = date++; // 2017-W24-1
+var (year, week, day) = date; // deconstructs.
+```
+
 ### Year
 Represents a year in the range [1-9999].
 
@@ -254,6 +259,7 @@ Represent a date with year and month precision.
 
 ``` C#
 var date = new YearMonth(2017, 06);
+var (year, month) = date; // deconstructs.
 
 // Querying
 date.IsIn(2017.CE()); // true
@@ -343,6 +349,7 @@ acts identically as a SVO.
 Money money = 125.34 + Currency.EUR;
 var sum = (12 + Currency.EUR) + (15 + Currency.USD); // Throws CurrencyMismatchException()
 var rounded = money.Round(0); // EUR 125.00
+var (amount, currency) = money; // deconstructs.
 ```
 
 ## Qowaiv globalization types
@@ -390,6 +397,7 @@ Fraction fromFloating = Fraction.Create(0.3456786754m);
 
 Fraction casted = (Fraction)34;
 Fraction casted = (Fraction)0.3333;
+var (numerator, denominator) = fluent; // deconstructs.
 ```
 
 #### Operations
@@ -1042,7 +1050,7 @@ is good defense against hash flooding.
 
 for test purposes, it is possible to generate a hashcode without using the randomizer:
 ``` C#
-using(Hash.WithoutRandomizer())
+using (Hash.WithoutRandomizer())
 {
     var hash = Hash.Code("QOWAIV string");
     hash.Should().Be(1211348473);
@@ -1059,7 +1067,6 @@ public int GetHashCode()
 
 This works out of the box because `Hash` can be implicitly cast to an `int`.
 Calling `Hash.GetHashCode()` is not allowed, just use the implicit cast.
-
 
 ### Sortable
 SVO's support sorting. So, LINQ expressions like OrderBy() and OrderByDescending()
@@ -1155,7 +1162,7 @@ change the behaviour, in most cases just for the scope of your current
 [Test]
 public void TestSomething()
 {
-    using(Clock.SetTimeForCurrentContext(() => new DateTime(2017, 06, 11))
+    using (Clock.SetTimeForCurrentContext(() => new DateTime(2017, 06, 11))
     {
         // test code.
     }

--- a/specs/Qowaiv.Specs/Date_span_specs.cs
+++ b/specs/Qowaiv.Specs/Date_span_specs.cs
@@ -292,3 +292,15 @@ public class Throws_when
             .Should().Throw<ArgumentOutOfRangeException>()
             .WithMessage("The specified years, months and days results in an un-representable DateSpan.");
 }
+
+public class Can_be_deconstructed
+{
+    [Test]
+    public void in_years_months_and_days_part()
+    {
+        var (years, months, days) = Svo.DateSpan;
+        years.Should().Be(10);
+        months.Should().Be(3);
+        days.Should().Be(-5);
+    }
+}

--- a/specs/Qowaiv.Specs/Date_specs.cs
+++ b/specs/Qowaiv.Specs/Date_specs.cs
@@ -283,3 +283,15 @@ public class Casts
     }
 }
 #endif
+
+public class Can_be_deconstructed
+{
+    [Test]
+    public void in_year_month_and_day_part()
+    {
+        var (year, month, day) = Svo.Date;
+        year.Should().Be(2017);
+        month.Should().Be(6);
+        day.Should().Be(11);
+    }
+}

--- a/specs/Qowaiv.Specs/Financial/Money_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/Money_specs.cs
@@ -131,3 +131,14 @@ public class Throws_when
             .WithMessage("The subtraction operation could not be applied. There is a mismatch between EUR and USD.");
     }
 }
+
+public class Can_be_deconstructed
+{
+    [Test]
+    public void in_amount_and_currency_part()
+    {
+        var (amount, currency) = Svo.Money;
+        amount.Should().Be(Svo.Amount);
+        currency.Should().Be(Svo.Currency);
+    }
+}

--- a/specs/Qowaiv.Specs/Formatting/Formatting_arguments_specs.cs
+++ b/specs/Qowaiv.Specs/Formatting/Formatting_arguments_specs.cs
@@ -89,3 +89,14 @@ public class IFormattable_ToString_extension
     public void null_for_null_IFormattable_with_null_arguments_collection()
         => Nil.IFormattable.ToString(Nil.FormattingArgumentsCollection).Should().BeNull();
 }
+
+public class Can_be_deconstructed
+{
+    [Test]
+    public void in_format_and_formatProvider_part()
+    {
+        var (format, formatProvider) = Svo.FormattingArguments;
+        format.Should().Be("0.000");
+        formatProvider.Should().Be(TestCultures.fr_BE);
+    }
+}

--- a/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
+++ b/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
@@ -954,3 +954,14 @@ public class Debugger
     public void has_custom_display(object display, Fraction svo)
         => svo.Should().HaveDebuggerDisplay(display);
 }
+
+public class Can_be_deconstructed
+{
+    [Test]
+    public void in_numerator_and_denominator_part()
+    {
+        var (numerator, denominator) = Svo.Fraction;
+        numerator.Should().Be(-69);
+        denominator.Should().Be(17);
+    }
+}

--- a/specs/Qowaiv.Specs/Month_span_specs.cs
+++ b/specs/Qowaiv.Specs/Month_span_specs.cs
@@ -270,3 +270,14 @@ public class Is_Open_API_data_type
            format: "month-span",
            pattern: @"[+-]?[0-9]+Y[+-][0-9]+M"));
 }
+
+public class Can_be_deconstructed
+{
+    [Test]
+    public void in_years_and_months_part()
+    {
+        var (years, months) = Svo.MonthSpan;
+        years.Should().Be(5);
+        months.Should().Be(9);
+    }
+}

--- a/specs/Qowaiv.Specs/TestTools/Svo.cs
+++ b/specs/Qowaiv.Specs/TestTools/Svo.cs
@@ -50,7 +50,7 @@ public static class Svo
     public static readonly EnergyLabel EnergyLabel = EnergyLabel.A(2);
 
     /// <summary>0.000 (fr-BE)</summary>
-    public static readonly FormattingArguments FormattingArguments = new("0.000", new CultureInfo("fr-BE"));
+    public static readonly FormattingArguments FormattingArguments = new("0.000", TestCultures.fr_BE);
 
     /// <summary>-69/17</summary>
     public static readonly Fraction Fraction = -69.DividedBy(17);
@@ -85,6 +85,8 @@ public static class Svo
     public static readonly TimeZoneInfo TimeZone = TestTimeZones.EastAustraliaStandardTime;
     public static readonly Timestamp Timestamp = 1234567890L;
     public static readonly Uuid Uuid = Uuid.Parse("Qowaiv_SVOLibrary_GUIA");
+
+    /// <summary>2017-W23-7</summary>
     public static readonly WeekDate WeekDate = new(2017, 23, 7);
     public static readonly Year Year = 1979.CE();
 

--- a/specs/Qowaiv.Specs/Text/Base32_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base32_specs.cs
@@ -69,7 +69,7 @@ public class TryGetBytes_from
 public class GetBytes
 {
     [Test]
-    public void Null__returns_EmptyArray()
+    public void Null_returns_EmptyArray()
     {
         Base32.GetBytes(null).Should().BeEmpty();
     }

--- a/specs/Qowaiv.Specs/Text/Base64_specs.cs
+++ b/specs/Qowaiv.Specs/Text/Base64_specs.cs
@@ -23,7 +23,7 @@ public class ToString
 public class TryGetBytes_from
 {
     [Test]
-    public void Null__returns_EmptyArray()
+    public void Null_returns_EmptyArray()
     {
         Base64.TryGetBytes(null, out var bytes).Should().BeTrue();
         bytes.Should().BeEmpty();

--- a/specs/Qowaiv.Specs/Text/CharBuffer_specs.cs
+++ b/specs/Qowaiv.Specs/Text/CharBuffer_specs.cs
@@ -110,7 +110,7 @@ public class Trim
 public class Uppercase
 {
     [Test]
-    public void Transforms_all_characters_to__uppercase_alternatives()
+    public void Transforms_all_characters_to_uppercase_alternatives()
     {
         var buffer = "abcDeéf".Buffer().Uppercase();
         buffer.Should().BeEquivalentTo("ABCDEÉF");

--- a/specs/Qowaiv.Specs/Week_date_specs.cs
+++ b/specs/Qowaiv.Specs/Week_date_specs.cs
@@ -212,3 +212,15 @@ public class Casts
     }
 }
 #endif
+
+public class Can_be_deconstructed
+{
+    [Test]
+    public void int_year_week_and_day_part()
+    {
+        var (year, week, day) = Svo.WeekDate;
+        year.Should().Be(2017);
+        week.Should().Be(23);
+        day.Should().Be(7);
+    }
+}

--- a/specs/Qowaiv.Specs/Week_date_specs.cs
+++ b/specs/Qowaiv.Specs/Week_date_specs.cs
@@ -216,7 +216,7 @@ public class Casts
 public class Can_be_deconstructed
 {
     [Test]
-    public void int_year_week_and_day_part()
+    public void in_year_week_and_day_part()
     {
         var (year, week, day) = Svo.WeekDate;
         year.Should().Be(2017);

--- a/specs/Qowaiv.Specs/YearMonth_specs.cs
+++ b/specs/Qowaiv.Specs/YearMonth_specs.cs
@@ -580,3 +580,14 @@ public class Debugger
     public void has_custom_display(object display, YearMonth svo)
         => svo.Should().HaveDebuggerDisplay(display);
 }
+
+public class Can_be_deconstructed
+{
+    [Test]
+    public void in_year_and_month_part()
+    {
+        var (year, month) = Svo.YearMonth;
+        year.Should().Be(2017);
+        month.Should().Be(6);
+    }
+}

--- a/src/Qowaiv.TestTools/Globalization/TestCultures.cs
+++ b/src/Qowaiv.TestTools/Globalization/TestCultures.cs
@@ -69,6 +69,9 @@ public static class TestCultures
         }
     }
 
+    /// <summary>Gets the French (fr-BE) <see cref="CultureInfo" />.</summary>
+    public static CultureInfo fr_BE => new("fr-BE");
+
     /// <summary>Gets the French (fr-FR) <see cref="CultureInfo" />.</summary>
     public static CultureInfo fr_FR => new("fr-FR");
 

--- a/src/Qowaiv/Date.cs
+++ b/src/Qowaiv/Date.cs
@@ -86,6 +86,15 @@ public readonly partial struct Date : IXmlSerializable, IFormattable, IEquatable
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly DateTime m_Value;
 
+    /// <summary>Deconstructs the date in a year, month and day.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void Deconstruct(out int year, out int month, out int day)
+    {
+        year = Year;
+        month = Month;
+        day = Day;
+    }
+
     /// <summary>Adds one day to the date.</summary>
     [Pure]
     internal Date Increment() => AddDays(+1);

--- a/src/Qowaiv/DateSpan.cs
+++ b/src/Qowaiv/DateSpan.cs
@@ -95,6 +95,15 @@ public readonly partial struct DateSpan : IXmlSerializable, IFormattable, IEquat
     /// <summary>Gets a (approximate) value to sort the date spans by.</summary>
     internal double TotalDays => Days + (TotalMonths * DaysPerMonth);
 
+    /// <summary>Deconstructs the date span in a years, months and days.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void Deconstruct(out int years, out int months, out int days)
+    {
+        years = Years;
+        months = Months;
+        days = Days;
+    }
+
     /// <summary>Unary plus the date span.</summary>
     [Pure]
     internal DateSpan Plus() => this;

--- a/src/Qowaiv/Extensions/System.IFormattable.cs
+++ b/src/Qowaiv/Extensions/System.IFormattable.cs
@@ -14,6 +14,7 @@ public static class QowaivFormattableExtensions
     /// A formatted string representing the object.
     /// </returns>
     [Pure]
+    [return: NotNullIfNotNull(nameof(formattable))]
     public static string? ToString(this IFormattable? formattable, FormattingArguments arguments)
         => formattable is { }
         ? arguments.ToString(formattable)
@@ -30,8 +31,9 @@ public static class QowaivFormattableExtensions
     /// A formatted string representing the object.
     /// </returns>
     [Pure]
+    [return: NotNullIfNotNull(nameof(formattable))]
     public static string? ToString(this IFormattable? formattable, FormattingArgumentsCollection? argumentsCollection)
-      => formattable is { }
+        => formattable is { }
         ? (argumentsCollection ?? []).ToString(formattable)
         : null;
 }

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -57,13 +57,13 @@ public readonly partial struct BusinessIdentifierCode : IXmlSerializable, IForma
     /// <summary>Gets the country info of the country code.</summary>
     public Country Country
         => m_Value is { Length: >= 6 }
-        ? Country.Parse(m_Value.Substring(4, 2), CultureInfo.InvariantCulture)
+        ? Country.Parse(m_Value[4..6], CultureInfo.InvariantCulture)
         : Country.Empty;
 
     /// <summary>Gets the location code.</summary>
     public string Location
         => m_Value is { Length: >= 8 } && !IsUnknown()
-        ? m_Value.Substring(6, 2)
+        ? m_Value[6..8]
         : string.Empty;
 
     /// <summary>Gets the branch code.</summary>

--- a/src/Qowaiv/Financial/Money.cs
+++ b/src/Qowaiv/Financial/Money.cs
@@ -58,6 +58,14 @@ public readonly partial struct Money : IXmlSerializable, IFormattable, IEquatabl
     /// <summary>Gets the currency of the money.</summary>
     public Currency Currency => m_Currency;
 
+    /// <summary>Deconstructs the money in the amount and its currency.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void Deconstruct(out Amount amount, out Currency currency)
+    {
+        amount = Amount;
+        currency = Currency;
+    }
+
     /// <summary>Gets the sign of the value of the money.</summary>
     [Pure]
     public int Sign() => m_Value.Sign();

--- a/src/Qowaiv/Formatting/FormattingArguments.cs
+++ b/src/Qowaiv/Formatting/FormattingArguments.cs
@@ -39,6 +39,14 @@ public readonly struct FormattingArguments : ISerializable, IEquatable<Formattin
     /// <summary>Gets the format provider.</summary>
     public IFormatProvider? FormatProvider { get; }
 
+    /// <summary>Deconstructs the formatting arguments in a format and formatProvider.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void Deconstruct(out string? format, out IFormatProvider? formatProvider)
+    {
+        format = Format;
+        formatProvider = FormatProvider;
+    }
+
     /// <summary>Formats the object using the formatting arguments.</summary>
     /// <param name="obj">
     /// The IFormattable object to get the formatted string representation from.
@@ -120,14 +128,10 @@ public readonly struct FormattingArguments : ISerializable, IEquatable<Formattin
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand.</param>
     [Pure]
-    public static bool operator ==(FormattingArguments left, FormattingArguments right)
-        => left.Equals(right);
+    public static bool operator ==(FormattingArguments left, FormattingArguments right) => left.Equals(right);
 
     /// <summary>Returns true if the left and right operand are equal, otherwise false.</summary>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand.</param>
-    public static bool operator !=(FormattingArguments left, FormattingArguments right)
-    {
-        return !(left == right);
-    }
+    public static bool operator !=(FormattingArguments left, FormattingArguments right) => !(left == right);
 }

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -130,6 +130,14 @@ public readonly partial struct Fraction : IXmlSerializable, IFormattable, IEquat
     /// <summary>Get whole of the fraction.</summary>
     public long Whole => IsZero() ? 0 : numerator / denominator;
 
+    /// <summary>Deconstructs the fraction in a numerator and denominator.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void Deconstruct(out long numerator, out long denominator)
+    {
+        numerator = Numerator;
+        denominator = Denominator;
+    }
+
     /// <summary>Gets the remainder of the fraction.</summary>
     /// <remarks>
     /// The remainder is expressed as an absolute value.

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -47,6 +47,14 @@ public readonly partial struct MonthSpan : IXmlSerializable, IFormattable, IEqua
     /// <summary>Gets the months component of the month span.</summary>
     public int Months => TotalMonths % DateSpan.MonthsPerYear;
 
+    /// <summary>Deconstructs the month span in a years, and months.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void Deconstruct(out int years, out int months)
+    {
+        years = Years;
+        months = Months;
+    }
+
     /// <summary>Unary plus the month span.</summary>
     [Pure]
     internal MonthSpan Plus() => this;

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -5,10 +5,19 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>7.2.0</Version>
+    <Version>7.2.1</Version>
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
       <![CDATA[
+v7.2.1
+- Add Deconstruct to Date.
+- Add Deconstruct to DateSpan.
+- Add Deconstruct to Fraction,
+- Add Deconstruct to FormattingAgurments.
+- Add Deconstruct to Money.
+- Add Deconstruct to MonthSpan.
+- Add Deconstruct to WeekDate.
+- Add Deconstruct to YearMonth.
 v7.2.0
 - Added .NET 9.0 version to the package.
 - Singapore postal codes contain 6, not 5 digits. (fix)

--- a/src/Qowaiv/WeekDate.cs
+++ b/src/Qowaiv/WeekDate.cs
@@ -92,6 +92,15 @@ public readonly partial struct WeekDate : IXmlSerializable, IFormattable, IEquat
     /// <summary>Gets the date time component of this instance.</summary>
     public Date Date => m_Value;
 
+    /// <summary>Deconstructs the week date in a year, week and day.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void Deconstruct(out int year, out int week, out int day)
+    {
+        year = Year;
+        week = Week;
+        day = Day;
+    }
+
     /// <summary>Gets the year of week part of the week date.</summary>
     [Pure]
     private int GetDatePart(int part)

--- a/src/Qowaiv/YearMonth.cs
+++ b/src/Qowaiv/YearMonth.cs
@@ -4,7 +4,7 @@ namespace Qowaiv;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable]
 [SingleValueObject(SingleValueStaticOptions.All ^ SingleValueStaticOptions.HasEmptyValue ^ SingleValueStaticOptions.HasUnknownValue, typeof(int))]
-[OpenApiDataType(description: "Date notation with month precision.", example: "2017-06", type: "string", format: "year-month", pattern: "[0-9]{4}-(0[1-9]|1[0-2])")]
+ [OpenApiDataType(description: "Date notation with month precision.", example: "2017-06", type: "string", format: "year-month", pattern: "[0-9]{4}-(0[1-9]|1[0-2])")]
 [TypeConverter(typeof(YearMonthTypeConverter))]
 #if NET6_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.YearMonthJsonConverter))]
@@ -41,6 +41,14 @@ public readonly partial struct YearMonth : IXmlSerializable, IFormattable, IEqua
     /// <summary>Returns a <see cref="string" /> that represents the year-month for DEBUG purposes.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => this.DebuggerDisplay("{0:yyyy-MM}");
+
+    /// <summary>Deconstructs the date month in a year and month.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void Deconstruct(out int year, out int month)
+    {
+        year = Year;
+        month = Month;
+    }
 
     /// <summary>Returns a new year-month that adds the value of the specified <see cref="MonthSpan" />
     /// to the value of this instance.


### PR DESCRIPTION
The option to [deconstruct types](https://learn.microsoft.com/dotnet/csharp/fundamentals/functional/deconstruct) exist since C# 7, so it was about time to add the support to SVO's that benefit from it:
- [x] Date
- [x] DateSpan
- [x] Fraction
- [x] Money
- [x] MonthSpan
- [x] WeekDate
- [x] YearMonth

It also has been added to `FormattingAgurments`, an helper to combine the arguments provided to apply `.ToString(string format, IFormatProvider formatProvider)`, defined by `IFormattable`.