### PR TITLE
Use pattern matching instead of if else if constructs

### DIFF
--- a/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
+++ b/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
@@ -63,18 +63,12 @@ public readonly partial struct Timestamp : IXmlSerializable, IFormattable, IEqua
     /// The format provider.
     /// </param>
     [Pure]
-    public string ToString(string? format, IFormatProvider? formatProvider)
+    public string ToString(string? format, IFormatProvider? formatProvider) => format switch
     {
-        if (StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        else if (string.IsNullOrEmpty(format))
-        {
-            return string.Format(formatProvider, "0x{0:X16}", m_Value);
-        }
-        else return m_Value.ToString(format, formatProvider);
-    }
+        _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted) => formatted,
+        null or "" => string.Format(formatProvider, "0x{0:X16}", m_Value),
+        _ => m_Value.ToString(format, formatProvider),
+    };
 
     /// <summary>Gets an XML string representation of the timestamp.</summary>
     [Pure]

--- a/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
+++ b/src/Qowaiv.Data.SqlClient/Sql/Timestamp.cs
@@ -66,7 +66,7 @@ public readonly partial struct Timestamp : IXmlSerializable, IFormattable, IEqua
     public string ToString(string? format, IFormatProvider? formatProvider) => format switch
     {
         _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted) => formatted,
-        null or "" => string.Format(formatProvider, "0x{0:X16}", m_Value),
+        null or "" => $"0x{m_Value:X16}",
         _ => m_Value.ToString(format, formatProvider),
     };
 

--- a/src/Qowaiv/Chemistry/CasRegistryNumber.cs
+++ b/src/Qowaiv/Chemistry/CasRegistryNumber.cs
@@ -44,18 +44,14 @@ public readonly partial struct CasRegistryNumber : IXmlSerializable, IFormattabl
     /// other (not empty) formats are applied on the number (long).
     /// </remarks>
     [Pure]
-    public string ToString(string? format, IFormatProvider? formatProvider)
+    public string ToString(string? format, IFormatProvider? formatProvider) => m_Value switch
     {
-        if (StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        else if (IsEmpty()) return string.Empty;
-        else if (IsUnknown()) return "?";
-        else return format.WithDefault("f") == "f"
-            ? m_Value.ToString(@"#00\-00\-0", formatProvider)
-            : m_Value.ToString(format, formatProvider);
-    }
+        _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted) => formatted,
+        _ when !HasValue => string.Empty,
+        _ when !IsKnown => "?",
+        _ when format.WithDefault("f") == "f" => m_Value.ToString(@"#00\-00\-0", formatProvider),
+        _ => m_Value.ToString(format, formatProvider),
+    };
 
     /// <summary>Gets an XML string representation of the CAS Registry Number.</summary>
     [Pure]

--- a/src/Qowaiv/Chemistry/CasRegistryNumber.cs
+++ b/src/Qowaiv/Chemistry/CasRegistryNumber.cs
@@ -44,7 +44,7 @@ public readonly partial struct CasRegistryNumber : IXmlSerializable, IFormattabl
     /// other (not empty) formats are applied on the number (long).
     /// </remarks>
     [Pure]
-    public string ToString(string? format, IFormatProvider? formatProvider) => m_Value switch
+    public string ToString(string? format, IFormatProvider? formatProvider) => format switch
     {
         _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted) => formatted,
         _ when !HasValue => string.Empty,

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -91,15 +91,13 @@ public readonly partial struct BusinessIdentifierCode : IXmlSerializable, IForma
     /// The format provider.
     /// </param>
     [Pure]
-    public string ToString(string? format, IFormatProvider? formatProvider)
+    public string ToString(string? format, IFormatProvider? formatProvider) => m_Value switch
     {
-        if (StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        else if (IsUnknown()) return "?";
-        else return m_Value ?? string.Empty;
-    }
+        _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted) => formatted,
+        _ when !HasValue => string.Empty,
+        _ when !IsKnown => "?",
+        _ => m_Value!,
+    };
 
     /// <summary>Gets an XML string representation of the BIC.</summary>
     [Pure]

--- a/src/Qowaiv/Financial/BusinessIdentifierCode.cs
+++ b/src/Qowaiv/Financial/BusinessIdentifierCode.cs
@@ -91,7 +91,7 @@ public readonly partial struct BusinessIdentifierCode : IXmlSerializable, IForma
     /// The format provider.
     /// </param>
     [Pure]
-    public string ToString(string? format, IFormatProvider? formatProvider) => m_Value switch
+    public string ToString(string? format, IFormatProvider? formatProvider) => format switch
     {
         _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted) => formatted,
         _ when !HasValue => string.Empty,

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -38,7 +38,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     public Country Country => m_Value switch
     {
         null => Country.Empty,
-        var v when v == Unknown.m_Value => Country.Unknown,
+        _ when m_Value == Unknown.m_Value => Country.Unknown,
         _ => Country.Parse(m_Value[..2], CultureInfo.InvariantCulture),
     };
 
@@ -58,7 +58,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     public string MachineReadable() => m_Value switch
     {
         null => string.Empty,
-        var v when v == Unknown.m_Value => "?",
+        _ when m_Value == Unknown.m_Value => "?",
         _ => m_Value,
     };
 

--- a/src/Qowaiv/HouseNumber.cs
+++ b/src/Qowaiv/HouseNumber.cs
@@ -94,16 +94,13 @@ public readonly partial struct HouseNumber : IXmlSerializable, IFormattable, IEq
     /// The format provider.
     /// </param>
     [Pure]
