### PR TITLE
Support casting to underlying type for generated ID's

### DIFF
--- a/specs/Qowaiv.Specs/Customization/ID_GUID_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_GUID_specs.cs
@@ -244,6 +244,13 @@ public class Supports_type_conversion
     [TestCase(typeof(string))]
     public void to(Type type)
         => Converting.To(type).From<GuidBasedId>().Should().BeTrue();
+
+    [Test]
+    public void to_underlying_via_explicit_cast()
+    {
+        var cast = (Guid)Svo.Generated.CustomGuid;
+        cast.Should().Be(Svo.Guid);
+    }
 }
 
 public class Supports_JSON_serialization

--- a/specs/Qowaiv.Specs/Customization/ID_UUID_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_UUID_specs.cs
@@ -244,6 +244,13 @@ public class Supports_type_conversion
     [TestCase(typeof(string))]
     public void to(Type type)
         => Converting.To(type).From<UuidBasedId>().Should().BeTrue();
+
+    [Test]
+    public void to_underlying_via_explicit_cast()
+    {
+        var cast = (Uuid)Svo.Generated.CustomUuid;
+        cast.Should().Be(Svo.Uuid);
+    }
 }
 
 public class Supports_JSON_serialization

--- a/specs/Qowaiv.Specs/Customization/ID_int_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_int_specs.cs
@@ -270,6 +270,13 @@ public class Supports_type_conversion
     [TestCase(typeof(string))]
     public void to(Type type)
         => Converting.To(type).From<Int32BasedId>().Should().BeTrue();
+
+    [Test]
+    public void to_underlying_via_explicit_cast()
+    {
+        var cast = (int)Svo.Generated.Int32Id;
+        cast.Should().Be(17);
+    }
 }
 
 public class Supports_XML_serialization

--- a/specs/Qowaiv.Specs/Customization/ID_long_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_long_specs.cs
@@ -309,6 +309,13 @@ public class Supports_XML_serialization
         IXmlSerializable obj = Svo.Generated.Int64Id;
         obj.GetSchema().Should().BeNull();
     }
+
+    [Test]
+    public void to_underlying_via_explicit_cast()
+    {
+        var cast = (long)Svo.Generated.Int64Id;
+        cast.Should().Be(987654321);
+    }
 }
 
 public class Debugger

--- a/specs/Qowaiv.Specs/Customization/ID_string_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_string_specs.cs
@@ -227,6 +227,18 @@ public class Supports_type_conversion
         => Converting.To(type).From<StringBasedId>().Should().BeTrue();
 }
 
+public class Does_not_support
+{
+    [Test]
+    public void casting()
+    {
+        var op_Explicit = typeof(StringBasedId).GetMethods(BindingFlags.Static | BindingFlags.Public)
+            .Where(m => m.IsSpecialName && m.Name == "op_Explicit")
+            .ToArray();
+
+        op_Explicit.Should().BeEmpty();
+    }
+}
 public class Supports_XML_serialization
 {
     [Test]

--- a/specs/Qowaiv.Specs/packages.lock.json
+++ b/specs/Qowaiv.Specs/packages.lock.json
@@ -14,12 +14,6 @@
         "resolved": "9.0.0",
         "contentHash": "7HpVy5wMgzBX9vmelhDdM6EshiaGuz8apnhPcWGAkrbc7rlgmtzEDNcUiTNIicTkurBY37JZYdDiNMWrnKdADA=="
       },
-      "AwesomeAssertions.Analyzers": {
-        "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "SM68/DKf+1cDBV7OsayTL0MiZJ7rqBdKlgf5ND1qFZqp6D0YMTzXUezfeMYttz+KAHE3Q2d4jkDF+6qFiWvF5Q=="
-      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -56,12 +50,6 @@
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
-      },
-      "NUnit.Analyzers": {
-        "type": "Direct",
-        "requested": "[4.8.0, )",
-        "resolved": "4.8.0",
-        "contentHash": "Drakg436nBH0UZr5CuMaZKQKYBwgDdgsfAq6NlTVI0bNnsgy+oS5z+EHyLYeTaBwCtSg7RrduJSsGJlCb0xS2Q=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -310,12 +298,6 @@
         "resolved": "9.0.0",
         "contentHash": "7HpVy5wMgzBX9vmelhDdM6EshiaGuz8apnhPcWGAkrbc7rlgmtzEDNcUiTNIicTkurBY37JZYdDiNMWrnKdADA=="
       },
