### PR TITLE
Mark generated SVO's as obsolete

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.4" />
+    <PackageVersion Include="Qowaiv.CodeGeneration.SingleValueObjects" Version="1.0.1" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.7.0.110445" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,17 +7,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AsyncFixer" Version="1.6.0" />
-    <PackageVersion Include="AwesomeAssertions" Version="8.0.2" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.10.0" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="0.34.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="1.5.11" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.5.11" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="1.5.12" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.5.12" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNet.Razor" Version="3.3.0" />
     <PackageVersion Include="Microsoft.AspNet.WebPages" Version="3.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
@@ -26,16 +26,16 @@
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="3.0.1" />
     <PackageVersion Include="Microsoft.Web.Infrastructure" Version="2.0.0" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.7.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
-    <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.4" />
+    <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.5" />
     <PackageVersion Include="Qowaiv.CodeGeneration.SingleValueObjects" Version="1.0.1" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.7.0.110445" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.8.0.113526" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.3" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AsyncFixer" Version="1.6.0" />
-    <PackageVersion Include="AwesomeAssertions" Version="8.10.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="0.34.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.5" />
-    <PackageVersion Include="Qowaiv.CodeGeneration.SingleValueObjects" Version="1.0.1" />
+    <PackageVersion Include="Qowaiv.CodeGeneration.SingleValueObjects" Version="1.0.2" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.8.0.113526" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />

--- a/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/Generic_SVO_specs.cs
@@ -40,23 +40,17 @@ public class With_domain_logic
     public void has_length(int length, CustomSvo svo)
         => svo.Length.Should().Be(length);
 
-    [TestCase(false, "QOWAIV")]
-    [TestCase(false, "?")]
-    [TestCase(true, "")]
-    public void IsEmpty_returns(bool result, CustomSvo svo)
-        => svo.IsEmpty().Should().Be(result);
-
-    [TestCase(false, "QOWAIV")]
-    [TestCase(true, "?")]
-    [TestCase(true, "")]
-    public void IsEmptyOrUnknown_returns(bool result, CustomSvo svo)
-        => svo.IsEmptyOrUnknown().Should().Be(result);
-
-    [TestCase(false, "QOWAIV")]
+    [TestCase(true, "QOWAIV")]
     [TestCase(true, "?")]
     [TestCase(false, "")]
-    public void IsUnknown_returns(bool result, CustomSvo svo)
-        => svo.IsUnknown().Should().Be(result);
+    public void IsEmpty_returns(bool result, CustomSvo svo)
+        => svo.HasValue.Should().Be(result);
+
+    [TestCase(true, "QOWAIV")]
+    [TestCase(false, "?")]
+    [TestCase(false, "")]
+    public void IsEmptyOrUnknown_returns(bool result, CustomSvo svo)
+        => svo.IsKnown.Should().Be(result);
 }
 
 public class Has_constant
@@ -413,7 +407,7 @@ public class Is_Open_API_data_type
 {
     [Test]
     public void with_info()
-       => OpenApiDataType.FromType(typeof(ForCustomSvo))
+       => OpenApiDataType.FromType(typeof(CustomSvo))
        .Should().Be(new OpenApiDataType(
            dataType: typeof(CustomSvo),
            description: "Custom SVO Example",
@@ -423,25 +417,6 @@ public class Is_Open_API_data_type
            pattern: null));
 }
 