-    public string ToString(string? format, IFormatProvider? formatProvider)
+    public string ToString(string? format, IFormatProvider? formatProvider) => format switch
     {
-        if (StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        else if (IsUnknown()) return "?";
-        else if (IsEmpty()) return string.Empty;
-        else return m_Value.ToString(format, formatProvider);
-    }
+        _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted)=> formatted,
+        _ when !HasValue => string.Empty,
+        _ when !IsKnown => "?",
+        _ => m_Value.ToString(format, formatProvider),
+    };
 
     /// <summary>Gets an XML string representation of the house number.</summary>
     [Pure]

--- a/src/Qowaiv/Json/SvoJsonConverter.cs
+++ b/src/Qowaiv/Json/SvoJsonConverter.cs
@@ -126,7 +126,7 @@ public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo : 
         _ when reader.TryGetInt64(out long num) => FromJson(num),
         _ when reader.TryGetDecimal(out decimal dec) => FromJson(dec),
         _ when reader.TryGetDouble(out double dbl) => FromJson(dbl),
-        _ => throw new JsonException($"QowaivJsonConverter does not support writing from {reader.GetString()}."),
+        _ => throw new JsonException($"QowaivJsonConverter does not support reading from {reader.GetString()}."),
     };
 }
 #endif

--- a/src/Qowaiv/Json/SvoJsonConverter.cs
+++ b/src/Qowaiv/Json/SvoJsonConverter.cs
@@ -121,21 +121,12 @@ public abstract class SvoJsonConverter<TSvo> : JsonConverter<TSvo> where TSvo : 
     [Pure]
     protected virtual TSvo FromJson(bool json) => FromJson(json ? "true" : "false");
 
-    private TSvo ReadNumber(ref Utf8JsonReader reader)
+    private TSvo ReadNumber(ref Utf8JsonReader reader) => reader switch
     {
-        if (reader.TryGetInt64(out long num))
-        {
-            return FromJson(num);
-        }
-        else if (reader.TryGetDecimal(out decimal dec))
-        {
-            return FromJson(dec);
-        }
-        else if (reader.TryGetDouble(out double dbl))
-        {
-            return FromJson(dbl);
-        }
-        else throw new JsonException($"QowaivJsonConverter does not support writing from {reader.GetString()}.");
-    }
+        _ when reader.TryGetInt64(out long num) => FromJson(num),
+        _ when reader.TryGetDecimal(out decimal dec) => FromJson(dec),
+        _ when reader.TryGetDouble(out double dbl) => FromJson(dbl),
+        _ => throw new JsonException($"QowaivJsonConverter does not support writing from {reader.GetString()}."),
+    };
 }
 #endif

--- a/src/Qowaiv/MonthSpan.cs
+++ b/src/Qowaiv/MonthSpan.cs
@@ -217,18 +217,12 @@ public readonly partial struct MonthSpan : IXmlSerializable, IFormattable, IEqua
     /// All others format the total months.
     /// </remarks>
     [Pure]
-    public string ToString(string? format, IFormatProvider? formatProvider)
+    public string ToString(string? format, IFormatProvider? formatProvider) => format switch
     {
-        if (StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        else if (string.IsNullOrEmpty(format) || format == "F")
-        {
-            return string.Format(formatProvider, "{0}Y{1:+0;-0;+0}M", Years, Months);
-        }
-        else return m_Value.ToString(format, formatProvider);
-    }
+        _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted) => formatted,
+        null or "" or "F" => $"{Years}Y{Months:+0;-0;+0}M",
+        _ => m_Value.ToString(format, formatProvider),
+    };
 
     /// <summary>Gets an XML string representation of the month span.</summary>
     [Pure]

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -225,18 +225,12 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
     /// The format provider.
     /// </param>
     [Pure]
-    public string ToString(string? format, IFormatProvider? formatProvider)
+    public string ToString(string? format, IFormatProvider? formatProvider) => format switch
     {
-        if (StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        else if (FormatInfo.TryParse(format, formatProvider, out var info))
-        {
-            return info.ToString(m_Value);
-        }
-        else throw new FormatException(QowaivMessages.FormatException_InvalidFormat);
-    }
+        _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted) => formatted,
+        _ when FormatInfo.TryParse(format, formatProvider, out var info) => info.ToString(m_Value),
+        _ => throw new FormatException(QowaivMessages.FormatException_InvalidFormat),
+    };
 
     /// <summary>Gets an XML string representation of the percentage.</summary>
     [Pure]

--- a/src/Qowaiv/Year.cs
+++ b/src/Qowaiv/Year.cs
@@ -73,16 +73,13 @@ public readonly partial struct Year : IXmlSerializable, IFormattable, IEquatable
     /// The format provider.
     /// </param>
     [Pure]
-    public string ToString(string? format, IFormatProvider? formatProvider)
+    public string ToString(string? format, IFormatProvider? formatProvider) => format switch
     {
-        if (StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted))
-        {
-            return formatted;
-        }
-        else if (IsEmpty()) { return string.Empty; }
-        else if (IsUnknown()) { return "?"; }
-        else { return m_Value.ToString(format, formatProvider); }
-    }
+        _ when StringFormatter.TryApplyCustomFormatter(format, this, formatProvider, out string formatted) => formatted,
+        _ when !HasValue => string.Empty,
+        _ when !IsKnown => "?",
+        _ => m_Value.ToString(format, formatProvider),
+    };
 
     /// <summary>Gets an XML string representation of the year.</summary>
     [Pure]


### PR DESCRIPTION
There are quite some `if else if else` blocks in this codebase. They have been written before the modern pattern matching switch statements exists. Now it does, writing it in such matter further improves the readabillity.