### PR TITLE
ID code generator should support potentially conflicting namespaces

### DIFF
--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/IdTemplate.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/IdTemplate.cs
@@ -27,7 +27,7 @@ public sealed class IdTemplate(IdParameters parameters) : Code
             .Transform(line => line
                 .Replace("@Svo", Parameters.Svo)
                 .Replace("@Behavior", Parameters.Behavior)
-                .Replace("@Raw", Parameters.Raw)
+                .Replace("@Raw", $"global::{Parameters.Raw}")
                 .Replace("@Namespace", Parameters.Namespace.ToString()))
             .Transform([Parameters.Raw == "System.String" ? new("StringBased") : new("NotStringBased")]));
 

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <Import Project="../../props/package.props" />
 
@@ -9,8 +9,14 @@
     <IncludeSymbols>false</IncludeSymbols>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>Qowaiv.CodeGeneration.SingleValueObjects</PackageId>
-    <Version>1.1.1</Version>
     <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
+    <Version>1.1.1</Version>
+    <ToBeReleased>
+      <![CDATA[
+v1.1.2
+- ID m_Value's raw type with global:: namespace prefix.
+      ]]>
+    </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
 v1.1.1


### PR DESCRIPTION
The ID code generated did not add the `global::` prefix when generating the type of the underlying *raw* value. This can lead to namespace conflicts when someone defines a sub namespace named `System`.