### PR TITLE
Add Percentage.Complement()

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ value += 10.Percent(); // value 55;
 
 var rounded = 17.56.Percent().Round(1); // 17.6%;
 
+var complement = 25.Percent().Complement(); // 75%
+
 var max = Percentage.Max(1.4.Percent(), 1.8.Percent()); // 1.8%;
 var min = Percentage.Min(1.7.Percent(), 1.9.Percent()); // 1.7%;
 

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -930,7 +930,7 @@ public class Can_get_100_percent_based_on_percentage
     }
 }
 
-public class can_be_tranformed
+public class can_be_transformed
 {
 
     [TestCase("0%", "0%")]

--- a/specs/Qowaiv.Specs/Percentage_specs.cs
+++ b/specs/Qowaiv.Specs/Percentage_specs.cs
@@ -930,6 +930,22 @@ public class Can_get_100_percent_based_on_percentage
     }
 }
 
+public class can_be_tranformed
+{
+
+    [TestCase("0%", "0%")]
+    [TestCase("-3%", "3%")]
+    [TestCase("10%", "10%")]
+    public void absolute_value(Percentage percentage, Percentage absolute)
+        => percentage.Abs().Should().Be(absolute);
+
+    [TestCase("42%", "58%")]
+    [TestCase("-10%", "110%")]
+    [TestCase("110%", "-10%")]
+    public void Complement(Percentage percentage, Percentage complement)
+        => percentage.Complement().Should().Be(complement);
+}
+
 public class Can_be_rounded
 {
     [Test]
@@ -1037,14 +1053,6 @@ public class Can_get
         actual.Should().Be(expected);
     }
 
-    [TestCase("3%", "-3%")]
-    [TestCase("0%", "0%")]
-    [TestCase("10%", "10%")]
-    public void absolute_value(Percentage expected, Percentage percentage)
-    {
-        var actual = percentage.Abs();
-        actual.Should().Be(expected);
-    }
 }
 
 public class Can_get_maximum_of

--- a/src/Qowaiv/Percentage.cs
+++ b/src/Qowaiv/Percentage.cs
@@ -49,6 +49,10 @@ public readonly partial struct Percentage : IXmlSerializable, IFormattable, IEqu
     [Pure]
     public Percentage Abs() => new(Math.Abs(m_Value));
 
+    /// <summary>Gets the complement (100% - current) of the percentage.</summary>
+    [Pure]
+    public Percentage Complement() => new(1 - m_Value);
+
     /// <summary>Returns the larger of two percentages.</summary>
     /// <param name="val1">
     /// The first of the two percentages to compare.

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -36,7 +36,7 @@
     <ToBeReleased>
       <![CDATA[
 v8.*
-- ?
+- Add Percentage.Complement().
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>


### PR DESCRIPTION
When reviewing the code of a co-worker, I saw this extension method (there called `Inverse()`). After some thoughts (advise of Gemini) I decided to go for `Complement` to get the `100.Percent() - value` of a percentage.