### PR TITLE
Supported generated custom SVO

### DIFF
--- a/src/Qowaiv/CodeGeneration/SvoAttribute.cs
+++ b/src/Qowaiv/CodeGeneration/SvoAttribute.cs
@@ -1,0 +1,21 @@
+using Qowaiv.Customization;
+
+namespace Qowaiv.CodeGeneration;
+
+/// <summary>
+/// Used by Qowaiv.CodeGeneration.SingleValueObjects to generateod the
+/// blumbping code for the custom SVO.
+/// </summary>
+/// <typeparam name="TBehavior">
+/// Singleton that handles the behavior of the custom SVO.
+/// </typeparam>
+[Conditional("CONTRACTS_FULL")]
+[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
+[ExcludeFromCodeCoverage]
+public sealed class SvoAttribute<TBehavior> : Attribute
+    where TBehavior : SvoBehavior, new()
+{
+    /// <inheritdoc />
+    [Pure]
+    public override string ToString() => $"[Svo<{typeof(TBehavior)}>]";
+}

--- a/src/Qowaiv/Customization/SvoAttribute.cs
+++ b/src/Qowaiv/Customization/SvoAttribute.cs
@@ -1,6 +1,4 @@
-using Qowaiv.Customization;
-
-namespace Qowaiv.CodeGeneration;
+namespace Qowaiv.Customization;
 
 /// <summary>
 /// Used by Qowaiv.CodeGeneration.SingleValueObjects to generateod the

--- a/src/Qowaiv/Customization/SvoBehavior.cs
+++ b/src/Qowaiv/Customization/SvoBehavior.cs
@@ -6,7 +6,8 @@ namespace Qowaiv.Customization;
 /// <summary>Handles the behavior of a custom Single Value Object.</summary>
 public abstract class SvoBehavior : TypeConverter, IComparer<string>
 {
-    internal static readonly string unknown = $"{char.MaxValue}";
+    /// <summary>The string to store the unknown state internally.</summary>
+    internal static readonly string unknown = "\uFFFF";
 
     /// <summary>Defines the minimum length the string representation of the Single Value Object may be.</summary>
     /// <remarks>
@@ -31,7 +32,7 @@ public abstract class SvoBehavior : TypeConverter, IComparer<string>
     /// The optional format provider.
     /// </param>
     [Pure]
-    public virtual bool IsUnknown(string str, IFormatProvider? formatProvider) => Unknown.IsUnknown(str, formatProvider as CultureInfo);
+    public virtual bool IsUnknown(string str, IFormatProvider? formatProvider) => Qowaiv.Unknown.IsUnknown(str, formatProvider as CultureInfo);
 
     /// <summary>Validates if the input <see cref="string" /> is valid given its format provider.</summary>
     /// <param name="str">
@@ -174,7 +175,7 @@ public abstract class SvoBehavior : TypeConverter, IComparer<string>
     /// True if the string was converted successfully, otherwise false.
     /// </returns>
     [Pure]
-    internal bool TryParse(string? str, IFormatProvider? formatProvider, out string? validated)
+    public bool TryParse(string? str, IFormatProvider? formatProvider, out string? validated)
     {
         var normalized = NormalizeInput(str, formatProvider);
         if (string.IsNullOrWhiteSpace(normalized))
@@ -219,20 +220,11 @@ public abstract class SvoBehavior : TypeConverter, IComparer<string>
     /// The format provider.
     /// </param>
     [Pure]
-    internal string ToString(string? str, string? format, IFormatProvider? formatProvider)
+    public string ToString(string? str, string? format, IFormatProvider? formatProvider) => str switch
     {
-        if (StringFormatter.TryApplyCustomFormatter(format, str!, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        else if (str is null)
-        {
-            return string.Empty;
-        }
-        else if (str == unknown)
-        {
-            return FormatUnknown(format, formatProvider);
-        }
-        else return Format(str, format, formatProvider);
-    }
+        _ when StringFormatter.TryApplyCustomFormatter(format, str!, formatProvider, out string formatted) => formatted,
+        null => string.Empty,
+        unknown => FormatUnknown(format, formatProvider),
+        _ => Format(str, format, formatProvider),
+    };
 }


### PR DESCRIPTION
Define `[Svo<TBehavior]` so that the code generator can use this attribute. Furthermore, some methods have become public as the generator should work for all assemblies.