### PR TITLE
Support [Id<TBehavior, TRaw>] without namespace

### DIFF
--- a/specs/Qowaiv.Specs.Generated/GlobalId.cs
+++ b/specs/Qowaiv.Specs.Generated/GlobalId.cs
@@ -1,0 +1,5 @@
+#pragma warning disable S3903 // Types should be defined in named namespaces
+// This type checks if the build without a namespace present works
+
+[Id<StringIdBehavior, string>]
+public readonly partial struct GlobalId { }

--- a/specs/Qowaiv.Specs/CodeGeneration/Namespace_specs.cs
+++ b/specs/Qowaiv.Specs/CodeGeneration/Namespace_specs.cs
@@ -1,0 +1,57 @@
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Qowaiv.CodeGeneration;
+
+namespace CodeGeneration.Namespace_specs;
+
+public class Parent
+{
+    [Test]
+    public void Empty_for_Empty()
+        => Namespace.Empty.Parent.Should().Be(Namespace.Empty);
+
+    [Test]
+    public void Empty_for_root()
+        => new Namespace("Qowaiv").Parent.Should().Be(Namespace.Empty);
+
+    [Test]
+    public void Resolvable_for_others()
+        => new Namespace("Qowaiv.CodeGeneration").Parent.Should().Be(new Namespace("Qowaiv"));
+}
+
+public class Child
+{
+    [Test]
+    public void Root_for_Empty()
+        => Namespace.Empty.Child("Qowaiv").Should().Be(new Namespace("Qowaiv"));
+
+    [Test]
+    public void Resolvable_for_others()
+        => new Namespace("Qowaiv").Child("CodeGeneration").Should().Be(new Namespace("Qowaiv.CodeGeneration"));
+}
+
+public class Formattable
+{
+    [Test]
+    public void Empty_is_string_Empty() => Namespace.Empty.ToString().Should().BeEmpty();
+
+    [Test]
+    public void ToString_represents_name() => new Namespace("Qowaiv").ToString().Should().Be("Qowaiv");
+}
+
+public class Convertable
+{
+    [TestCase("")]
+    [TestCase(null)]
+    public void From_empty_strings_with_casting(string? str)
+    {
+        Namespace ns = str;
+        ns.Should().Be(Namespace.Empty);
+    }
+
+    [Test]
+    public void From_string_with_casting()
+    {
+        Namespace ns = "Qowaiv";
+        ns.Should().Be(new Namespace("Qowaiv"));
+    }
+}

--- a/specs/Qowaiv.Specs/CodeGeneration/Namespace_specs.cs
+++ b/specs/Qowaiv.Specs/CodeGeneration/Namespace_specs.cs
@@ -1,4 +1,3 @@
-using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Qowaiv.CodeGeneration;
 
 namespace CodeGeneration.Namespace_specs;

--- a/specs/Qowaiv.Specs/Customization/ID_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_specs.cs
@@ -1,0 +1,10 @@
+namespace Specs.Customization.UuidBasedId_specs;
+
+internal class Implements
+{
+    [Test]
+    public void INext()
+    {
+        //var next = GlobalId
+    }
+}

--- a/specs/Qowaiv.Specs/Customization/ID_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_specs.cs
@@ -4,8 +4,6 @@ internal class Implements
 {
     [Test]
     public void INext()
-    {
-        global::GlobalId id = default;
-       // ((INext<GlobalId>)id).Should().NotBeNull();
-    }
+        => typeof(GlobalId).GetMethod("Next", BindingFlags.Public | BindingFlags.Static)
+        .Should().NotBeNull();
 }

--- a/specs/Qowaiv.Specs/Customization/ID_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_specs.cs
@@ -5,6 +5,7 @@ internal class Implements
     [Test]
     public void INext()
     {
-        //var next = GlobalId
+        GlobalId id = default;
+       // ((INext<GlobalId>)id).Should().NotBeNull();
     }
 }

--- a/specs/Qowaiv.Specs/Customization/ID_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_specs.cs
@@ -5,7 +5,7 @@ internal class Implements
     [Test]
     public void INext()
     {
-        GlobalId id = default;
+        global::GlobalId id = default;
        // ((INext<GlobalId>)id).Should().NotBeNull();
     }
 }

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/BaseGenerator.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/BaseGenerator.cs
@@ -39,7 +39,8 @@ public abstract class BaseGenerator<TParameters> : IIncrementalGenerator
         foreach (var pars in parameters)
         {
             var code = Generate(context, pars);
-            context.AddSource($"{pars.Namespace}.{pars.Svo}.g.cs", code.ToString());
+            var ns = pars.Namespace.IsEmpty() ? "__global__" : pars.Namespace.ToString();
+            context.AddSource($"{ns}.{pars.Svo}.g.cs", code.ToString());
         }
     }
 

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/IdGenerator.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/IdGenerator.cs
@@ -24,7 +24,9 @@ public sealed class IdGenerator : BaseGenerator<IdParameters>
             Svo = symbol.Name,
             Behavior = FullName(attr.TypeArguments[0]),
             Raw = FullName(attr.TypeArguments[1]),
