### PR TITLE
Unit test clean-up

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AsyncFixer" Version="1.6.0" />
-    <PackageVersion Include="AwesomeAssertions" Version="8.0.1" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.0.2" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="0.34.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="1.5.10.1" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.5.10.1" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="1.5.11" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.5.11" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNet.Razor" Version="3.3.0" />
@@ -35,6 +35,6 @@
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.2" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.3" />
   </ItemGroup>
 </Project>

--- a/specs/Qowaiv.Specs/Month_span_specs.cs
+++ b/specs/Qowaiv.Specs/Month_span_specs.cs
@@ -1,5 +1,27 @@
 namespace Month_span_specs;
 
+public class Guards
+{
+    [TestCase(10_000)]
+    [TestCase(20_000)]
+    public void year_not_to_exceed_9999(int years)
+        => years.Invoking(MonthSpan.FromYears)
+        .Should().Throw<ArgumentOutOfRangeException>();
+
+    [TestCase(10_000 * 12)]
+    [TestCase(200_000)]
+    public void months_not_to_exceed_9999(int months)
+        => months.Invoking(MonthSpan.FromMonths)
+        .Should().Throw<ArgumentOutOfRangeException>();
+
+    [Test]
+    public void ctor_arguments()
+    {
+        Func<MonthSpan> ctor = () => new MonthSpan(years: 9800, months: 5000);
+        ctor.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}
+
 public class Is_equal_by_value
 {
     [Test]

--- a/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
+++ b/specs/Qowaiv.Specs/Statistics/Elo_specs.cs
@@ -1,5 +1,15 @@
 namespace Statistics.Elo_specs;
 
+public class Z_score
+{
+    [Test]
+    public void calculates()
+    {
+        var z = Elo.GetZScore(1600, 1500);
+        z.Should().BeApproximately(0.64, 0.01);
+    }
+}
+
 public class Is_invalid
 {
     [Test]

--- a/specs/Qowaiv.Specs/TestTools/Should.cs
+++ b/specs/Qowaiv.Specs/TestTools/Should.cs
@@ -1,0 +1,12 @@
+namespace Qowaiv.TestTools;
+
+internal static class Should
+{
+    /// <summary>Verifies if the two objects are equal.</summary>
+    /// <remarks>
+    /// This method exists to minimize the burden of converting the legacy
+    /// tests. It should not be used for new tests.
+    /// </remarks>
+    public static void BeEqual<T>(T expected, T actual, string because = "")
+        => actual.Should().Be(expected, because);
+}

--- a/specs/Qowaiv.Specs/Web/Internet_media_type_specs.cs
+++ b/specs/Qowaiv.Specs/Web/Internet_media_type_specs.cs
@@ -37,6 +37,19 @@ public class Created_from_file
         => InternetMediaType.FromFile(string.Empty).Should().Be(InternetMediaType.Empty);
 }
 
+public class Is_equal_by_value
+{
+    [TestCase("", 0)]
+    [TestCase("application/x-chess-pgn", 787633777)]
+    public void hash_code_is_value_based(InternetMediaType svo, int hash)
+    {
+        using (Hash.WithoutRandomizer())
+        {
+            svo.GetHashCode().Should().Be(hash);
+        }
+    }
+}
+
 public class Supports_type_conversion
 {
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/DateSpanTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/DateSpanTest.cs
@@ -41,7 +41,7 @@ public class DateSpanTest
     {
         string str = "5Y+3M+2D";
         DateSpan.TryParse(str, out DateSpan val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString(), "Value");
+        Should.BeEqual(str, val.ToString(), "Value");
     }
 
     [Test]
@@ -114,9 +114,9 @@ public class DateSpanTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -136,9 +136,9 @@ public class DateSpanTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_DateSpanSerializeObject_AreEqual()
@@ -156,9 +156,9 @@ public class DateSpanTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -180,9 +180,9 @@ public class DateSpanTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -202,9 +202,9 @@ public class DateSpanTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/DateTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/DateTest.cs
@@ -40,7 +40,7 @@ public class DateTest
         string str = "1983-05-02";
 
         Date.TryParse(str, out Date val).Should().BeTrue();
-        Assert.AreEqual(new Date(1983, 05, 02), val, "Value");
+        Should.BeEqual(new Date(1983, 05, 02), val, "Value");
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -52,7 +52,7 @@ public class DateTest
             string str = "not a date";
 
             Date.TryParse(str, out Date val).Should().BeFalse();
-            Assert.AreEqual(Date.MinValue, val, "Value");
+            Should.BeEqual(Date.MinValue, val, "Value");
         }
     }
 
@@ -99,7 +99,7 @@ public class DateTest
         var info = new SerializationInfo(typeof(Date), new System.Runtime.Serialization.FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual(new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), info.GetDateTime("Value"));
+        Should.BeEqual(new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), info.GetDateTime("Value"));
     }
 
     [Test]
