### PR TITLE
TryCreate should return default(T?) instead of default(T)

### DIFF
--- a/specs/Qowaiv.Specs/Customization/ID_int_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_int_specs.cs
@@ -23,6 +23,15 @@ public class Has_constant
     public void HasValue_is(bool result, Int32BasedId svo) => svo.HasValue.Should().Be(result);
 }
 
+public class Create
+{
+    [Test]
+    public void returns_null_for_non_representable_values()
+    {
+        EvenOnlyId.TryCreate(17).Should().Be(null);
+    }
+}
+
 public class Is_equal_by_value
 {
     [Test]
@@ -67,7 +76,6 @@ public class Is_equal_by_value
         }
     }
 }
-
 
 public class Bytes
 {

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/IdTemplate.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/IdTemplate.cs
@@ -28,7 +28,8 @@ public sealed class IdTemplate(IdParameters parameters) : Code
                 .Replace("@Svo", Parameters.Svo)
                 .Replace("@Behavior", Parameters.Behavior)
                 .Replace("@Raw", Parameters.Raw)
-                .Replace("@Namespace", Parameters.Namespace.ToString())));
+                .Replace("@Namespace", Parameters.Namespace.ToString()))
+            .Transform([Parameters.Raw == "System.String" ? new("StringBased") : new("NotStringBased")]));
 
     /// <inheritdoc />
     [Pure]

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
@@ -9,9 +9,11 @@
     <IncludeSymbols>false</IncludeSymbols>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>Qowaiv.CodeGeneration.SingleValueObjects</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageReleaseNotes>
       <![CDATA[
+v1.1.1
+- Do not generate Create and TryCreate for string based ID's.
 v1.1.0
 - Generated custom ID's.
 v1.0.2

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Create.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Create.cs
@@ -1,4 +1,4 @@
-#if !NotStringBased // exec
+#if !StringBased // exec
 partial struct @Svo
 {
     /// <summary>Creates a new instance of the <see cref="@Svo" /> struct.</summary>
@@ -18,6 +18,6 @@ partial struct @Svo
     public static @Svo? TryCreate(@Raw value)
         => behavior.TryTransform(@value, out var tranformed)
         ? new @Svo(tranformed)
-        : default;
+        : null;
 }
 #endif // exec

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -38,9 +38,11 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>7.4.0</Version>
+    <Version>7.4.1</Version>
     <PackageReleaseNotes>
       <![CDATA[
+v7.4.1
+- return null instead of default(TSvo) for TryCreate when false.
 v7.4.0
 - Support [Id<TBehavior, TRaw>]. #483
 v7.3.0


### PR DESCRIPTION
Small bug when `TSvo.TryCreate(TRaw)` fails. It should return `default(TSvo?)`, instead of `TSvo.Empty`.