### PR TITLE
PostalCode.Empty is valid for countries without a postal code system

### DIFF
--- a/specs/Qowaiv.Specs/Postal_code_specs.cs
+++ b/specs/Qowaiv.Specs/Postal_code_specs.cs
@@ -47,9 +47,15 @@ public class Is_valid_for
 {
     static readonly IEnumerable<object[]> ValidForCountry = PostalCodes.Valid.SelectMany(codes => codes.ToArrays());
 
+    static readonly IEnumerable<Country> CountriesWithoutPostalCodeSystem = PostalCodeCountryInfo.GetCountriesWithoutPostalCode();
+
     [TestCaseSource(nameof(ValidForCountry))]
     public void country(Country country, PostalCode postalCode)
         => postalCode.IsValid(country).Should().BeTrue();
+
+    [TestCaseSource(nameof(CountriesWithoutPostalCodeSystem))]
+    public void countries_without_postal_code_when_empty(Country country)
+        => PostalCode.Empty.IsValid(country).Should().BeTrue();
 
     [Test]
     public void multiple_countries()
@@ -68,6 +74,19 @@ public class Is_valid_for
             Country.PG,
         ]);
     }
+}
+
+public class Is_not_valid_for
+{
+    static readonly IEnumerable<Country> CountriesWithoutPostalCodeSystem = PostalCodeCountryInfo.GetCountriesWithoutPostalCode();
+
+    [Test]
+    public void country_with_different_system()
+        => Svo.PostalCode.IsValid(Country.NL).Should().BeFalse();
+
+    [TestCaseSource(nameof(CountriesWithoutPostalCodeSystem))]
+    public void countries_without_postal_code(Country country)
+        => PostalCode.Parse("1234").IsValid(country).Should().BeFalse();
 }
 
 public class Has_constant

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -5,7 +5,11 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0;net9.0</TargetFrameworks>
+    <!--
+      TODO: renable netcoreapp3.1, it currently fails due to ICU (culture) issues
+      See: https://forum.manjaro.org/t/dotnet-3-1-builds-fail-after-icu-system-package-updated-to-71-1-1
+    -->
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <DefineConstants>CONTRACTS_FULL</DefineConstants>
   </PropertyGroup>
 

--- a/specs/Qowaiv.Specs/TestTools/Svo.cs
+++ b/specs/Qowaiv.Specs/TestTools/Svo.cs
@@ -78,7 +78,10 @@ public static class Svo
     public static readonly MonthSpan MonthSpan = MonthSpan.FromMonths(69);
 
     public static readonly Percentage Percentage = 17.51.Percent();
+
+    /// <summary>H0H0H0 (Canada)</summary>
     public static readonly PostalCode PostalCode = PostalCode.Parse("H0H0H0");
+
     public static readonly Secret Secret = Secret.Parse("Ken sent me!");
     public static readonly Sex Sex = Sex.Female;
     public static readonly StreamSize StreamSize = 123456789.Bytes();

--- a/src/Qowaiv/Globalization/Country.cs
+++ b/src/Qowaiv/Globalization/Country.cs
@@ -94,6 +94,10 @@ public readonly partial struct Country : IXmlSerializable, IFormattable, IEquata
         }
     }
 
+    /// <summary>Returns true if the country has a postal code system.</summary>
+    [Pure]
+    public bool HasPostalCodeSystem() => PostalCodeCountryInfo.GetInstance(this).HasPostalCode;
+
     /// <summary>Gets the display name for a specified culture.</summary>
     /// <param name="culture">
     /// The culture of the display name.

--- a/src/Qowaiv/Globalization/PostalCodeCountryInfo.cs
+++ b/src/Qowaiv/Globalization/PostalCodeCountryInfo.cs
@@ -49,9 +49,10 @@ public sealed partial class PostalCodeCountryInfo
     /// </remarks>
     [Pure]
     public bool IsValid(string? postalcode)
