### PR TITLE
Drop fluent assertions from TestTools

### DIFF
--- a/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
@@ -448,5 +448,7 @@ public class Debugger
     [TestCase("{unknown}", "?")]
     [TestCase("QOWAIV", "QOWAIV")]
     public void has_custom_display(object display, CustomSvo svo)
-        => svo.Should().HaveDebuggerDisplay(display);
+    {
+        svo.Should().HaveDebuggerDisplay(display);
+    }
 }

--- a/specs/Qowaiv.Specs/TestTools/FluentAssertions/QowaivAssemblyAssertions.cs
+++ b/specs/Qowaiv.Specs/TestTools/FluentAssertions/QowaivAssemblyAssertions.cs
@@ -1,19 +1,15 @@
 using FluentAssertions.Execution;
 using FluentAssertions.Reflection;
-using System.Reflection;
 
 namespace FluentAssertions;
 
 /// <summary>Extensions on <see cref="AssemblyAssertions" />.</summary>
-public static class QowaivAssemblyAssertions
+internal static class QowaivAssemblyAssertions
 {
     /// <summary>Asserts the <see cref="Assembly" /> to have a specific public key.</summary>
-    [CLSCompliant(false)]
     [CustomAssertion]
     public static AndConstraint<AssemblyAssertions> HavePublicKey(this AssemblyAssertions assertions, string publicKey, string because = "", params object[] becauseArgs)
     {
-        Guard.NotNull(assertions);
-
         var bytes = assertions.Subject.GetName().GetPublicKey() ?? [];
 
 #pragma warning disable CA1872 // Prefer 'Convert.ToHexString' and 'Convert.ToHexStringLower' over call chains based on 'BitConverter.ToString'

--- a/specs/Qowaiv.Specs/TestTools/FluentAssertions/QowaivDebuggerDisplayAssertions.cs
+++ b/specs/Qowaiv.Specs/TestTools/FluentAssertions/QowaivDebuggerDisplayAssertions.cs
@@ -1,15 +1,13 @@
 using FluentAssertions.Execution;
 using FluentAssertions.Numeric;
 using FluentAssertions.Primitives;
-using System.Reflection;
 
 namespace FluentAssertions;
 
 /// <summary>Extensions to assert debugger display behavior.</summary>
-public static class QowaivDebuggerDisplayAssertions
+internal static class QowaivDebuggerDisplayAssertions
 {
     /// <summary>Verifies the outcome of the <see cref="DebuggerDisplayAttribute" /> of a certain <see cref="object" />.</summary>
-    [CLSCompliant(false)]
     [CustomAssertion]
     public static AndConstraint<ObjectAssertions> HaveDebuggerDisplay(
         this ObjectAssertions assertions,
@@ -17,7 +15,7 @@ public static class QowaivDebuggerDisplayAssertions
         string because = "",
         params object[] becauseArgs)
     {
-        var prop = DebuggerDisplay(Guard.NotNull(assertions).Subject.GetType());
+        var prop = DebuggerDisplay(assertions.Subject.GetType());
 
         if (Execute.Assertion
             .ForCondition(prop is { })
@@ -29,7 +27,6 @@ public static class QowaivDebuggerDisplayAssertions
     }
 
     /// <summary>Verifies the outcome of the <see cref="DebuggerDisplayAttribute" /> of a certain <see cref="object" />.</summary>
-    [CLSCompliant(false)]
     [CustomAssertion]
     public static AndConstraint<ComparableTypeAssertions<T>> HaveDebuggerDisplay<T>(
         this ComparableTypeAssertions<T> assertions,
@@ -37,7 +34,7 @@ public static class QowaivDebuggerDisplayAssertions
         string because = "",
         params object[] becauseArgs)
     {
-        var prop = DebuggerDisplay(Guard.NotNull(assertions).Subject.GetType());
+        var prop = DebuggerDisplay(/*Guard.NotNull(assertions)*/assertions.Subject.GetType());
 
         if (Execute.Assertion
             .ForCondition(prop is { })

--- a/specs/Qowaiv.Specs/TestTools/FluentAssertions/QowaivTypeConverterAssertions.cs
+++ b/specs/Qowaiv.Specs/TestTools/FluentAssertions/QowaivTypeConverterAssertions.cs
@@ -4,15 +4,12 @@ using FluentAssertions.Types;
 namespace FluentAssertions;
 
 /// <summary>Extensions to assert type converter behavior.</summary>
-public static class QowaivTypeConverterAssertions
+internal static class QowaivTypeConverterAssertions
 {
     /// <summary>Asserts that the type converter exists for the specified type.</summary>
-    [CLSCompliant(false)]
     [CustomAssertion]
     public static AndConstraint<TypeAssertions> HaveTypeConverterDefined(this TypeAssertions assertions, string because = "", params object[] becauseArgs)
     {
-        Guard.NotNull(assertions);
-
         var converter = TypeDescriptor.GetConverter(assertions.Subject);
 
         Execute.Assertion

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -5,20 +5,22 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>7.2.0</Version>
+    <Version>8.0.0</Version>
     <PackageId>Qowaiv.TestTools</PackageId>
     <ProductName>Qowaiv Test Tools</ProductName>
     <PackageReleaseNotes>
       <![CDATA[
+v8.0.0
+- Drop FluentAssertion dependency. (BREAKING)
 v7.2.0
 - Added .NET 9.0 version to the package.
 - Introduction FileInfo.Lock() to lock files during a test.
 v7.0.1
 - Update Qowaiv.Diagnostics.Contracts to 2.0.0. #418
 v7.0.0
-- Drop support for .NET 5 and .NET 7 STS's. #359 (breaking)
-- TestCultures properties lowercased. (breaking)
-- No Serializer.Binary for .NET 8. (breaking)
+- Drop support for .NET 5 and .NET 7 STS's. #359 (BREAKING)
+- TestCultures properties lowercased. (BREAKING)
+- No Serializer.Binary for .NET 8. (BREAKING)
 - Introduction of the EmptyTestClass attribute.
 v6.4.0
 - Support .NET 7.0. #261
@@ -29,21 +31,13 @@ v6.0.0
 - Added Serialize, SerializeDeserialize, and Converting helpers. #218
 - Added FluentAssertions extensions. #218
 - Decorate nullable types. #228
-- Assert* classes dropped. #218 (breaking)
+- Assert* classes dropped. #218 (BREAKING)
 ]]>
     </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="../../shared/Guard.cs" Link="Guard.cs" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
-  </ItemGroup>
-
-  <ItemGroup Label="Analyzers">
-    <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We do not longer can/want ship FluentAssertions as part of Qowaiv.TestTools, as the licenses are not longer compatible.