### PR TITLE
Tweak Year-month Open API definition pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ and if the data type is nullable, all when applicable.
     "example": "2017-06",
     "type": "string",
     "format": "year-month",
-    "pattern": "[0-9]{4}-[01][0-9]",
+    "pattern": "[0-9]{4}-(0?[1-9]|1[0-2])",
     "nullable": false
   },
   "YesNo": {

--- a/specs/Qowaiv.Specs/YearMonth_specs.cs
+++ b/specs/Qowaiv.Specs/YearMonth_specs.cs
@@ -560,8 +560,9 @@ public class Is_Open_API_data_type
            example: "2017-06",
            type: "string",
            format: "year-month",
-           pattern: "[0-9]{4}-(0[1-9]|1[0-2])"));
+           pattern: "[0-9]{4}-(0?[1-9]|1[0-2])"));
 
+    [TestCase("2017-6")]
     [TestCase("2017-06")]
     [TestCase("1900-11")]
     [TestCase("1979-12")]

--- a/specs/Qowaiv.Specs/YearMonth_specs.cs
+++ b/specs/Qowaiv.Specs/YearMonth_specs.cs
@@ -564,6 +564,7 @@ public class Is_Open_API_data_type
 
     [TestCase("2017-6")]
     [TestCase("2017-06")]
+    [TestCase("1900-10")]
     [TestCase("1900-11")]
     [TestCase("1979-12")]
     public void pattern_matches(string input)

--- a/src/Qowaiv/OpenApi/OpenApiDataType.cs
+++ b/src/Qowaiv/OpenApi/OpenApiDataType.cs
@@ -89,7 +89,8 @@ public sealed record OpenApiDataType
     /// <summary>Returns true if the pattern matches the input, or the is no pattern restriction.</summary>
     [Pure]
     public bool Matches(string? str)
-        => Pattern is null || Regex.IsMatch(str!, Pattern, RegexOptions.None, RegOptions.Timeout);
+        => Pattern is null
+        || Regex.IsMatch(str!, '^' + Pattern + '$', RegexOptions.None, RegOptions.Timeout);
 
     /// <summary>
     /// Creates an <see cref="OpenApiDataType" /> based on a type, null if not

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,6 +9,8 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
       <![CDATA[
+TOBeReleased:
+- Year-month Open API definition pattern allows months without leading zero. (fix)
 v7.2.0
 - Added .NET 9.0 version to the package.
 - Singapore postal codes contain 6, not 5 digits. (fix)

--- a/src/Qowaiv/YearMonth.cs
+++ b/src/Qowaiv/YearMonth.cs
@@ -4,7 +4,7 @@ namespace Qowaiv;
 [DebuggerDisplay("{DebuggerDisplay}")]
 [Serializable]
 [SingleValueObject(SingleValueStaticOptions.All ^ SingleValueStaticOptions.HasEmptyValue ^ SingleValueStaticOptions.HasUnknownValue, typeof(int))]
-[OpenApiDataType(description: "Date notation with month precision.", example: "2017-06", type: "string", format: "year-month", pattern: "[0-9]{4}-(0[1-9]|1[0-2])")]
+[OpenApiDataType(description: "Date notation with month precision.", example: "2017-06", type: "string", format: "year-month", pattern: "[0-9]{4}-(0?[1-9]|1[0-2])")]
 [TypeConverter(typeof(YearMonthTypeConverter))]
 #if NET6_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.YearMonthJsonConverter))]


### PR DESCRIPTION
That pattern for Year-month as specified by the Open API attribute should not only allow `2017-06`, but also `2017-6`, even though Qowaiv will seralize with the leading zero.