@@ -156,9 +156,9 @@ public class DateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -178,9 +178,9 @@ public class DateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_DateSerializeObject_AreEqual()
@@ -198,9 +198,9 @@ public class DateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -222,9 +222,9 @@ public class DateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -244,9 +244,9 @@ public class DateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -595,14 +595,14 @@ public class DateTest
     public void Add_12Months_AreEqual()
     {
         var added = new Date(1970, 02, 14) + MonthSpan.FromMonths(12);
-        Assert.AreEqual(new Date(1971, 02, 14), added);
+        Should.BeEqual(new Date(1971, 02, 14), added);
     }
 
     [Test]
     public void Subtract_3Months_AreEqual()
     {
         var subtracted = new Date(1971, 02, 14) - MonthSpan.FromMonths(3);
-        Assert.AreEqual(new Date(1970, 11, 14), subtracted);
+        Should.BeEqual(new Date(1970, 11, 14), subtracted);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Financial/AmountTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Financial/AmountTest.cs
@@ -45,7 +45,7 @@ public class AmountTest
         {
             string str = "14.1804";
             Amount.TryParse(str, out Amount val).Should().BeTrue();
-            Assert.AreEqual(str, val.ToString(), "Value");
+            Should.BeEqual(str, val.ToString(), "Value");
         }
     }
 
@@ -158,9 +158,9 @@ public class AmountTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -180,9 +180,9 @@ public class AmountTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_AmountSerializeObject_AreEqual()
@@ -200,9 +200,9 @@ public class AmountTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -224,9 +224,9 @@ public class AmountTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -246,9 +246,9 @@ public class AmountTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -601,7 +601,7 @@ public class AmountTest
     {
         Amount amount = (Amount)40.10;
         Amount other = (Amount)2.07;
-        Assert.AreEqual(TestStruct, amount + other);
+        Should.BeEqual(TestStruct, amount + other);
     }
 
     [Test]
@@ -609,7 +609,7 @@ public class AmountTest
     {
         Amount amount = (Amount)40.00;
         var p = 10.Percent();
-        Assert.AreEqual((Amount)44.00, amount + p);
+        Should.BeEqual((Amount)44.00, amount + p);
     }
 
     [Test]
@@ -617,7 +617,7 @@ public class AmountTest
     {
         Amount amount = (Amount)43.20;
         Amount other = (Amount)1.03;
-        Assert.AreEqual(TestStruct, amount - other);
+        Should.BeEqual(TestStruct, amount - other);
     }
 
     [Test]
@@ -625,7 +625,7 @@ public class AmountTest
     {
         Amount amount = (Amount)40.00;
         var p = 25.Percent();
-        Assert.AreEqual((Amount)30.00, amount - p);
+        Should.BeEqual((Amount)30.00, amount - p);
     }
 
     [Test]
@@ -634,7 +634,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         var p = 50.Percent();
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount * p);
+        Should.BeEqual(expected, amount * p);
     }
 
     [Test]
@@ -643,7 +643,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         float p = 0.5F;
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount * p);
+        Should.BeEqual(expected, amount * p);
     }
 
     [Test]
@@ -652,7 +652,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         double p = 0.5;
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount * p);
+        Should.BeEqual(expected, amount * p);
     }
 
     [Test]
@@ -661,7 +661,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         var p = 0.5m;
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount * p);
+        Should.BeEqual(expected, amount * p);
     }
 
     [Test]
@@ -670,7 +670,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         short f = 2;
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount * f);
+        Should.BeEqual(expected, amount * f);
     }
 
     [Test]
@@ -679,7 +679,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         int f = 2;
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount * f);
+        Should.BeEqual(expected, amount * f);
     }
 
     [Test]
@@ -688,7 +688,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         long f = 2;
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount * f);
+        Should.BeEqual(expected, amount * f);
     }
 
     [Test]
@@ -697,7 +697,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         ushort f = 2;
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount * f);
+        Should.BeEqual(expected, amount * f);
     }
 
     [Test]
@@ -706,7 +706,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         uint f = 2;
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount * f);
+        Should.BeEqual(expected, amount * f);
     }
 
     [Test]
@@ -715,7 +715,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         ulong f = 2;
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount * f);
+        Should.BeEqual(expected, amount * f);
     }
 
     [Test]
