### PR TITLE
Reduce required C# language version from 12 to 10

### DIFF
--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/CollectionMutationAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/CollectionMutationAttribute.cs
@@ -10,5 +10,8 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class CollectionMutationAttribute(global::System.String? justification = null) : global::Qowaiv.Diagnostics.Contracts.ImpureAttribute(justification) { }
+    internal sealed class CollectionMutationAttribute : global::Qowaiv.Diagnostics.Contracts.ImpureAttribute
+    {
+        public CollectionMutationAttribute(global::System.String? justification = null) : base(justification) { }
+    }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyClassAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyClassAttribute.cs
@@ -12,5 +12,8 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal class EmptyClassAttribute(global::System.String justification) : global::Qowaiv.Diagnostics.Contracts.EmptyTypeAttribute(justification) { }
+    internal class EmptyClassAttribute : global::Qowaiv.Diagnostics.Contracts.EmptyTypeAttribute
+    {
+        public EmptyClassAttribute(global::System.String justification) : base(justification) { }
+    }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyEnumAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyEnumAttribute.cs
@@ -8,5 +8,8 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Enum, AllowMultiple = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal class EmptyEnumAttribute(global::System.String justification) : global::Qowaiv.Diagnostics.Contracts.EmptyTypeAttribute(justification) { }
+    internal class EmptyEnumAttribute : global::Qowaiv.Diagnostics.Contracts.EmptyTypeAttribute
+    {
+        public EmptyEnumAttribute(global::System.String justification) : base(justification) { }
+    }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyInterfaceAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyInterfaceAttribute.cs
@@ -8,5 +8,8 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Interface, AllowMultiple = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal class EmptyInterfaceAttribute(global::System.String justification) : global::Qowaiv.Diagnostics.Contracts.EmptyTypeAttribute(justification) { }
+    internal class EmptyInterfaceAttribute : global::Qowaiv.Diagnostics.Contracts.EmptyTypeAttribute
+    {
+        public EmptyInterfaceAttribute(global::System.String justification) : base(justification) { }
+    }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyStructAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyStructAttribute.cs
@@ -8,5 +8,8 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Struct, AllowMultiple = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal class EmptyStructAttribute(global::System.String justification) : global::Qowaiv.Diagnostics.Contracts.EmptyTypeAttribute(justification) { }
+    internal class EmptyStructAttribute : global::Qowaiv.Diagnostics.Contracts.EmptyTypeAttribute
+    {
+        public EmptyStructAttribute(global::System.String justification) : base(justification) { }
+    }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTestClassAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTestClassAttribute.cs
@@ -12,8 +12,10 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class EmptyTestClassAttribute(global::System.String? justification) : global::Qowaiv.Diagnostics.Contracts.EmptyClassAttribute(justification ?? "For test purposes.")
+    internal sealed class EmptyTestClassAttribute : global::Qowaiv.Diagnostics.Contracts.EmptyClassAttribute
     {
+        public EmptyTestClassAttribute(global::System.String? justification) : base(justification ?? "For test purposes.") { }
+
         public EmptyTestClassAttribute() : this(null) { }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTestEnumAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTestEnumAttribute.cs
@@ -8,8 +8,10 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Enum, AllowMultiple = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class EmptyTestEnumAttribute(global::System.String? justification) : global::Qowaiv.Diagnostics.Contracts.EmptyEnumAttribute(justification ?? "For test purposes.")
+    internal sealed class EmptyTestEnumAttribute : global::Qowaiv.Diagnostics.Contracts.EmptyEnumAttribute
     {
+        public EmptyTestEnumAttribute(global::System.String? justification) : base(justification ?? "For test purposes.") { }
+
         public EmptyTestEnumAttribute() : this(null) { }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTestInterfaceAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTestInterfaceAttribute.cs
@@ -8,8 +8,10 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Interface, AllowMultiple = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class EmptyTestInterfaceAttribute(global::System.String? justification) : global::Qowaiv.Diagnostics.Contracts.EmptyInterfaceAttribute(justification ?? "For test purposes.")
+    internal sealed class EmptyTestInterfaceAttribute : global::Qowaiv.Diagnostics.Contracts.EmptyInterfaceAttribute
     {
+        public EmptyTestInterfaceAttribute(global::System.String? justification) : base (justification ?? "For test purposes.") { }
+
         public EmptyTestInterfaceAttribute() : this(null) { }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTestStructAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTestStructAttribute.cs
@@ -8,8 +8,10 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Struct, AllowMultiple = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class EmptyTestStructAttribute(global::System.String? justification) : global::Qowaiv.Diagnostics.Contracts.EmptyStructAttribute(justification ?? "For test purposes.")
+    internal sealed class EmptyTestStructAttribute : global::Qowaiv.Diagnostics.Contracts.EmptyStructAttribute
     {
+        public EmptyTestStructAttribute(global::System.String? justification) : base(justification ?? "For test purposes.") { }
+
         public EmptyTestStructAttribute() : this(null) { }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTypeAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/EmptyTypeAttribute.cs
@@ -7,9 +7,11 @@ namespace Qowaiv.Diagnostics.Contracts
     /// <summary>Indicates the type is empty by design.</summary>
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal abstract class EmptyTypeAttribute(global::System.String justification) : global::System.Attribute
+    internal abstract class EmptyTypeAttribute : global::System.Attribute
     {
+        protected EmptyTypeAttribute(global::System.String justification) => this.Justification = justification;
+
         /// <summary>The justification of this decoration.</summary>
-        public global::System.String Justification { get; } = justification;
+        public global::System.String Justification { get; }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/FluentSyntaxAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/FluentSyntaxAttribute.cs
@@ -10,8 +10,10 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class FluentSyntaxAttribute(global::System.String? justification) : global::Qowaiv.Diagnostics.Contracts.ImpureAttribute(justification)
+    internal sealed class FluentSyntaxAttribute : global::Qowaiv.Diagnostics.Contracts.ImpureAttribute
     {
+        public FluentSyntaxAttribute(global::System.String? justification) : base(justification) { }
+
         public FluentSyntaxAttribute() : this(null) { }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/ImpureAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/ImpureAttribute.cs
@@ -8,11 +8,13 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal class ImpureAttribute(global::System.String? justification) : global::System.Attribute
+    internal class ImpureAttribute : global::System.Attribute
     {
+        public ImpureAttribute(global::System.String? justification) => Justification = justification;
+
         public ImpureAttribute() : this(null) { }
 
         /// <summary>The justification of this decoration.</summary>
-        public global::System.String? Justification { get; init; } = justification;
+        public global::System.String? Justification { get; init; }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/InheritableAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/InheritableAttribute.cs
@@ -8,11 +8,13 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal class InheritableAttribute(global::System.String? justification) : global::System.Attribute
+    internal class InheritableAttribute : global::System.Attribute
     {
+        public InheritableAttribute(global::System.String? justification) => Justification = justification;
+
         public InheritableAttribute() : this(null) { }
 
         /// <summary>The justification of this decoration.</summary>
-        public global::System.String? Justification { get; init; } = justification;
+        public global::System.String? Justification { get; init; }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/MutableAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/MutableAttribute.cs
@@ -8,11 +8,13 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class MutableAttribute(global::System.String? justification) : global::System.Attribute
+    internal sealed class MutableAttribute : global::System.Attribute
     {
+        public MutableAttribute(global::System.String? justification) => Justification = justification;
+
         public MutableAttribute() : this(null) { }
 
         /// <summary>The justification of this decoration.</summary>
-        public global::System.String? Justification { get; init; } = justification;
+        public global::System.String? Justification { get; init; }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Attributes/WillBeSealedAttribute.cs
+++ b/src/Qowaiv.Diagnostics.Contracts/Attributes/WillBeSealedAttribute.cs
@@ -8,8 +8,10 @@ namespace Qowaiv.Diagnostics.Contracts
     [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     [global::System.Diagnostics.Conditional("CONTRACTS_FULL")]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class WillBeSealedAttribute(global::System.String? justification) : global::Qowaiv.Diagnostics.Contracts.InheritableAttribute(justification)
+    internal sealed class WillBeSealedAttribute: global::Qowaiv.Diagnostics.Contracts.InheritableAttribute
     {
+        public WillBeSealedAttribute(global::System.String? justification) : base(justification) { }
+
         public WillBeSealedAttribute() : this(null) { }
     }
 }

--- a/src/Qowaiv.Diagnostics.Contracts/Qowaiv.Diagnostics.Contracts.csproj
+++ b/src/Qowaiv.Diagnostics.Contracts/Qowaiv.Diagnostics.Contracts.csproj
@@ -12,8 +12,11 @@
     <Version>2.0.5</Version>
     <PackageId>Qowaiv.Diagnostics.Contracts</PackageId>
     <ProductName>Qowaiv Diagnostics Contracts</ProductName>
+    <LangVersion>10</LangVersion>
     <PackageReleaseNotes>
       <![CDATA[
+v2.0.6
+- Reduce required C# language version from 12 to 10.
 v2.0.5
 - Decorate all code with [ExcludeFromCodeCoverage].
 v2.0.4


### PR DESCRIPTION
Primary constructors are only available since C# 12. By not using them, the language requirements is loosen.