### PR TITLE
Email address topdomain can not be longer than 63

### DIFF
--- a/specs/Qowaiv.Specs/Email_address_format_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_format_specs.cs
@@ -29,6 +29,10 @@ public class Local_part
     public void not_empty(string empty)
         => Email.ShouldBeInvalid($"{empty}@qowaiv.org");
 
+    [Test]
+    public void can_contain_emoji()
+        => Email.ShouldBeValid("❤️@qowaiv.org");
+
     [TestCase(1)]
     [TestCase(2)]
     [TestCase(17)]
@@ -134,8 +138,14 @@ public class Domain_part
     [TestCase("xn--bcher-kva8445foa")]
     [TestCase("xn--eckwd4c7cu47r2wf")]
     [TestCase("xn--3e0b707e")]
-    public void can_be_puny_code(string punyCode)
+    public void can_be_punycode(string punyCode)
         => Email.ShouldBeValid($"info@qowaiv.{punyCode}");
+
+    [TestCase("xn-bcher-kva8445foa")]
+    [TestCase("xn--e")]
+    [TestCase("xn--")]
+    public void can_not_be_pseude_punycode(string pseudo)
+         => Email.ShouldBeInvalid($"info@qowaiv.{pseudo}");
 
     [Test]
     public void dots_can_separate_parts()
@@ -190,6 +200,8 @@ public class Address_sign
 public class Display_name
 {
     [TestCase(@"""Joe Smith"" info@qowaiv.org")]
+    [TestCase(@"""Joe Smith""  info@qowaiv.org")]
+    [TestCase("\"Joe Smith\"\tinfo@qowaiv.org")]
     [TestCase(@"""Joe\\tSmith"" info@qowaiv.org")]
     [TestCase(@"""Joe\""Smith"" info@qowaiv.org")]
     public void Quoted(string quoted)

--- a/specs/Qowaiv.Specs/Email_address_format_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_format_specs.cs
@@ -9,7 +9,7 @@ public class Length
         => EmailAddress.Parse(max).Length.Should().Be(254);
 
     [TestCase("i234567890_234567890_234567890_234567890_234567890_234567890_234@long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long1")]
-    public void not_more_then_255(string max)
+    public void not_255_or_longer(string max)
     {
         max.Length.Should().BeGreaterThanOrEqualTo(255);
         Email.ShouldBeInvalid(max);

--- a/specs/Qowaiv.Specs/Email_address_format_specs.cs
+++ b/specs/Qowaiv.Specs/Email_address_format_specs.cs
@@ -19,7 +19,8 @@ public class Length
 public class Local_part
 {
     public static IEnumerable<char> WithoutLimitations
-     => "abcdefghijklmnopqrstuvwxyz"
+     => "0123456789"
+     + "abcdefghijklmnopqrstuvwxyz"
      + "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
      + "!#$%&'*+-/=?^_`{}|~";
 
@@ -101,6 +102,12 @@ public class Domain_part
     [TestCase(99)]
     public void part_not_above_63(int length)
         => Email.ShouldBeInvalid($"info@{new string('a', length)}.qowaiv.org");
+
+    [TestCase(64)]
+    [TestCase(65)]
+    [TestCase(99)]
+    public void last_part_not_above_63(int length)
+       => Email.ShouldBeInvalid($"info@{new string('a', length)}");
 
     public static IEnumerable<char> Forbidden => "!#$%&'*+/=?^`{}|~";
 

--- a/specs/Qowaiv.Specs/Qowaiv.Internal/ASCII_specs.cs
+++ b/specs/Qowaiv.Specs/Qowaiv.Internal/ASCII_specs.cs
@@ -2,11 +2,43 @@ namespace Text.ASCII_specs;
 
 public class Email
 {
-    /// <remarks>
-    /// Due to this internal code being included, a warning was produced on the
-    /// code not being used. Now it is.
-    /// </remarks>
     [Test]
-    public void is_referenced()
-        => ASCII.EmailAddress.IsLocal('q').Should().BeTrue();
+    public void is_local_contains_82_chars()
+    {
+        var local = new string([.. Enumerable.Range(0, 127)
+            .Select(i => (char)i)
+            .Where(ASCII.EmailAddress.IsLocal)]);
+
+        local.Should().Be("!#$%&'*+-./0123456789=?ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz{|}~");
+    }
+
+    [Test]
+    public void is_domain_contains_63_chars()
+    {
+        var domain = new string([.. Enumerable.Range(0, 127)
+            .Select(i => (char)i)
+            .Where(ASCII.EmailAddress.IsDomain)]);
+
+        domain.Should().Be("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz");
+    }
+
+    [Test]
+    public void is_top_domain_contains_52_chars()
+    {
+        var topDomain = new string([.. Enumerable.Range(0, 127)
+            .Select(i => (char)i)
+            .Where(ASCII.EmailAddress.IsTopDomain)]);
+
+        topDomain.Should().Be("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+    }
+
+    [Test]
+    public void is_punycode_contains_63_chars()
+    {
+        var punycode = new string([.. Enumerable.Range(0, 127)
+            .Select(i => (char)i)
+            .Where(ASCII.EmailAddress.IsPunycode)]);
+
+        punycode.Should().Be("-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+    }
 }

--- a/src/Qowaiv/EmailParser.cs
+++ b/src/Qowaiv/EmailParser.cs
@@ -211,8 +211,7 @@ internal static partial class EmailParser
     {
         if (state.Input.IsEmpty()
             && state.Buffer.Length > 1
-            && (dot == NotFound
-            || state.ValidTopDomain(dot)))
+            && state.ValidTopDomain(dot))
         {
             state.Result.Add(state.Buffer);
             return state;
@@ -300,7 +299,8 @@ internal static partial class EmailParser
     private static bool ValidTopDomain(this State state, int dot)
     {
         var topDomain = state.Buffer.Substring(dot + 1);
-        return topDomain.IsPunycode() || topDomain.All(IsTopDomain);
+        return topDomain.Length <= DomainPartMaxLength
+            && (topDomain.IsPunycode() || topDomain.All(IsTopDomain));
     }
 
     [Pure]

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -44,8 +44,7 @@
       <![CDATA[
 ToBeReleased:
 - Use [SkipLocalsInit] (speed improvement). #458
-ToBeReleased
-- Email address topdomain can not be longer than 63. (fix)
+- Email address topdomain can not be longer than 63. (fix) #459
 v7.2.3
 - IBAN adjustments for Nicaragua and Côte d'Ivoire. (fix) #454
 v7.2.2

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -44,6 +44,8 @@
       <![CDATA[
 ToBeReleased:
 - Use [SkipLocalsInit] (speed improvement). #458
+ToBeReleased
+- Email address topdomain can not be longer than 63. (fix)
 v7.2.3
 - IBAN adjustments for Nicaragua and Côte d'Ivoire. (fix) #454
 v7.2.2


### PR DESCRIPTION
While implementing the [`EmailAddress` for TypeScript](https://github.com/Qowaiv/qowaiv-js/pull/22) I noticed there was a constraint that is not validated here: the length of the last part/topdomain of the domain part of the address.

Some extra tests have been added to help developing the TS/JS implementation too.