-      "AwesomeAssertions.Analyzers": {
-        "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "SM68/DKf+1cDBV7OsayTL0MiZJ7rqBdKlgf5ND1qFZqp6D0YMTzXUezfeMYttz+KAHE3Q2d4jkDF+6qFiWvF5Q=="
-      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -352,12 +334,6 @@
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
-      },
-      "NUnit.Analyzers": {
-        "type": "Direct",
-        "requested": "[4.8.0, )",
-        "resolved": "4.8.0",
-        "contentHash": "Drakg436nBH0UZr5CuMaZKQKYBwgDdgsfAq6NlTVI0bNnsgy+oS5z+EHyLYeTaBwCtSg7RrduJSsGJlCb0xS2Q=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -602,12 +578,6 @@
         "resolved": "9.0.0",
         "contentHash": "7HpVy5wMgzBX9vmelhDdM6EshiaGuz8apnhPcWGAkrbc7rlgmtzEDNcUiTNIicTkurBY37JZYdDiNMWrnKdADA=="
       },
-      "AwesomeAssertions.Analyzers": {
-        "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "SM68/DKf+1cDBV7OsayTL0MiZJ7rqBdKlgf5ND1qFZqp6D0YMTzXUezfeMYttz+KAHE3Q2d4jkDF+6qFiWvF5Q=="
-      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -644,12 +614,6 @@
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
-      },
-      "NUnit.Analyzers": {
-        "type": "Direct",
-        "requested": "[4.8.0, )",
-        "resolved": "4.8.0",
-        "contentHash": "Drakg436nBH0UZr5CuMaZKQKYBwgDdgsfAq6NlTVI0bNnsgy+oS5z+EHyLYeTaBwCtSg7RrduJSsGJlCb0xS2Q=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -878,12 +842,6 @@
         "resolved": "9.0.0",
         "contentHash": "7HpVy5wMgzBX9vmelhDdM6EshiaGuz8apnhPcWGAkrbc7rlgmtzEDNcUiTNIicTkurBY37JZYdDiNMWrnKdADA=="
       },
-      "AwesomeAssertions.Analyzers": {
-        "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "SM68/DKf+1cDBV7OsayTL0MiZJ7rqBdKlgf5ND1qFZqp6D0YMTzXUezfeMYttz+KAHE3Q2d4jkDF+6qFiWvF5Q=="
-      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -920,12 +878,6 @@
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
-      },
-      "NUnit.Analyzers": {
-        "type": "Direct",
-        "requested": "[4.8.0, )",
-        "resolved": "4.8.0",
-        "contentHash": "Drakg436nBH0UZr5CuMaZKQKYBwgDdgsfAq6NlTVI0bNnsgy+oS5z+EHyLYeTaBwCtSg7RrduJSsGJlCb0xS2Q=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",

--- a/specs/Qowaiv.Specs/packages.lock.json
+++ b/specs/Qowaiv.Specs/packages.lock.json
@@ -14,6 +14,12 @@
         "resolved": "9.0.0",
         "contentHash": "7HpVy5wMgzBX9vmelhDdM6EshiaGuz8apnhPcWGAkrbc7rlgmtzEDNcUiTNIicTkurBY37JZYdDiNMWrnKdADA=="
       },
+      "AwesomeAssertions.Analyzers": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "SM68/DKf+1cDBV7OsayTL0MiZJ7rqBdKlgf5ND1qFZqp6D0YMTzXUezfeMYttz+KAHE3Q2d4jkDF+6qFiWvF5Q=="
+      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -50,6 +56,12 @@
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
+      },
+      "NUnit.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.8.0, )",
+        "resolved": "4.8.0",
+        "contentHash": "Drakg436nBH0UZr5CuMaZKQKYBwgDdgsfAq6NlTVI0bNnsgy+oS5z+EHyLYeTaBwCtSg7RrduJSsGJlCb0xS2Q=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -239,20 +251,20 @@
       "qowaiv.data.sqlclient": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )",