@@ -724,7 +724,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         var p = 50.Percent();
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount / p);
+        Should.BeEqual(expected, amount / p);
     }
 
     [Test]
@@ -733,7 +733,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         float p = 0.5F;
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount / p);
+        Should.BeEqual(expected, amount / p);
     }
 
     [Test]
@@ -742,7 +742,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         double p = 0.5;
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount / p);
+        Should.BeEqual(expected, amount / p);
     }
 
     [Test]
@@ -751,7 +751,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         var p = 0.5m;
         Amount expected = (Amount)200.80m;
-        Assert.AreEqual(expected, amount / p);
+        Should.BeEqual(expected, amount / p);
     }
 
     [Test]
@@ -760,7 +760,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         short f = 2;
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount / f);
+        Should.BeEqual(expected, amount / f);
     }
 
     [Test]
@@ -769,7 +769,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         int f = 2;
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount / f);
+        Should.BeEqual(expected, amount / f);
     }
 
     [Test]
@@ -778,7 +778,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         long f = 2;
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount / f);
+        Should.BeEqual(expected, amount / f);
     }
 
     [Test]
@@ -787,7 +787,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         ushort f = 2;
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount / f);
+        Should.BeEqual(expected, amount / f);
     }
 
     [Test]
@@ -796,7 +796,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         uint f = 2;
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount / f);
+        Should.BeEqual(expected, amount / f);
     }
 
     [Test]
@@ -805,7 +805,7 @@ public class AmountTest
         Amount amount = (Amount)100.40m;
         ulong f = 2;
         Amount expected = (Amount)50.20m;
-        Assert.AreEqual(expected, amount / f);
+        Should.BeEqual(expected, amount / f);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Financial/BusinessIdentifierCodeTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Financial/BusinessIdentifierCodeTest.cs
@@ -112,7 +112,7 @@ public class BusinessIdentifierCodeTest
     {
         string str = "AEGONL2UXXX";
         BusinessIdentifierCode.TryParse(str, out BusinessIdentifierCode val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString(), "Value");
+        Should.BeEqual(str, val.ToString(), "Value");
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -235,9 +235,9 @@ public class BusinessIdentifierCodeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -257,9 +257,9 @@ public class BusinessIdentifierCodeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_BusinessIdentifierCodeSerializeObject_AreEqual()
@@ -277,9 +277,9 @@ public class BusinessIdentifierCodeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -301,9 +301,9 @@ public class BusinessIdentifierCodeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -323,9 +323,9 @@ public class BusinessIdentifierCodeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Financial/CurrencyTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Financial/CurrencyTest.cs
@@ -161,7 +161,7 @@ public class CurrencyTest
     {
         string str = "USD";
         Currency.TryParse(str, out Currency val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString(), "Value");
+        Should.BeEqual(str, val.ToString(), "Value");
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -292,9 +292,9 @@ public class CurrencyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -314,9 +314,9 @@ public class CurrencyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_CurrencySerializeObject_AreEqual()
@@ -334,9 +334,9 @@ public class CurrencyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -358,9 +358,9 @@ public class CurrencyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -380,9 +380,9 @@ public class CurrencyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Financial/MoneyTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Financial/MoneyTest.cs
@@ -28,7 +28,7 @@ public class MoneyTest
         {
             Money exp = 42.17 + Currency.EUR;
             Money.TryParse("€42,17", out Money act).Should().BeTrue();
-            Assert.AreEqual(exp, act, "Value");
+            Should.BeEqual(exp, act, "Value");
         }
     }
 
@@ -38,7 +38,7 @@ public class MoneyTest
     {
         string str = "string";
         Money.TryParse(str, out Money val).Should().BeFalse();
-        Assert.AreEqual(Money.Zero, val, "Value");
+        Should.BeEqual(Money.Zero, val, "Value");
     }
 
     [Test]
@@ -164,9 +164,9 @@ public class MoneyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -186,9 +186,9 @@ public class MoneyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_MoneySerializeObject_AreEqual()
@@ -206,9 +206,9 @@ public class MoneyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -230,9 +230,9 @@ public class MoneyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -252,9 +252,9 @@ public class MoneyTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -592,7 +592,7 @@ public class MoneyTest
     {
         var money = value + Currency.USD;
         var abs = money.Abs();
-        Assert.AreEqual(expected + Currency.USD, abs);
+        Should.BeEqual(expected + Currency.USD, abs);
     }
 
     [Test]
@@ -635,7 +635,7 @@ public class MoneyTest
         var r = 26 + Currency.EUR;
         var a = 42 + Currency.EUR;
 
-        Assert.AreEqual(a, l + r);
+        Should.BeEqual(a, l + r);
     }
 
     [Test]