-            Namespace = symbol.ContainingNamespace?.ToString(),
+            Namespace = symbol.ContainingNamespace.IsGlobalNamespace
+                ? Namespace.Empty
+                : symbol.ContainingNamespace.ToString(),
         };
     }
 

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/IdGenerator.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/IdGenerator.cs
@@ -24,7 +24,7 @@ public sealed class IdGenerator : BaseGenerator<IdParameters>
             Svo = symbol.Name,
             Behavior = FullName(attr.TypeArguments[0]),
             Raw = FullName(attr.TypeArguments[1]),
-            Namespace = symbol.ContainingNamespace.ToString(),
+            Namespace = symbol.ContainingNamespace?.ToString(),
         };
     }
 

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/IdTemplate.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/IdTemplate.cs
@@ -28,10 +28,16 @@ public sealed class IdTemplate(IdParameters parameters) : Code
                 .Replace("@Svo", Parameters.Svo)
                 .Replace("@Behavior", Parameters.Behavior)
                 .Replace("@Raw", $"global::{Parameters.Raw}")
-                .Replace("@Namespace", Parameters.Namespace.ToString()))
+                .Replace("@NamespaceDeclaration", NamespaceDeclaration()))
             .Transform([Parameters.Raw == "System.String" ? new("StringBased") : new("NotStringBased")]));
 
     /// <inheritdoc />
     [Pure]
     public override string ToString() => this.Stringify();
+
+    [Pure]
+    private string NamespaceDeclaration()
+        => Parameters.Namespace.IsEmpty()
+        ? string.Empty
+        : $"namespace {Parameters.Namespace};";
 }

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
@@ -16,6 +16,7 @@
 v1.1.2
 - ID m_Value's raw type with global:: namespace prefix.
 - ID's implement INext<TSvo>.
+- ID's can be generated in the global namespace.
       ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Json.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Json.cs
@@ -1,5 +1,5 @@
 #if NET6_0_OR_GREATER
-    [global::System.Text.Json.Serialization.JsonConverter(typeof(global::@Namespace.@Svo.SvoJsonConverter))]
+    [global::System.Text.Json.Serialization.JsonConverter(typeof(@Svo.SvoJsonConverter))]
 #endif
 partial struct @Svo
 {

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Structure.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Structure.cs
@@ -1,4 +1,4 @@
-namespace @Namespace;
+@NamespaceDeclaration
 
 [global::System.ComponentModel.TypeConverter(typeof(@Svo.TypeConverter))]
 readonly partial struct @Svo

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Structure.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Structure.cs
@@ -1,6 +1,6 @@
 namespace @Namespace;
 
-[global::System.ComponentModel.TypeConverter(typeof(global::@Namespace.@Svo.TypeConverter))]
+[global::System.ComponentModel.TypeConverter(typeof(@Svo.TypeConverter))]
 readonly partial struct @Svo
 {
     /// <summary>An singleton instance that deals with the @FullName specific behavior.</summary>

--- a/src/Qowaiv.CodeGeneration/Types/Namespace.cs
+++ b/src/Qowaiv.CodeGeneration/Types/Namespace.cs
@@ -13,13 +13,9 @@ public readonly struct Namespace(string name) : IEquatable<Namespace>
 
     /// <summary>Get the parent namespace of the namespace.</summary>
     public Namespace Parent
-    {
-        get
-        {
-            var index = Name.LastIndexOf('.');
-            return index == -1 ? default : new(Name[..index]);
-        }
-    }
+        => Name?.LastIndexOf('.') is { } index && index is not -1
+        ? new(Name[..index])
+        : default;
 
     /// <summary>Returns true if empty.</summary>
     [Pure]

--- a/src/Qowaiv.CodeGeneration/Types/Namespace.cs
+++ b/src/Qowaiv.CodeGeneration/Types/Namespace.cs
@@ -55,7 +55,7 @@ public readonly struct Namespace(string name) : IEquatable<Namespace>
     public static bool operator !=(Namespace left, Namespace right) => !(left == right);
 
     /// <summary>Implicitly casts a string to a namespace.</summary>
-    public static implicit operator Namespace(string value) => new(value);
+    public static implicit operator Namespace(string? value) => value is { Length: > 0 } ? new(value) : Empty;
 
     /// <summary>Creates a collection of global namespaces based on file.</summary>
     [Pure]


### PR DESCRIPTION
If no namespace have been defined in code file class, the `[Id<TBehavior, TRaw>]` now successfully generates an ID, instead of resulting in an obscure crash.