### PR TITLE
Hide Guard methods from stack trace

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,10 +2,15 @@
 
   <PropertyGroup>
     <IsPublishable>false</IsPublishable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>library</OutputType>
   </PropertyGroup>
 
+  <PropertyGroup Label="Compiler options">
+    <LangVersion>preview</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+  </PropertyGroup>
+  
   <PropertyGroup Label="Diagnostics">
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <NuGetAudit>true</NuGetAudit>
@@ -57,7 +62,6 @@ inside and outside a Domain-driven context.
     </PackageTags>
     <Company>Qowaiv community</Company>
     <Copyright>Copyright © Qowaiv community 2013-current</Copyright>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Signing">

--- a/shared/Guard.cs
+++ b/shared/Guard.cs
@@ -20,6 +20,7 @@ namespace Qowaiv;
 /// * Keep the checks cheap so that you also can run them in production code.
 /// </remarks>
 [ExcludeFromCodeCoverage]
+[StackTraceHidden]
 internal static partial class Guard
 {
     /// <summary>Guards the parameter if not null, otherwise throws an argument (null) exception.</summary>
@@ -84,6 +85,7 @@ internal static partial class Guard
     /// <remarks>
     /// That <typeparamref name="T" /> is an enum is implicitly guard by <see cref="Enum.IsDefined(Type, object)" />.
     /// </remarks>
+    [DebuggerStepThrough]
     public static T DefinedEnum<T>(T parameter, [CallerArgumentExpression(nameof(parameter))] string? paramName = null)
         where T : struct
         => Enum.IsDefined(typeof(T), parameter)

--- a/specs/Qowaiv.Specs/Qowaiv.Internal/Guard_specs.cs
+++ b/specs/Qowaiv.Specs/Qowaiv.Internal/Guard_specs.cs
@@ -1,0 +1,31 @@
+#if NET6_0_OR_GREATER
+
+namespace Guard_specs;
+
+public class Stacktrace
+{
+    [Test]
+    public void does_not_contain_guard_method_in_exception()
+    {
+        try
+        {
+            _ = Clock.Today(null!);
+        }
+        catch (ArgumentNullException x)
+        {
+            var trace = new StackTrace(x);
+
+            var method = trace.GetFrames()[0].GetMethod();
+
+            method.Should().BeEquivalentTo(
+                new 
+                {
+                    Name = "NotNull",
+                    DeclaringType = new { Name = "Guard" },
+                });
+
+            x.StackTrace.Should().NotContain("NotNull");
+        }
+    }
+}
+#endif

--- a/src/Qowaiv.Data.SqlClient/Qowaiv.Data.SqlClient.csproj
+++ b/src/Qowaiv.Data.SqlClient/Qowaiv.Data.SqlClient.csproj
@@ -9,6 +9,8 @@
     <PackageId>Qowaiv.Data.SqlClient</PackageId>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased:
+- Hide Guard methods from stacktrace.
 v7.2.0
 - Added .NET 9.0 version to the package.
 - Potentially improved performance of concurrency when generating sql parameters in .NET 9 and up (using new System.Threading.Lock).

--- a/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
+++ b/src/Qowaiv.TestTools/Qowaiv.TestTools.csproj
@@ -10,6 +10,8 @@
     <ProductName>Qowaiv Test Tools</ProductName>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased:
+- Hide Guard methods from stacktrace.
 v8.0.0
 - Drop FluentAssertion dependency. (BREAKING)
 v7.2.0

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -41,6 +41,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased:
+- Hide Guard methods from stacktrace.
 - Use [SkipLocalsInit] (speed improvement). #458
 - Email address topdomain can not be longer than 63. (fix) #459
 - Rewritten email parser 2.4 times faster. #460


### PR DESCRIPTION
I stumbled on the `[StackTraceHidden]` attribute (by accident) I thought, that would be nice to remove the `Guard` methods from the stack trace. It turns out, I'm not the only one who thinks so, as I found this blog: [Hide a method from the stack trace](https://makolyte.com/csharp-exclude-exception-throw-helper-methods-from-the-stack-trace)