@@ -645,7 +645,7 @@ public class MoneyTest
         var p = 25.Percent();
         var a = 20 + Currency.EUR;
 
-        Assert.AreEqual(a, l + p);
+        Should.BeEqual(a, l + p);
     }
 
     [Test]
@@ -655,7 +655,7 @@ public class MoneyTest
         var r = 27 + Currency.EUR;
         var a = 42 + Currency.EUR;
 
-        Assert.AreEqual(a, l - r);
+        Should.BeEqual(a, l - r);
     }
 
     [Test]
@@ -665,7 +665,7 @@ public class MoneyTest
         var p = 25.Percent();
         var a = 12 + Currency.EUR;
 
-        Assert.AreEqual(a, l - p);
+        Should.BeEqual(a, l - p);
     }
 
     [Test]
@@ -674,7 +674,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         var p = 50.Percent();
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money * p);
+        Should.BeEqual(expected, money * p);
     }
 
     [Test]
@@ -683,7 +683,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         float p = 0.5F;
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money * p);
+        Should.BeEqual(expected, money * p);
     }
 
     [Test]
@@ -692,7 +692,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         double p = 0.5;
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money * p);
+        Should.BeEqual(expected, money * p);
     }
 
     [Test]
@@ -701,7 +701,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         var p = 0.5m;
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money * p);
+        Should.BeEqual(expected, money * p);
     }
 
     [Test]
@@ -710,7 +710,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         short f = 2;
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money * f);
+        Should.BeEqual(expected, money * f);
     }
 
     [Test]
@@ -719,7 +719,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         int f = 2;
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money * f);
+        Should.BeEqual(expected, money * f);
     }
 
     [Test]
@@ -728,7 +728,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         long f = 2;
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money * f);
+        Should.BeEqual(expected, money * f);
     }
 
     [Test]
@@ -737,7 +737,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         ushort f = 2;
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money * f);
+        Should.BeEqual(expected, money * f);
     }
 
     [Test]
@@ -746,7 +746,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         uint f = 2;
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money * f);
+        Should.BeEqual(expected, money * f);
     }
 
     [Test]
@@ -755,7 +755,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         ulong f = 2;
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money * f);
+        Should.BeEqual(expected, money * f);
     }
 
     [Test]
@@ -764,7 +764,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         var p = 50.Percent();
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money / p);
+        Should.BeEqual(expected, money / p);
     }
 
     [Test]
@@ -773,7 +773,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         float p = 0.5F;
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money / p);
+        Should.BeEqual(expected, money / p);
     }
 
     [Test]
@@ -782,7 +782,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         double p = 0.5;
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money / p);
+        Should.BeEqual(expected, money / p);
     }
 
     [Test]
@@ -791,7 +791,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         var p = 0.5m;
         var expected = 200.8m + Currency.USD;
-        Assert.AreEqual(expected, money / p);
+        Should.BeEqual(expected, money / p);
     }
 
     [Test]
@@ -800,7 +800,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         short f = 2;
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money / f);
+        Should.BeEqual(expected, money / f);
     }
 
     [Test]
@@ -809,7 +809,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         int f = 2;
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money / f);
+        Should.BeEqual(expected, money / f);
     }
 
     [Test]
@@ -818,7 +818,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         long f = 2;
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money / f);
+        Should.BeEqual(expected, money / f);
     }
 
     [Test]
@@ -827,7 +827,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         ushort f = 2;
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money / f);
+        Should.BeEqual(expected, money / f);
     }
 
     [Test]
@@ -836,7 +836,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         uint f = 2;
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money / f);
+        Should.BeEqual(expected, money / f);
     }
 
     [Test]
@@ -845,7 +845,7 @@ public class MoneyTest
         var money = 100.40m + Currency.USD;
         ulong f = 2;
         var expected = 50.20m + Currency.USD;
-        Assert.AreEqual(expected, money / f);
+        Should.BeEqual(expected, money / f);
     }
 
     [Test]
@@ -853,7 +853,7 @@ public class MoneyTest
     {
         var money = 123.4567m + Currency.EUR;
         var rounded = money.Round();
-        Assert.AreEqual(123.46m + Currency.EUR, rounded);
+        Should.BeEqual(123.46m + Currency.EUR, rounded);
     }
 
     [Test]
@@ -861,7 +861,7 @@ public class MoneyTest
     {
         var money = 123.4567m + Currency.EUR;
         var rounded = money.Round(1);
-        Assert.AreEqual(123.5m + Currency.EUR, rounded);
+        Should.BeEqual(123.5m + Currency.EUR, rounded);
     }
 
     [Test]
