### PR TITLE
Change decoration of [Id<>] and [Svo<>] attributes

### DIFF
--- a/src/Qowaiv/Customization/IdAttribute.cs
+++ b/src/Qowaiv/Customization/IdAttribute.cs
@@ -16,7 +16,7 @@ namespace Qowaiv.Customization;
 /// - <see cref="string" />
 /// or other.
 /// </typeparam>
-[Conditional("CONTRACTS_FULL")]
+[Conditional("CODE_GENERATOR_ATTRIBUTES")]
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
 [ExcludeFromCodeCoverage]
 public sealed class IdAttribute<TBehavior, TValue> : Attribute

--- a/src/Qowaiv/Customization/SvoAttribute.cs
+++ b/src/Qowaiv/Customization/SvoAttribute.cs
@@ -7,7 +7,7 @@ namespace Qowaiv.Customization;
 /// <typeparam name="TBehavior">
 /// Singleton that handles the behavior of the custom SVO.
 /// </typeparam>
-[Conditional("CONTRACTS_FULL")]
+[Conditional("CODE_GENERATOR_ATTRIBUTES")]
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
 [ExcludeFromCodeCoverage]
 public sealed class SvoAttribute<TBehavior> : Attribute

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -38,9 +38,11 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>7.4.1</Version>
+    <Version>7.4.2</Version>
     <PackageReleaseNotes>
       <![CDATA[
+v7.4.2
+- Code generators are decorated with [Conditional("CODE_GENERATOR_ATTRIBUTES")].
 v7.4.1
 - return null instead of default(TSvo) for TryCreate when false.
 v7.4.0


### PR DESCRIPTION
Previously, the  `[Id<>]` and `[Svo<>]` attributes where decorated with `[Conditional("FULL_CONTRACT")]`. As a result, once this constant was defined, for .NET Framework targets, `Type.GetCustomAttributes()` would crash, as it does not support generic attributes.

By changing the decoration to `[Conditional("CODE_GENERATOR_ATTRIBUTES")]`, the attributes will not longer be included (unless this specific constant is set).