### PR TITLE
Implement converters for System.Net.Http.HttpMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,16 @@ Represents an Internet media type (also known as MIME-type and content type).
 Represents a pattern to match strings, using wildcard characters ? and *. It 
 also support the use of SQL wildcard characters _ and %.
 
+## Extensions on .NET build-in types
+For types that are shipped with the .NET standard library that meet (most) SVO
+cryteria, Qowaiv can offer some extenions to improove usage.
+
+### System.Net.Http.HttpMethod
+The [`HttpMethod`](https://learn.microsoft.com/dotnet/api/system.net.http.httpmethod)
+lacks a `TypeConverter` and a `JsonConverter`:
+* `Qowaiv.Conversion.Web.HttpMethodTypeConverter`
+* `Qowaiv.Json.Web.HttpMethodJsonConverter`
+
 ## Qowaiv helpers
 
 ### Decimal round

--- a/specs/Qowaiv.Specs/Customization/ID_int_specs.cs
+++ b/specs/Qowaiv.Specs/Customization/ID_int_specs.cs
@@ -209,7 +209,7 @@ public class Supports_JSON_serialization
     [TestCase(int.MaxValue + 1L)]
     public void taking_constrains_into_account(object json)
     {
-        json.Invoking(JsonTester.Read_System_Text_JSON<Specs_Generated.EvenOnlyId>)
+        json.Invoking(j => JsonTester.Read_System_Text_JSON<Specs_Generated.EvenOnlyId>(j))
             .Should().Throw<System.Text.Json.JsonException>()
             .WithMessage("Not a valid EvenOnlyId");
     }

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int32_specs.cs
@@ -58,7 +58,7 @@ public class Supports_JSON_serialization
     [TestCase(int.MaxValue + 1L)]
     public void taking_constrains_into_account(object json)
     {
-        json.Invoking(JsonTester.Read_System_Text_JSON<Id<ForEven>>)
+        json.Invoking(j => JsonTester.Read_System_Text_JSON<Id<ForEven>>(j))
             .Should().Throw<System.Text.Json.JsonException>()
             .WithMessage("Not a valid identifier");
     }

--- a/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
+++ b/specs/Qowaiv.Specs/Identifiers/Id_for_Int64_specs.cs
@@ -57,7 +57,7 @@ public class Supports_JSON_serialization
     [TestCase("17")]
     public void taking_constrains_into_account(object json)
     {
-        json.Invoking(JsonTester.Read_System_Text_JSON<Id<ForEven>>)
+        json.Invoking(j => JsonTester.Read_System_Text_JSON<Id<ForEven>>(j))
             .Should().Throw<System.Text.Json.JsonException>()
             .WithMessage("Not a valid identifier");
     }

--- a/specs/Qowaiv.Specs/TestTools/FluentAssertions/QowaivTypeConverterAssertions.cs
+++ b/specs/Qowaiv.Specs/TestTools/FluentAssertions/QowaivTypeConverterAssertions.cs
@@ -18,4 +18,18 @@ internal static class QowaivTypeConverterAssertions
 
         return new AndConstraint<TypeAssertions>(assertions);
     }
+
+    /// <summary>Asserts that the type converter exists for the specified type.</summary>
+    [CustomAssertion]
+    public static AndConstraint<TypeAssertions> HaveNoTypeConverterDefined(this TypeAssertions assertions, string because = "", params object[] becauseArgs)
+    {
+        var converter = TypeDescriptor.GetConverter(assertions.Subject);
+
+        assertions.CurrentAssertionChain
+           .BecauseOf(because, becauseArgs)
+           .ForCondition(converter.GetType() == typeof(TypeConverter))
+           .FailWith($"There is type converter defined for '{assertions.Subject}' ({converter.GetType().FullName}).");
+
+        return new AndConstraint<TypeAssertions>(assertions);
+    }
 }

--- a/specs/Qowaiv.Specs/TestTools/Svo.cs
+++ b/specs/Qowaiv.Specs/TestTools/Svo.cs
@@ -1,5 +1,6 @@
 using Qowaiv.Chemistry;
 using Qowaiv.Sustainability;
+using System.Net.Http;
 
 namespace Qowaiv.TestTools;
 
@@ -61,6 +62,9 @@ public static class Svo
 
     /// <summary>123.456.789</summary>
     public static readonly HouseNumber HouseNumber = 123456789L;