@@ -869,7 +869,7 @@ public class MoneyTest
     {
         var money = 123.6567m + Currency.EUR;
         var rounded = money.RoundToMultiple(0.25m);
-        Assert.AreEqual(123.75m + Currency.EUR, rounded);
+        Should.BeEqual(123.75m + Currency.EUR, rounded);
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/_Legacy/Formatting/FormattingArgumentsTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Formatting/FormattingArgumentsTest.cs
@@ -29,7 +29,7 @@ public class FormattingArgumentsTest
         obj.GetObjectData(info, default);
 
         info.GetString("Format").Should().Be("0.000");
-        Assert.AreEqual(new CultureInfo("fr-BE"), info.GetValue("FormatProvider", typeof(IFormatProvider)));
+        Should.BeEqual(new CultureInfo("fr-BE"), info.GetValue("FormatProvider", typeof(IFormatProvider)));
     }
 
     [Test]
@@ -49,9 +49,9 @@ public class FormattingArgumentsTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -71,9 +71,9 @@ public class FormattingArgumentsTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     #endregion

--- a/specs/Qowaiv.Specs/_Legacy/Globalization/CountryTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Globalization/CountryTest.cs
@@ -104,7 +104,7 @@ public class CountryTest
     {
         string str = "VA";
         Country.TryParse(str, null, out Country val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString(), "Value");
+        Should.BeEqual(str, val.ToString(), "Value");
     }
 
     /// <summary>TryParse with specified string value should be valid.</summary>
@@ -113,7 +113,7 @@ public class CountryTest
     {
         string str = "VA";
         Country.TryParse(str, out Country val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString(), "Value");
+        Should.BeEqual(str, val.ToString(), "Value");
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -262,9 +262,9 @@ public class CountryTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -284,9 +284,9 @@ public class CountryTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_CountrySerializeObject_AreEqual()
@@ -304,9 +304,9 @@ public class CountryTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -328,9 +328,9 @@ public class CountryTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -350,9 +350,9 @@ public class CountryTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Globalization/CultureInfoScopeTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Globalization/CultureInfoScopeTest.cs
@@ -10,8 +10,8 @@ public class CultureInfoScopeTest
 
         using (new CultureInfoScope("es-ES", "fr-FR"))
         {
-            Assert.AreEqual("es-ES", CultureInfo.CurrentCulture.Name);
-            Assert.AreEqual("fr-FR", CultureInfo.CurrentUICulture.Name);
+            Should.BeEqual("es-ES", CultureInfo.CurrentCulture.Name);
+            Should.BeEqual("fr-FR", CultureInfo.CurrentUICulture.Name);
         }
 
         CultureInfo.CurrentCulture.Should().Be(current);
@@ -26,8 +26,8 @@ public class CultureInfoScopeTest
 
         using (new CultureInfo("es-ES").Scoped())
         {
-            Assert.AreEqual("es-ES", CultureInfo.CurrentCulture.Name);
-            Assert.AreEqual("es-ES", CultureInfo.CurrentUICulture.Name);
+            Should.BeEqual("es-ES", CultureInfo.CurrentCulture.Name);
+            Should.BeEqual("es-ES", CultureInfo.CurrentUICulture.Name);
         }
 
         CultureInfo.CurrentCulture.Should().Be(current);

--- a/specs/Qowaiv.Specs/_Legacy/HouseNumberTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/HouseNumberTest.cs
@@ -128,7 +128,7 @@ public class HouseNumberTest
         string str = "123";
 
         HouseNumber.TryParse(str, out HouseNumber val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString(), "Value");
+        Should.BeEqual(str, val.ToString(), "Value");
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -286,9 +286,9 @@ public class HouseNumberTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -308,9 +308,9 @@ public class HouseNumberTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_HouseNumberSerializeObject_AreEqual()
@@ -328,9 +328,9 @@ public class HouseNumberTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -352,9 +352,9 @@ public class HouseNumberTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -374,9 +374,9 @@ public class HouseNumberTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/IO/StreamSizeTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/IO/StreamSizeTest.cs
@@ -155,9 +155,9 @@ public class StreamSizeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -177,9 +177,9 @@ public class StreamSizeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_StreamSizeSerializeObject_AreEqual()
@@ -197,9 +197,9 @@ public class StreamSizeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -221,9 +221,9 @@ public class StreamSizeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -243,9 +243,9 @@ public class StreamSizeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Identifiers/IdForGuidTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Identifiers/IdForGuidTest.cs
@@ -139,7 +139,7 @@ public class IdForGuidTest
     public void TryCreate_Guid_Successful()
     {
         Id<ForGuid>.TryCreate(Guid.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), out var id).Should().BeTrue();
-        Assert.AreEqual(Id<ForGuid>.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), id);
+        Should.BeEqual(Id<ForGuid>.Parse("0F5AB5AB-12CB-4629-878D-B18B88B9A504"), id);
     }
 
     [Test]