+          "Qowaiv": "[7.4.3, )",
           "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "qowaiv.specs.generated": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "qowaiv.testtools": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "Newtonsoft.Json": {
@@ -298,6 +310,12 @@
         "resolved": "9.0.0",
         "contentHash": "7HpVy5wMgzBX9vmelhDdM6EshiaGuz8apnhPcWGAkrbc7rlgmtzEDNcUiTNIicTkurBY37JZYdDiNMWrnKdADA=="
       },
+      "AwesomeAssertions.Analyzers": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "SM68/DKf+1cDBV7OsayTL0MiZJ7rqBdKlgf5ND1qFZqp6D0YMTzXUezfeMYttz+KAHE3Q2d4jkDF+6qFiWvF5Q=="
+      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -334,6 +352,12 @@
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
+      },
+      "NUnit.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.8.0, )",
+        "resolved": "4.8.0",
+        "contentHash": "Drakg436nBH0UZr5CuMaZKQKYBwgDdgsfAq6NlTVI0bNnsgy+oS5z+EHyLYeTaBwCtSg7RrduJSsGJlCb0xS2Q=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -519,20 +543,20 @@
       "qowaiv.data.sqlclient": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )",
+          "Qowaiv": "[7.4.3, )",
           "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "qowaiv.specs.generated": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "qowaiv.testtools": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "Newtonsoft.Json": {
@@ -578,6 +602,12 @@
         "resolved": "9.0.0",
         "contentHash": "7HpVy5wMgzBX9vmelhDdM6EshiaGuz8apnhPcWGAkrbc7rlgmtzEDNcUiTNIicTkurBY37JZYdDiNMWrnKdADA=="
       },
+      "AwesomeAssertions.Analyzers": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "SM68/DKf+1cDBV7OsayTL0MiZJ7rqBdKlgf5ND1qFZqp6D0YMTzXUezfeMYttz+KAHE3Q2d4jkDF+6qFiWvF5Q=="
+      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -614,6 +644,12 @@
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
+      },
+      "NUnit.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.8.0, )",
+        "resolved": "4.8.0",
+        "contentHash": "Drakg436nBH0UZr5CuMaZKQKYBwgDdgsfAq6NlTVI0bNnsgy+oS5z+EHyLYeTaBwCtSg7RrduJSsGJlCb0xS2Q=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -795,20 +831,20 @@
       "qowaiv.data.sqlclient": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )",
+          "Qowaiv": "[7.4.3, )",
           "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "qowaiv.specs.generated": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "qowaiv.testtools": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "Newtonsoft.Json": {
@@ -842,6 +878,12 @@
         "resolved": "9.0.0",
         "contentHash": "7HpVy5wMgzBX9vmelhDdM6EshiaGuz8apnhPcWGAkrbc7rlgmtzEDNcUiTNIicTkurBY37JZYdDiNMWrnKdADA=="
       },
+      "AwesomeAssertions.Analyzers": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "SM68/DKf+1cDBV7OsayTL0MiZJ7rqBdKlgf5ND1qFZqp6D0YMTzXUezfeMYttz+KAHE3Q2d4jkDF+6qFiWvF5Q=="
+      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -878,6 +920,12 @@
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
+      },
+      "NUnit.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.8.0, )",
+        "resolved": "4.8.0",
+        "contentHash": "Drakg436nBH0UZr5CuMaZKQKYBwgDdgsfAq6NlTVI0bNnsgy+oS5z+EHyLYeTaBwCtSg7RrduJSsGJlCb0xS2Q=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -1059,20 +1107,20 @@
       "qowaiv.data.sqlclient": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )",
+          "Qowaiv": "[7.4.3, )",
           "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "qowaiv.specs.generated": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "qowaiv.testtools": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "Newtonsoft.Json": {

--- a/specs/Qowaiv.Wikipedia/packages.lock.json
+++ b/specs/Qowaiv.Wikipedia/packages.lock.json
@@ -108,7 +108,7 @@
       "qowaiv.data.sqlclient": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )",
+          "Qowaiv": "[7.4.3, )",
           "System.Data.SqlClient": "[4.8.6, )"
         }
       },