+
+    /// <summary>POST.</summary>
+    public static readonly HttpMethod HttpMethod = HttpMethod.Post;
 
     /// <summary>NL20 INGB 0001 2345 67</summary>
     public static readonly InternationalBankAccountNumber Iban = InternationalBankAccountNumber.Parse("NL20 INGB 0001 2345 67");

--- a/specs/Qowaiv.Specs/Web/HTTP_method_specs.cs
+++ b/specs/Qowaiv.Specs/Web/HTTP_method_specs.cs
@@ -1,0 +1,72 @@
+using Qowaiv.Conversion.Web;
+using System.Net.Http;
+#if NET6_0_OR_GREATER
+using Qowaiv.Json.Web;
+using System.Text.Json;
+#endif
+namespace Web.HTTP_method_specs;
+
+public class Supports_type_conversion
+{
+    [Test]
+    public void not_via_TypeConverter_registered_with_attribute()
+        => typeof(HttpMethod).Should().HaveNoTypeConverterDefined();
+
+    [Test]
+    public void from_null_string()
+    {
+        using (TestCultures.en_GB.Scoped())
+        {
+            Converting.FromNull<string>().With<HttpMethodTypeConverter>().To<HttpMethod>().Should().BeNull();
+        }
+    }
+
+    [Test]
+    public void from_empty_string()
+    {
+        using (TestCultures.en_GB.Scoped())
+        {
+            Converting.From(string.Empty).With<HttpMethodTypeConverter>().To<HttpMethod>().Should().BeNull();
+        }
+    }
+
+    [Test]
+    public void from_string()
+    {
+        using (TestCultures.en_GB.Scoped())
+        {
+            Converting.From("POST").With<HttpMethodTypeConverter>().To<HttpMethod>().Should().Be(Svo.HttpMethod);
+        }
+    }
+
+    [Test]
+    public void to_string()
+    {
+        using (TestCultures.en_GB.Scoped())
+        {
+            Converting.ToString().From(Svo.HttpMethod).Should().Be("POST");
+        }
+    }
+}
+
+#if NET6_0_OR_GREATER
+public class Supports_JSON_serialization
+{
+    [TestCase(null)]
+    [TestCase("POST")]
+    public void System_Text_JSON_deserialization(object? json)
+        => JsonTester.Read_System_Text_JSON<HttpMethod>(json, Options()).Should().Be(json is null ? null : HttpMethod.Post);
+
+    [TestCase(null)]
+    [TestCase("POST")]
+    public void System_Text_JSON_serialization(object? json)
+        => JsonTester.Write_System_Text_JSON(json is null ? null : HttpMethod.Post, Options()).Should().Be(json);
+
+    private static JsonSerializerOptions Options()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new HttpMethodJsonConverter());
+        return options;
+    }
+}
+#endif

--- a/src/Qowaiv.TestTools/ConvertFrom.cs
+++ b/src/Qowaiv.TestTools/ConvertFrom.cs
@@ -8,11 +8,21 @@ public sealed class ConvertFrom<TFrom>
     /// <summary>The subject that can be converted to a destination type.</summary>
     public TFrom? Subject { get; }
 
+    private TypeConverter? Converter { get; init; }
+
+    /// <summary>Defines the <see cref="TypeConverter"/> to use while converting.</summary>
+    /// <typeparam name="TConverter">
+    /// The type converter to use.
+    /// </typeparam>
+    [Pure]
+    public ConvertFrom<TFrom> With<TConverter>() where TConverter : TypeConverter, new()
+        => new(Subject) { Converter = new TConverter() };
+
     /// <summary>Converts the value to the destination type, using its <see cref="TypeConverter" />.</summary>
     [Pure]
     public To? To<To>()
     {
-        var converter = Converter<To>();
+        var converter = Init<To>();
 
         return Subject switch
         {
@@ -24,5 +34,5 @@ public sealed class ConvertFrom<TFrom>
     }
 
     [Pure]
-    private static TypeConverter Converter<To>() => TypeDescriptor.GetConverter(typeof(To));
+    private TypeConverter Init<To>() => Converter ?? TypeDescriptor.GetConverter(typeof(To));
 }