@@ -185,9 +185,9 @@ public class IdForGuidTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -211,9 +211,9 @@ public class IdForGuidTest
 
         ;
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -236,9 +236,9 @@ public class IdForGuidTest
 
         ;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -264,9 +264,9 @@ public class IdForGuidTest
 
         ;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -290,9 +290,9 @@ public class IdForGuidTest
 
         ;
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -320,7 +320,7 @@ public class IdForGuidTest
     public void ToJson_TestStruct_StringValue()
     {
         var json = TestStruct.ToJson();
-        Assert.AreEqual("0f5ab5ab-12cb-4629-878d-b18b88b9a504", json);
+        Should.BeEqual("0f5ab5ab-12cb-4629-878d-b18b88b9a504", json);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Identifiers/IdForInt32Test.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Identifiers/IdForInt32Test.cs
@@ -183,9 +183,9 @@ public class IdForInt32Test
 
         ;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -209,9 +209,9 @@ public class IdForInt32Test
 
         ;
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -234,9 +234,9 @@ public class IdForInt32Test
 
         ;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -262,9 +262,9 @@ public class IdForInt32Test
 
         ;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -288,9 +288,9 @@ public class IdForInt32Test
 
         ;
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Identifiers/IdForInt64Test.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Identifiers/IdForInt64Test.cs
@@ -183,9 +183,9 @@ public class IdForInt64Test
 
         ;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -209,9 +209,9 @@ public class IdForInt64Test
 
         ;
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -234,9 +234,9 @@ public class IdForInt64Test
 
         ;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -262,9 +262,9 @@ public class IdForInt64Test
 
         ;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -288,9 +288,9 @@ public class IdForInt64Test
 
         ;
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Identifiers/IdForStringTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Identifiers/IdForStringTest.cs
@@ -142,9 +142,9 @@ public class IdForStringTest
 
         ;
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -168,9 +168,9 @@ public class IdForStringTest
 
         ;
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -193,9 +193,9 @@ public class IdForStringTest
 
         ;
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -220,9 +220,9 @@ public class IdForStringTest
         };
 
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -246,9 +246,9 @@ public class IdForStringTest
 
         ;
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/LocalDateTimeTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/LocalDateTimeTest.cs
@@ -30,7 +30,7 @@ public class LocalDateTimeTest
         {
             string str = "26-4-2015 17:07:13";
             LocalDateTime.TryParse(str, out LocalDateTime val).Should().BeTrue();
-            Assert.AreEqual(new LocalDateTime(2015, 04, 26, 17, 07, 13, 000), val, "Value");
+            Should.BeEqual(new LocalDateTime(2015, 04, 26, 17, 07, 13, 000), val, "Value");
         }
     }
 
@@ -135,9 +135,9 @@ public class LocalDateTimeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -157,9 +157,9 @@ public class LocalDateTimeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_LocalDateTimeSerializeObject_AreEqual()
@@ -177,9 +177,9 @@ public class LocalDateTimeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -198,9 +198,9 @@ public class LocalDateTimeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/MonthSpanTest.cs
@@ -115,7 +115,7 @@ public class MonthSpanTest
         ISerializable obj = TestStruct;
         var info = new SerializationInfo(typeof(MonthSpan), new FormatterConverter());
         obj.GetObjectData(info, default);
-        Assert.AreEqual(69, info.GetValue("Value", typeof(int)));
+        Should.BeEqual(69, info.GetValue("Value", typeof(int)));
     }
 
     [Test]
@@ -162,9 +162,9 @@ public class MonthSpanTest
         var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var exp = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -174,9 +174,9 @@ public class MonthSpanTest
         var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var exp = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -185,9 +185,9 @@ public class MonthSpanTest
         var input = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var exp = new MonthSpanSerializeObject { Id = 17, Obj = TestStruct, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -199,9 +199,9 @@ public class MonthSpanTest
         var input = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var exp = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -211,9 +211,9 @@ public class MonthSpanTest
         var input = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var exp = new MonthSpanSerializeObject { Id = 17, Obj = default, Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local), };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]