@@ -117,8 +117,8 @@
         "dependencies": {
           "AwesomeAssertions": "[9.0.0, )",
           "NUnit": "[3.14.0, )",
-          "Qowaiv": "[7.4.2, )",
-          "Qowaiv.CodeGeneration.SingleValueObjects": "[1.1.1, )",
+          "Qowaiv": "[7.4.3, )",
+          "Qowaiv.CodeGeneration.SingleValueObjects": "[1.1.3, )",
           "Qowaiv.Data.SqlClient": "[7.2.0, )",
           "Qowaiv.Specs.Generated": "[1.0.0, )",
           "Qowaiv.TestTools": "[8.0.0, )"
@@ -127,13 +127,13 @@
       "qowaiv.specs.generated": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "qowaiv.testtools": {
         "type": "Project",
         "dependencies": {
-          "Qowaiv": "[7.4.2, )"
+          "Qowaiv": "[7.4.3, )"
         }
       },
       "AwesomeAssertions": {

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/package.props" />
 

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
@@ -1,5 +1,5 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <Import Project="../../props/package.props" />
 
   <PropertyGroup>
@@ -8,34 +8,6 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IncludeSymbols>false</IncludeSymbols>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <PackageId>Qowaiv.CodeGeneration.SingleValueObjects</PackageId>
-    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
-    <Version>1.1.3</Version>
-    <ToBeReleased>
-      <![CDATA[
-      ]]>
-    </ToBeReleased>
-    <PackageReleaseNotes>
-      <![CDATA[
-v1.1.3
-- Use Microsoft.CodeAnalysis.CSharp v4.11.0 (.NET 8.0).
-v1.1.2
-- ID m_Value's raw type with global:: namespace prefix.
-- ID's implement INext<TSvo>.
-- ID's can be generated in the global namespace.
-- ID ToString() supports custom formatters and string.Empty for default value.
-v1.1.1
-- Do not generate Create and TryCreate for string based ID's.
-v1.1.0
-- Generated custom ID's.
-v1.0.2
-- Fixes for Generation before .NET 6.0.
-v1.0.1
-- Generate JSON Converter only for .NET 6.0 and higher.
-v1.0.0
-- Generate custom SVO's.
-]]>
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -74,5 +46,40 @@ v1.0.0
   <ItemGroup Label="DependencyPackaging">
     <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <PackageId>Qowaiv.CodeGeneration.SingleValueObjects</PackageId>
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
+    <Version>1.1.3</Version>
+    <ToBeReleased>
+      <![CDATA[
+v1.1.*
+?
+      ]]>
+    </ToBeReleased>
+    <PackageReleaseNotes>
+      <![CDATA[
+v1.1.4
+- Generate explicit castings for non-string based ID's.
+v1.1.3
+- Use Microsoft.CodeAnalysis.CSharp v4.11.0 (.NET 8.0).
+v1.1.2
+- ID m_Value's raw type with global:: namespace prefix.
+- ID's implement INext<TSvo>.
+- ID's can be generated in the global namespace.
+- ID ToString() supports custom formatters and string.Empty for default value.
+v1.1.1
+- Do not generate Create and TryCreate for string based ID's.
+v1.1.0
+- Generated custom ID's.
+v1.0.2
+- Fixes for Generation before .NET 6.0.
+v1.0.1
+- Generate JSON Converter only for .NET 6.0 and higher.
+v1.0.0
+- Generate custom SVO's.
+]]>
+    </PackageReleaseNotes>
+  </PropertyGroup>
 
 </Project>

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Structure.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Behavior.Structure.cs
@@ -14,6 +14,11 @@ readonly partial struct @Svo
     [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
     private readonly @Raw m_Value;
 
+#if !StringBased // exec
+    /// <summary>Casts the Single Value Object to a <see cref="@Raw" />.</summary>
+    public static explicit operator @Raw(@Svo id) => id.m_Value;
+#endif // exec
+
     private sealed class TypeConverter(global::System.Type underlying) : global::Qowaiv.Customization.CustomBehaviorTypeConverter<@Svo, @Raw, @Behavior>
     {
         /// <summary>Converts from the raw/underlying type.</summary>


### PR DESCRIPTION
The `Id<TBehavior>` supports casting to underlying types. This was lacking for its generated alternatives. Note that string based Id's also do not support casting. If needed, `ToString()` obviously can expose the underlying value.

#500 closes