--- a/src/Qowaiv.TestTools/ConvertTo_To.cs
+++ b/src/Qowaiv.TestTools/ConvertTo_To.cs
@@ -5,7 +5,17 @@ public sealed class ConvertTo<To> : ConvertTo
 {
     internal ConvertTo() : base(typeof(To)) { }
 
+    private TypeConverter? Converter { get; init; }
+
+    /// <summary>Defines the <see cref="TypeConverter"/> to use while converting.</summary>
+    /// <typeparam name="TConverter">
+    /// The type converter to use.
+    /// </typeparam>
+    [Pure]
+    public ConvertTo<To> With<TConverter>() where TConverter : TypeConverter, new()
+        => new() { Converter = new TConverter() };
+
     /// <summary>Converts the value to the destination type, using the <see cref="TypeConverter" /> of the subject.</summary>
     [Pure]
-    public To? From<TFrom>(TFrom subject) => (To?)Converter<TFrom>().ConvertTo(subject, typeof(To));
+    public To? From<TFrom>(TFrom subject) => (To?)(Converter ?? Converter<TFrom>()).ConvertTo(subject, typeof(To));
 }

--- a/src/Qowaiv.TestTools/JsonTester.cs
+++ b/src/Qowaiv.TestTools/JsonTester.cs
@@ -12,9 +12,9 @@ public static class JsonTester
 #if NET6_0_OR_GREATER
     /// <summary>Reads the JSON using System.Text.Json.</summary>
     [Pure]
-    public static T? Read_System_Text_JSON<T>(object? val)
+    public static T? Read_System_Text_JSON<T>(object? val, JsonSerializerOptions? options = null)
     {
-        return JsonSerializer.Deserialize<T>(ToString(val));
+        return JsonSerializer.Deserialize<T>(ToString(val), options);
 
         static string ToString(object? val)
             => val switch
@@ -33,9 +33,9 @@ public static class JsonTester
     /// <see cref="JsonSerializer.SerializeToElement(object?, Type, JsonSerializerOptions?)" /> is only available in .NET 6.0.
     /// </remarks>
     [Pure]
-    public static object? Write_System_Text_JSON(object? svo)
+    public static object? Write_System_Text_JSON(object? svo, JsonSerializerOptions? options = null)
     {
-        var json = JsonSerializer.SerializeToElement(svo);
+        var json = JsonSerializer.SerializeToElement(svo, options);
 
         if (json.ValueKind == JsonValueKind.String) return json.GetString();
         else if (json.ValueKind == JsonValueKind.Number)

--- a/src/Qowaiv/Conversion/Web/HttpMethodTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Web/HttpMethodTypeConverter.cs
@@ -1,0 +1,43 @@
+using System.Net.Http;
+
+namespace Qowaiv.Conversion.Web;
+
+/// <summary>Provides a conversion for an HTTP method.</summary>
+public sealed class HttpMethodTypeConverter : TypeConverter
+{
+    /// <inheritdoc />
+    [Pure]
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+        => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+    /// <inheritdoc />
+    [Pure]
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
+        => value is null || value is string
+        ? FromString(value as string)
+        : base.ConvertFrom(context, culture, value);
+
+#if NET8_0_OR_GREATER
+    /// <summary>Converts from <see cref="string" />.</summary>
+    [Pure]
+    private static HttpMethod? FromString(string? str)
+        => str is { Length: > 0 }
+        ? HttpMethod.Parse(str)
+        : null;
+#else
+    /// <summary>Converts from <see cref="string" />.</summary>
+    [Pure]
+    private static HttpMethod? FromString(string? str) => str?.ToUpperInvariant() switch
+    {
+        "Delete" => HttpMethod.Delete,
+        "Get" => HttpMethod.Get,
+        "Head" => HttpMethod.Head,
+        "Options" => HttpMethod.Options,
+        "Post" => HttpMethod.Post,
+        "Put" => HttpMethod.Put,
+        "Trace" => HttpMethod.Trace,
+        { Length: > 0 } => new(str),
+        _ => null,
+    };
+#endif
+}

--- a/src/Qowaiv/Conversion/Web/HttpMethodTypeConverter.cs
+++ b/src/Qowaiv/Conversion/Web/HttpMethodTypeConverter.cs
@@ -1,4 +1,4 @@
-using System.Net.Http;
+using Qowaiv.Web;
 
 namespace Qowaiv.Conversion.Web;
 
@@ -14,30 +14,6 @@ public sealed class HttpMethodTypeConverter : TypeConverter
     [Pure]
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
         => value is null || value is string
-        ? FromString(value as string)
+        ? HttpMethodParser.Parse(value as string)
         : base.ConvertFrom(context, culture, value);
-
-#if NET8_0_OR_GREATER
-    /// <summary>Converts from <see cref="string" />.</summary>
-    [Pure]
-    private static HttpMethod? FromString(string? str)
-        => str is { Length: > 0 }
-        ? HttpMethod.Parse(str)
-        : null;
-#else
-    /// <summary>Converts from <see cref="string" />.</summary>
-    [Pure]
-    private static HttpMethod? FromString(string? str) => str?.ToUpperInvariant() switch
-    {
-        "Delete" => HttpMethod.Delete,
-        "Get" => HttpMethod.Get,
-        "Head" => HttpMethod.Head,
-        "Options" => HttpMethod.Options,
-        "Post" => HttpMethod.Post,
-        "Put" => HttpMethod.Put,
-        "Trace" => HttpMethod.Trace,
-        { Length: > 0 } => new(str),
-        _ => null,
-    };
-#endif
 }

--- a/src/Qowaiv/Json/Web/HttpMethodJsonConverter.cs
+++ b/src/Qowaiv/Json/Web/HttpMethodJsonConverter.cs
@@ -1,0 +1,25 @@
+#if NET6_0_OR_GREATER
+
+using Qowaiv.Web;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Qowaiv.Json.Web;
+
+/// <summary>Provides a JSON conversion for an HTTP Method.</summary>
+[Inheritable]
+public class HttpMethodJsonConverter : JsonConverter<HttpMethod>
+{
+    /// <inheritdoc />
+    [Pure]
+    public override HttpMethod? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.GetString() is { Length: > 0 } s
+            ? HttpMethodParser.Parse(s)
+            : null;
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, HttpMethod value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.Method);
+}
+#endif