@@ -273,7 +273,7 @@ public class MonthSpanTest
     public void Negated_TestStruct_Min69Months()
     {
         var negated = -TestStruct;
-        Assert.AreEqual(MonthSpan.FromMonths(-69), negated);
+        Should.BeEqual(MonthSpan.FromMonths(-69), negated);
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/MonthSpanTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/MonthSpanTest.cs
@@ -76,24 +76,6 @@ public class MonthSpanTest
        => MonthSpan.TryParse("invalid input").Should().BeNull();
 
     [Test]
-    public void FromYears_20k_Throws()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(() => MonthSpan.FromYears(20_000));
-    }
-
-    [Test]
-    public void FromMonths_200k_Throws()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(() => MonthSpan.FromMonths(200_000));
-    }
-
-    [Test]
-    public void Constructor_OutOfRange()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new MonthSpan(years: 9800, months: 5000));
-    }
-
-    [Test]
     public void Constructor_5Years9Months_69Months()
     {
         var ctor = new MonthSpan(years: 5, months: 9);

--- a/specs/Qowaiv.Specs/_Legacy/Sql/TimestampTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Sql/TimestampTest.cs
@@ -14,7 +14,7 @@ public class TimestampTest
         string str = "0x00000000075BCD15";
 
         Timestamp.TryParse(str, out Timestamp val).Should().BeTrue();
-        Assert.AreEqual(TestStruct, val, "Value");
+        Should.BeEqual(TestStruct, val, "Value");
     }
 
     [Test]
@@ -23,7 +23,7 @@ public class TimestampTest
         string str = "123456789";
 
         Timestamp.TryParse(str, out Timestamp val).Should().BeTrue();
-        Assert.AreEqual(TestStruct, val, "Value");
+        Should.BeEqual(TestStruct, val, "Value");
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -33,7 +33,7 @@ public class TimestampTest
         string str = "0xInvalidTimeStamp";
 
         Timestamp.TryParse(str, out Timestamp val).Should().BeFalse();
-        Assert.AreEqual(Timestamp.MinValue, val, "Value");
+        Should.BeEqual(Timestamp.MinValue, val, "Value");
     }
 
     [Test]
@@ -126,9 +126,9 @@ public class TimestampTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -148,9 +148,9 @@ public class TimestampTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_TimestampSerializeObject_AreEqual()
@@ -168,9 +168,9 @@ public class TimestampTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -192,9 +192,9 @@ public class TimestampTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -214,9 +214,9 @@ public class TimestampTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/Statistics/EloTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Statistics/EloTest.cs
@@ -27,19 +27,6 @@ namespace Qowaiv.UnitTests.Statistics
 
         #endregion
 
-        #region Methods
-
-        [Test]
-        public void GetZScore_Delta100_0Dot64()
-        {
-            var act = Elo.GetZScore(1600, 1500);
-            var exp = 0.64;
-
-            Assert.AreEqual(exp, act, 0.001);
-        }
-
-        #endregion
-
         #region TryParse tests
 
         /// <summary>TryParse with specified string value should be valid.</summary>
@@ -48,7 +35,7 @@ namespace Qowaiv.UnitTests.Statistics
         {
             string str = "1400";
             Elo.TryParse(str, out Elo val).Should().BeTrue();
-            Assert.AreEqual(str, val.ToString(), "Value");
+            Should.BeEqual(str, val.ToString(), "Value");
         }
 
         [Test]
@@ -147,9 +134,9 @@ namespace Qowaiv.UnitTests.Statistics
                 Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
             };
             var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
+            Should.BeEqual(exp.Id, act.Id, "Id");
+            Should.BeEqual(exp.Obj, act.Obj, "Obj");
+            Should.BeEqual(exp.Date, act.Date, "Date");
         }
 #endif
 
@@ -169,9 +156,9 @@ namespace Qowaiv.UnitTests.Statistics
                 Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
             };
             var act = SerializeDeserialize.Xml(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
+            Should.BeEqual(exp.Id, act.Id, "Id");
+            Should.BeEqual(exp.Obj, act.Obj, "Obj");
+            Should.BeEqual(exp.Date, act.Date, "Date");
         }
         [Test]
         public void DataContractSerializeDeserialize_EloSerializeObject_AreEqual()
@@ -189,9 +176,9 @@ namespace Qowaiv.UnitTests.Statistics
                 Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
             };
             var act = SerializeDeserialize.DataContract(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
+            Should.BeEqual(exp.Id, act.Id, "Id");
+            Should.BeEqual(exp.Obj, act.Obj, "Obj");
+            Should.BeEqual(exp.Date, act.Date, "Date");
         }
 
 #if NET8_0_OR_GREATER
