### PR TITLE
Test .NET standard 2.0 via .NET 5.0

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            6.0.x
-            8.0.x
-            9.0.x
+            5.x
+            6.x
+            8.x
+            9.x
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -21,6 +21,10 @@ jobs:
             6.x
             8.x
             9.x
+      - name: Install OpenSSL 1.1 # Needed for dotnet 5.x
+        run: |
+          wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb
+          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,35 +6,35 @@
     <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AsyncFixer" Version="*" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.*" />
-    <PackageVersion Include="coverlet.collector" Version="*" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="*" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="*" />
+    <PackageVersion Include="AsyncFixer" Version="1.6.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="1.5.5" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.5.5" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
-    <PackageVersion Include="FluentAssertions.Analyzers" Version="*" />
+    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.34.1" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.*" />
-    <PackageVersion Include="Microsoft.AspNet.Razor" Version="3.*" />
-    <PackageVersion Include="Microsoft.AspNet.WebPages" Version="3.*" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="*" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.*" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.*" />
+    <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.AspNet.Razor" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.AspNet.WebPages" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="*" />
-    <PackageVersion Include="Microsoft.Sbom.Targets" Version="*" />
-    <PackageVersion Include="Microsoft.Web.Infrastructure" Version="1.*" />
-    <PackageVersion Include="NUnit" Version="3.*" />
-    <PackageVersion Include="NUnit.Analyzers" Version="*" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="*" />
-    <PackageVersion Include="PolySharp" Version="1.*" />
-    <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="*" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="*" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="*-*" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.Sbom.Targets" Version="3.0.1" />
+    <PackageVersion Include="Microsoft.Web.Infrastructure" Version="2.0.0" />
+    <PackageVersion Include="NUnit" Version="3.14.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
+    <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.4" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.5.0.109200" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="coverlet.collector" Version="*" />
     <PackageVersion Include="DotNetProjectFile.Analyzers" Version="*" />
     <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="*" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="FluentAssertions.Analyzers" Version="*" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.*" />

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -5,11 +5,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
-    <!--
-      TODO: renable netcoreapp3.1, it currently fails due to ICU (culture) issues
-      See: https://forum.manjaro.org/t/dotnet-3-1-builds-fail-after-icu-system-package-updated-to-71-1-1
-    -->
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <DefineConstants>CONTRACTS_FULL</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
We found the hard way that we not longer could run the builds on .NET Core 3.1 (see #446 ). By using .NET 5.0 instead of trying to do really complex stuff, we now (since the .NET 5.0 targets have been dropped #359) can use it to test the .NET standard 2.0 target.