--- a/src/Qowaiv/Properties/GlobalUsings.cs
+++ b/src/Qowaiv/Properties/GlobalUsings.cs
@@ -8,6 +8,7 @@ global using Qowaiv.Security;
 global using Qowaiv.Text;
 global using System;
 global using System.Collections;
+global using System.Collections.Frozen;
 global using System.Collections.Generic;
 global using System.ComponentModel;
 global using System.Diagnostics;

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -44,6 +44,7 @@
       <![CDATA[
 v7.4.4
 - Add Oman, Somalia, and Yemen to the list of countries with IBAN. #508
+- Provide a TypeConverter for System.Net.Http.HttpMethod as Micrsoft does not. #509
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -45,6 +45,7 @@
 v7.4.4
 - Add Oman, Somalia, and Yemen to the list of countries with IBAN. #508
 - Provide a TypeConverter for System.Net.Http.HttpMethod as Micrsoft does not. #509
+- Provide a JsonConverter for System.Net.Http.HttpMethod as Micrsoft does not. #509
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/Qowaiv/Web/HttpMethodParser.cs
+++ b/src/Qowaiv/Web/HttpMethodParser.cs
@@ -1,0 +1,41 @@
+using System.Net.Http;
+
+namespace Qowaiv.Web;
+
+/// <summary>Helper method to facility parsing for an <see cref="HttpMethod"/>.</summary>
+/// <remarks>
+/// Required to support .NET 6.0 and earlier.
+/// </remarks>
+internal static class HttpMethodParser
+{
+#if NET8_0_OR_GREATER
+    /// <inheritdoc cref="HttpMethod.Parse(ReadOnlySpan{char})" />
+    [Pure]
+    public static HttpMethod? Parse(string? str)
+        => str is { Length: > 0 }
+        ? HttpMethod.Parse(str)
+        : null;
+#else
+    /// <summary>Parses an <see cref="HttpMethod"/>.</summary>
+    [Pure]
+    public static HttpMethod? Parse(string? str) => str?.ToUpperInvariant() switch
+    {
+        null => null,
+        _ when Methods.TryGetValue(str, out var method) => method,
+        { Length: > 0 } => new(str),
+        _ => null,
+    };
+
+    private static readonly FrozenDictionary<string, HttpMethod> Methods = new Dictionary<string, HttpMethod>
+    {
+        ["DELETE"] = HttpMethod.Delete,
+        ["GET"] = HttpMethod.Get,
+        ["HEAD"] = HttpMethod.Head,
+        ["OPTIONS"] = HttpMethod.Options,
+        ["POST"] = HttpMethod.Post,
+        ["PUT"] = HttpMethod.Put,
+        ["TRACE"] = HttpMethod.Trace,
+    }
+    .ToFrozenDictionary();
+#endif
+}


### PR DESCRIPTION
When dealing with HTTP Methods, Microsoft's [`HttpMethod`](https://learn.microsoft.com/dotnet/api/system.net.http.httpmethod) is a good fit. Creating a competing SVO in Qowaiv does not feel fruitful (besides potential namespace conflicts that might be introduced). However, it lacks a `TypeConverter` and a `JsonConverter`, which have been provided with this PR.