-        => !string.IsNullOrEmpty(postalcode)
-        && ValidationPattern is { }
-        && postalcode.Unify().Matches(ValidationPattern);
+        => HasPostalCode
+        ? !string.IsNullOrEmpty(postalcode)
+            && postalcode.Unify().Matches(ValidationPattern!)
+        : string.IsNullOrEmpty(postalcode);
 
     /// <summary>Formats the postal code.</summary>
     /// <param name="postalcode">

--- a/src/Qowaiv/Globalization/PostalCodeCountryInfo.cs
+++ b/src/Qowaiv/Globalization/PostalCodeCountryInfo.cs
@@ -118,7 +118,7 @@ public sealed partial class PostalCodeCountryInfo
     /// <summary>Gets countries without a postal code system.</summary>
     [Pure]
     public static IEnumerable<Country> GetCountriesWithoutPostalCode()
-        => Country.GetExisting().Where(country => !GetInstance(country).HasPostalCode);
+        => Country.GetExisting().Where(country => country.HasPostalCodeSystem());
 
     /// <summary>Gets countries with postal codes with formatting.</summary>
     [Pure]

--- a/src/Qowaiv/Globalization/PostalCodeCountryInfo.cs
+++ b/src/Qowaiv/Globalization/PostalCodeCountryInfo.cs
@@ -45,7 +45,7 @@ public sealed partial class PostalCodeCountryInfo
     /// The postal code to test.
     /// </param>
     /// <remarks>
-    /// Returns false if the country does not have postal codes.
+    /// Returns false if the country does not have postal codes, unless the postal code is empty.
     /// </remarks>
     [Pure]
     public bool IsValid(string? postalcode)

--- a/src/Qowaiv/Globalization/PostalCodeCountryInfo.cs
+++ b/src/Qowaiv/Globalization/PostalCodeCountryInfo.cs
@@ -118,7 +118,7 @@ public sealed partial class PostalCodeCountryInfo
     /// <summary>Gets countries without a postal code system.</summary>
     [Pure]
     public static IEnumerable<Country> GetCountriesWithoutPostalCode()
-        => Country.GetExisting().Where(country => country.HasPostalCodeSystem());
+        => Country.GetExisting().Where(country => !country.HasPostalCodeSystem());
 
     /// <summary>Gets countries with postal codes with formatting.</summary>
     [Pure]

--- a/src/Qowaiv/PostalCode.cs
+++ b/src/Qowaiv/PostalCode.cs
@@ -27,7 +27,7 @@ public readonly partial struct PostalCode : IXmlSerializable, IFormattable, IEqu
     /// The country to valid for.
     /// </param>
     /// <remarks>
-    /// Returns false if the country does not have postal codes.
+    /// Returns false if the country does not have postal codes, unless the postal code is empty.
     /// </remarks>
     [Pure]
     public bool IsValid(Country country) => IsValid(m_Value, country);
@@ -129,7 +129,7 @@ public readonly partial struct PostalCode : IXmlSerializable, IFormattable, IEqu
     /// The country to valid for.
     /// </param>
     /// <remarks>
-    /// Returns false if the country does not have postal codes.
+    /// Returns false if the country does not have postal codes, unless the postal code is empty.
     /// </remarks>
     [Pure]
     public static bool IsValid(string? postalcode, Country country)

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -10,7 +10,8 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased:
-- PostalCode.Empty is valid for countries without a postal code system. (fix)
+- PostalCode.Empty is valid for countries without a postal code system. (fix) #444
+- Added Country.HasPostalCodeSystem(). #444
 v7.2.1
 - Add Deconstruct to Date.
 - Add Deconstruct to DateSpan.

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -9,6 +9,8 @@
     <PackageId>Qowaiv</PackageId>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased:
+- PostalCode.Empty is valid for countries without a postal code system. (fix)
 v7.2.1
 - Add Deconstruct to Date.
 - Add Deconstruct to DateSpan.


### PR DESCRIPTION
For countries without a postal code system, `PostalCode.Empty` should be valid (and all other values should not be valid, what was already the case).

Closes #443 