@@ -213,9 +200,9 @@ namespace Qowaiv.UnitTests.Statistics
                 Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
             };
             var act = SerializeDeserialize.Binary(input);
-            Assert.AreEqual(exp.Id, act.Id, "Id");
-            Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-            Assert.AreEqual(exp.Date, act.Date, "Date");
+            Should.BeEqual(exp.Id, act.Id, "Id");
+            Should.BeEqual(exp.Obj, act.Obj, "Obj");
+            Should.BeEqual(exp.Date, act.Date, "Date");
         }
 #endif
 

--- a/specs/Qowaiv.Specs/_Legacy/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Web/InternetMediaTypeTest.cs
@@ -386,20 +386,6 @@ public class InternetMediaTypeTest
 
     #region IEquatable tests
 
-    /// <summary>GetHash should not fail for InternetMediaType.Empty.</summary>
-    [Test]
-    public void GetHash_Empty_0()
-    {
-        InternetMediaType.Empty.GetHashCode().Should().Be(0);
-    }
-
-    /// <summary>GetHash should not fail for the test struct.</summary>
-    [Test]
-    public void GetHash_TestStruct_NotZero()
-    {
-        Assert.NotZero(TestStruct.GetHashCode());
-    }
-
     [Test]
     public void Equals_EmptyEmpty_IsTrue()
     {

--- a/specs/Qowaiv.Specs/_Legacy/Web/InternetMediaTypeTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/Web/InternetMediaTypeTest.cs
@@ -122,7 +122,7 @@ public class InternetMediaTypeTest
         string str = "application/atom+xml";
 
         InternetMediaType.TryParse(str, out var val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString(), "Value");
+        Should.BeEqual(str, val.ToString(), "Value");
     }
 
     /// <summary>TryParse with specified string value should be invalid.</summary>
@@ -189,7 +189,7 @@ public class InternetMediaTypeTest
         var info = new SerializationInfo(typeof(InternetMediaType), new System.Runtime.Serialization.FormatterConverter());
         obj.GetObjectData(info, default);
 
-        Assert.AreEqual("application/x-chess-pgn", info.GetString("Value"));
+        Should.BeEqual("application/x-chess-pgn", info.GetString("Value"));
     }
 
     [Test]
@@ -246,9 +246,9 @@ public class InternetMediaTypeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -268,9 +268,9 @@ public class InternetMediaTypeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_InternetMediaTypeSerializeObject_AreEqual()
@@ -288,9 +288,9 @@ public class InternetMediaTypeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -312,9 +312,9 @@ public class InternetMediaTypeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -334,9 +334,9 @@ public class InternetMediaTypeTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]

--- a/specs/Qowaiv.Specs/_Legacy/WeekDateTest.cs
+++ b/specs/Qowaiv.Specs/_Legacy/WeekDateTest.cs
@@ -25,7 +25,7 @@ public class WeekDateTest
     {
         string str = "1234-W50-6";
         WeekDate.TryParse(str, out WeekDate val).Should().BeTrue();
-        Assert.AreEqual(str, val.ToString(), "Value");
+        Should.BeEqual(str, val.ToString(), "Value");
     }
 
     [Test]
@@ -140,9 +140,9 @@ public class WeekDateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -162,9 +162,9 @@ public class WeekDateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
     [Test]
     public void DataContractSerializeDeserialize_WeekDateSerializeObject_AreEqual()
@@ -182,9 +182,9 @@ public class WeekDateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.DataContract(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
 #if NET8_0_OR_GREATER
@@ -206,9 +206,9 @@ public class WeekDateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Binary(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 #endif
 
@@ -228,9 +228,9 @@ public class WeekDateTest
             Date = new DateTime(1970, 02, 14, 00, 00, 000, DateTimeKind.Local),
         };
         var act = SerializeDeserialize.Xml(input);
-        Assert.AreEqual(exp.Id, act.Id, "Id");
-        Assert.AreEqual(exp.Obj, act.Obj, "Obj");
-        Assert.AreEqual(exp.Date, act.Date, "Date");
+        Should.BeEqual(exp.Id, act.Id, "Id");
+        Should.BeEqual(exp.Obj, act.Obj, "Obj");
+        Should.BeEqual(exp.Date, act.Date, "Date");
     }
 
     [Test]


### PR DESCRIPTION
We can not update to NUnit 4 yet, as we still have .NET 5.0 targets tests (to test the standard2.0 target which is also not supported by NUnit 4). But with the introduction (because it is easy) of `Should.BeEqual` as alternative to `Assert.AreEqual`, we do not longer relay on most of NUnit 3.0 assertions (that will be dropped).