-#if NET8_0_OR_GREATER
-#else
-public class Supports_binary_serialization
-{
-    [Test]
-    [Obsolete("Usage of the binary formatter is considered harmful.")]
-    public void using_BinaryFormatter()
-    {
-        var round_tripped = SerializeDeserialize.Binary(Svo.CustomSvo);
-        round_tripped.Should().Be(Svo.CustomSvo);
-    }
-    [Test]
-    public void storing_string_in_SerializationInfo()
-    {
-        var info = Serialize.GetInfo(Svo.CustomSvo);
-        info.GetString("Value").Should().Be("QOWAIV");
-    }
-}
-#endif
 public class Debugger
 {
     [TestCase("{empty}", "")]

--- a/specs/Qowaiv.Specs/Properties/GlobalUsings.cs
+++ b/specs/Qowaiv.Specs/Properties/GlobalUsings.cs
@@ -38,7 +38,6 @@ global using System.Text;
 global using System.Text.RegularExpressions;
 global using System.Threading.Tasks;
 global using System.Xml.Serialization;
-global using CustomSvo = Qowaiv.Customization.Svo<Qowaiv.TestTools.ForCustomSvo>;
 global using GenericSvo = Qowaiv.Customization.Svo<Qowaiv.TestTools.WithDefaultBehavior>;
 global using CustomGuid = Qowaiv.Identifiers.Id<Qowaiv.TestTools.ForGuid>;
 global using Int32Id = Qowaiv.Identifiers.Id<Qowaiv.TestTools.ForInt32>;

--- a/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
+++ b/specs/Qowaiv.Specs/Qowaiv.Specs.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="coverlet.collector" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" PrivateAssets="all" />
     <PackageReference Include="NUnit3TestAdapter" PrivateAssets="all" />
+    <PackageReference Include="Qowaiv.CodeGeneration.SingleValueObjects" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- We do not want to report on this during a PR/Release build. -->

--- a/specs/Qowaiv.Specs/TestTools/Svo.cs
+++ b/specs/Qowaiv.Specs/TestTools/Svo.cs
@@ -119,14 +119,18 @@ public static class Svo
 public sealed class WithDefaultBehavior : SvoBehavior { }
 
 [OpenApiDataType(description: "Custom SVO Example", type: "string", example: "QOWAIV", format: "custom")]
-public sealed class ForCustomSvo : SvoBehavior
+[Svo<Behavior>]
+public readonly partial struct CustomSvo
 {
-    public override int MinLength => 3;
-    public override int MaxLength => 16;
-    public override Regex Pattern => new("^[A-Z]+$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(1));
+    private sealed class Behavior : SvoBehavior
+    {
+        public override int MinLength => 3;
+        public override int MaxLength => 16;
+        public override Regex Pattern => new("^[A-Z]+$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(1));
 
-    public override string NormalizeInput(string? str, IFormatProvider? formatProvider)
-        => str?.Replace("-", "").ToUpper(formatProvider ?? CultureInfo.InvariantCulture) ?? string.Empty;
+        public override string NormalizeInput(string? str, IFormatProvider? formatProvider)
+            => str?.Replace("-", "").ToUpper(formatProvider ?? CultureInfo.InvariantCulture) ?? string.Empty;
+    }
 }
 
 public sealed class ForInt32 : Int32IdBehavior

--- a/specs/Qowaiv.Specs/TestTools/Svo.cs
+++ b/specs/Qowaiv.Specs/TestTools/Svo.cs
@@ -122,7 +122,7 @@ public sealed class WithDefaultBehavior : SvoBehavior { }
 [Svo<Behavior>]
 public readonly partial struct CustomSvo
 {
-    private sealed class Behavior : SvoBehavior
+    public sealed class Behavior : SvoBehavior
     {
         public override int MinLength => 3;
         public override int MaxLength => 16;

--- a/src/Qowaiv/Conversion/Customization/SvoTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Customization/SvoTypeConverter.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 namespace Qowaiv.Conversion.Customization;
 
 /// <summary>Provides a conversion for strongly typed identifiers.</summary>
+[Obsolete("Used by obsolete Svo<TBehavior>. Will be dropped in version 8.0.0.")]
 public sealed class SvoTypeConverter : TypeConverter
 {
     /// <summary>Accessor to the underlying value.</summary>

--- a/src/Qowaiv/Customization/Svo.cs
+++ b/src/Qowaiv/Customization/Svo.cs
@@ -17,6 +17,7 @@ namespace Qowaiv.Customization;
 #if NET6_0_OR_GREATER
 [System.Text.Json.Serialization.JsonConverter(typeof(Json.Customization.GenericSvoJsonConverter))]
 #endif
+[Obsolete("Use a generated SVO with [Svo<SvoBehavior>] instead.")]
 public readonly struct Svo<TSvoBehavior> : IXmlSerializable, IFormattable, IEquatable<Svo<TSvoBehavior>>, IComparable, IComparable<Svo<TSvoBehavior>>, IUnknown<Svo<TSvoBehavior>>
 #if NET8_0_OR_GREATER
 , IEqualityOperators<Svo<TSvoBehavior>, Svo<TSvoBehavior>, bool>

--- a/src/Qowaiv/Customization/SvoBehavior.cs
+++ b/src/Qowaiv/Customization/SvoBehavior.cs
@@ -132,10 +132,12 @@ public abstract class SvoBehavior : TypeConverter, IComparer<string>
     /// A 'For'-prefix will be stripped from the name in the message.
     /// </remarks>
     [Pure]
-    public virtual string InvalidFormatMessage(string? str, IFormatProvider? formatProvider)
-        => GetType().Name.StartsWith("For")
-        ? $"Not a valid {GetType().Name[3..]}"
-        : $"Not a valid {GetType().Name}";
+    public virtual string InvalidFormatMessage(string? str, IFormatProvider? formatProvider) => GetType() switch
+    {
+        var t when t.DeclaringType is { } declaring => $"Not a valid {declaring.Name}",
+        var t when t.Name.StartsWith("For") /*...*/ => $"Not a valid {t.Name[3..]}",
+        var t /*.................................*/ => $"Not a valid {t.Name}",
+    };
 
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>7.3.0-rc.1</Version>
+    <Version>7.3.0</Version>
     <PackageReleaseNotes>
       <![CDATA[
 v7.3.0


### PR DESCRIPTION
Mark `Svo<TBehavior>` as obsolete in favour of generated structs decorated with  `[Svo<TBehavior>]`.